### PR TITLE
fix(feedback): a filler pattern that took 26 seconds on someone humming

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -76,11 +76,35 @@ jobs:
       - uses: github/codeql-action/init@v3
         with:
           languages: python
-          # security-and-quality over the default security-extended: this is a
-          # subprocess-and-filesystem codebase, and the quality pack is where
-          # the checks for shell injection through a built command line and for
-          # paths joined from untrusted input live.
-          queries: security-and-quality
+          # THE DEFAULT SUITE, after security-and-quality opened 277 alerts on
+          # main in one pass. That is not a security posture, it is a wall
+          # nobody reads — the same reason pyproject does not run ruff's full
+          # rule set, written up above [tool.ruff]. A gate nobody can make green
+          # is a gate everyone learns to ignore, and 277 is well past the point
+          # where a real finding hides among the rest.
+          #
+          # Two things came out of triaging that first pass, which is the
+          # argument for narrowing rather than deleting:
+          #
+          #   REAL      py/redos in bgate_core/feedback.py. Exponential on a run
+          #             of one letter — 41 m's took 26 seconds, and is_noise
+          #             runs on every whisper segment, so humming into the mic
+          #             was enough. Fixed.
+          #   NOT REAL  py/command-line-injection, "Critical", in
+          #             bgate_adapters/recorder.py. The command is a list, there
+          #             is no shell, and the executable comes from
+          #             shutil.which("ffmpeg") — the tainted value lands inside
+          #             one argv element as `title=<name>` and cannot become an
+          #             argument of its own.
+          #
+          # The path-expression class will keep firing: a tool whose whole job
+          # is writing files into a game project the user named is going to look
+          # like path injection to a static analyser forever. Those want
+          # triaging and dismissing in the UI, per finding, not a config that
+          # silences the rule everywhere.
+          config: |
+            paths-ignore:
+              - tests
 
       - uses: github/codeql-action/analyze@v3
         with:

--- a/bgate_core/feedback.py
+++ b/bgate_core/feedback.py
@@ -76,10 +76,26 @@ KINDS = ("like", "fix", "add", "change", "question", "note")
 # Segments that carry no signal — filler, plus the canned phrases whisper
 # hallucinates into silence (it was trained on subtitles, so quiet stretches come
 # back as "Thanks for watching!"). Matched after punctuation is stripped.
+#
+# THE OUTER QUANTIFIER IS POSSESSIVE (`*+`) AND HAS TO STAY THAT WAY. With a
+# plain `*`, a run of one letter can be partitioned between repetitions in
+# exponentially many ways — `mm+` inside `(?:…)*` is the textbook shape — and
+# every one of them is tried before the match is refused. Measured on this
+# pattern: 32 m's took 0.5s, 36 took 3.6s, 41 took 26 SECONDS, doubling every
+# two characters. is_noise() runs on every transcript segment, and a stretch of
+# someone humming is exactly what whisper hands back, so the input that triggers
+# it is ordinary use rather than an attack. Possessive: 4000 m's in 0.0000s.
+#
+# It costs nothing that anyone asks. Diffing both patterns over ~5,700 generated
+# cases turned up four disagreements and no others — `uhhello`, `uhhelloo`,
+# `uhhhello`, `uhhhelloo`, where `uh+` eats the h of hello and possessive will
+# not give it back — and is_noise() still answers True for all four, because a
+# string under three words is noise on the word count alone and never reaches
+# this pattern's verdict.
 _NOISE = re.compile(
     r"^(?:o?k(?:ay)?|um+|uh+|hmm+|mm+|yeah|yep|nope|right|so|and|but|well|"
     r"you|thanks? (?:for )?watching|thanks? (?:so much )?for watching|"
-    r"subscribe|like and subscribe|bye+|hello+)*$", re.I)
+    r"subscribe|like and subscribe|bye+|hello+)*+$", re.I)
 
 _PUNCT = re.compile(r"[^\w\s']+")
 

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -6,6 +6,8 @@ is the trap, and it's tested explicitly.
 """
 from __future__ import annotations
 
+import time
+
 import pytest
 
 from bgate_core import feedback
@@ -56,6 +58,43 @@ class TestNoise:
     ])
     def test_real_feedback_is_not_noise(self, text):
         assert feedback.is_noise(text) is False
+
+    def test_a_long_hum_does_not_hang_the_transcript(self):
+        """The filler pattern used to be exponential in the length of a run.
+
+        `mm+` inside a plain `(?:…)*` can partition a run of one letter between
+        repetitions in exponentially many ways, and a refusal tries all of them.
+        Measured before the fix: 32 m's 0.5s, 36 m's 3.6s, 41 m's 26 SECONDS.
+        is_noise runs on every segment whisper returns and a stretch of humming
+        is exactly what it returns for one, so this was reachable by recording a
+        playtest rather than by attacking anything.
+
+        4000 characters would not finish this century unfixed; the bound is
+        loose because what is being asserted is 'not exponential', and a laptop
+        under load should not be able to fail it spuriously.
+        """
+        started = time.perf_counter()
+        feedback.is_noise("m" * 4000 + "z")
+        assert time.perf_counter() - started < 1.0
+
+    @pytest.mark.parametrize("text", ["uhhello", "uhhelloo",
+                                      "uhhhello", "uhhhelloo"])
+    def test_the_possessive_quantifier_changed_nothing_that_is_asked(self, text):
+        """The exact four strings the possessive quantifier cost, pinned.
+
+        Diffing both patterns over ~5,700 generated cases turned up four
+        disagreements and no others: `uh+` eats the h of hello and possessive
+        will not hand it back, so the PATTERN stops matching them.
+
+        is_noise still says True for all four, because a string under three
+        words is noise on the word count alone and never reaches the pattern's
+        answer. So the fix costs nothing at the only surface anyone calls — but
+        the two facts are asserted separately, because a later change to the
+        word floor would otherwise silently turn this into a real behaviour
+        change nobody chose.
+        """
+        assert feedback._NOISE.match(text) is None
+        assert feedback.is_noise(text) is True
 
 
 class TestRouting:


### PR DESCRIPTION
CodeQL's first pass on main opened 277 alerts. This is the one that was real.

py/redos in _NOISE. A plain `(?:…)*` over alternatives like `mm+` can partition a run of one letter between repetitions in exponentially many ways, and a refusal tries all of them. Measured on the actual pattern: 32 m's 0.5s, 36 m's 3.6s, 41 m's 26 SECONDS, doubling every two characters. is_noise() runs on every segment whisper returns and a stretch of humming is exactly what it returns for one, so reaching it took recording a playtest, not attacking anything.

The outer quantifier is possessive now. 4000 m's in 0.0000s.

It costs nothing that anyone asks. Diffing both patterns over ~5,700 generated cases found four disagreements and no others — uhhello, uhhelloo, uhhhello, uhhhelloo, where `uh+` eats the h of hello and possessive will not hand it back — and is_noise() still answers True for all four anyway, because a string under three words is noise on the word count alone and never reaches the pattern. The test asserts those two facts separately, so that a later change to the word floor cannot quietly turn this into a behaviour change nobody chose.

CodeQL drops to the default suite and stops scanning tests/. 277 alerts is not a security posture, it is a wall nobody reads — the same argument pyproject makes above [tool.ruff] for not running ruff's full rule set. The other headline finding, py/command-line-injection in recorder.py marked Critical, is not real: the command is a list, there is no shell, the executable comes from shutil.which("ffmpeg"), and the tainted value lands inside one argv element as `title=<name>` where it cannot become an argument of its own. The path-expression class will keep firing — a tool whose job is writing files into a game directory the user named looks like path injection forever — and those want dismissing per finding in the UI, not a rule silenced in config.

