### PR TITLE
Feat/3d-upgrades

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,33 @@ KREA_API_KEY=
 # Optional: skip the dashboard's token auth. Localhost-only development
 # convenience -- never set this on a machine reachable from a network.
 # BGATE_NO_AUTH=1
+
+# ---------------------------------------------------------------------------
+# Optional: image-to-3D. Nothing below is needed unless you want to turn a
+# generated image into a mesh. `bgate doctor` reports an imageto3d row; a red
+# one means only that path is unavailable.
+#
+# LOCAL. The adapter talks HTTP to a server you run; it never imports torch
+# and never loads a model in this process. Point it at whichever is running.
+# BGATE_TRELLIS_CPP_URL=http://127.0.0.1:8080
+# BGATE_COMFY_URL=http://127.0.0.1:8188
+# BGATE_COMFY_WORKFLOW=C:\path\to\workflow_api.json
+# BGATE_HUNYUAN3D_URL=http://127.0.0.1:8081
+#
+# Local inference needs its own interpreter -- the one running Builders Gate
+# may well have a CPU-only torch. This is never defaulted to sys.executable.
+# BGATE_IMAGETO3D_PYTHON=C:\path\to\that\venv\Scripts\python.exe
+#
+# DECLARE THE MODEL. A local backend is a transport: ComfyUI being MIT says
+# nothing about the weights it loads, and the adapter cannot read your graph.
+# Undeclared resolves to "licence unknown" and will not clear a shipped asset.
+# Known: trellis, trellis2, hunyuan3d, sf3d, spar3d, triposr, instantmesh,
+# zero123plus, partpacker. Check the terms yourself before shipping -- some
+# exclude whole territories, and partpacker is non-commercial outright.
+# BGATE_LOCAL_MODEL=trellis2
+#
+# HOSTED, if you would rather not run one. Paid tiers only for commercial use
+# on some of these; the adapter reports each licence with its verdict.
+# STABILITY_API_KEY=
+# TRIPO_API_KEY=
+# MESHY_API_KEY=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,56 @@ repository at first publication. There is no earlier release history to record.
 
 ## [Unreleased]
 
-### Added
+## [1.3.0] - 2026-07-31
+
+The version jumps from `0.1.29` because the 3D path stopped being a blockout
+generator. Everything below `### Added — 3D` is the difference between "a
+correctly-proportioned mannequin with paddle arms and no face" and a generated
+mesh that survives the same gates as one modelled by hand.
+
+### Added — 3D
+
+- **Image-to-3D on the user's own GPU.** `bgate_adapters/imageto3d.py` and the
+  `blender_generate` MCP tool. The primary backends are open-weight models
+  running locally over loopback HTTP — TRELLIS.cpp, ComfyUI with a 3D node
+  pack, Hunyuan3D — because everything else in this product is local and
+  renting a mesh generator would have been the one place that stopped being
+  true. Hosted APIs (Stability, Tripo, Meshy) sit behind the same interface as
+  a fallback, not as the design centre. It imports nothing heavy: no torch, no
+  CUDA, no model library, ever, in this process — the GPU is probed with
+  `nvidia-smi` and a local server with a short HTTP GET, the rule
+  `transcribe.py` established for faster-whisper. It works with nothing
+  configured, prices the request rather than the backend, and **states the
+  licence before it generates**: a local backend is a transport, ComfyUI being
+  MIT says nothing about the weights it loads, so `BGATE_LOCAL_MODEL` has to be
+  declared and a backend whose terms carry conditions never becomes an
+  automatic choice.
+- **Krea 3D**, through the `KREA_API_KEY` that was already configured — the
+  same open-weight models one would otherwise self-host, with no GPU, no CUDA
+  toolchain and no 16 GB of weights.
+- **`bg_adopt` — a generation is not an asset.** Measured on real output: a
+  crate came back as 20,748 shells and 495,061 triangles, a mannequin as 604
+  shells with 21,796 non-manifold edges. Weld, decimate, scale, orient, ground,
+  in that order, because grounding before scaling leaves the mesh floating.
+  Welding is gentle on purpose — chasing one shell took the mannequin to 20,285
+  non-manifold edges, after which the decimator could not reach budget at all,
+  since collapse will not cross a non-manifold junction. And it reports
+  asked/got/met with a reason instead of returning a mesh 50× over budget under
+  an ok-looking report.
+- **Orientation is refused rather than guessed.** Generated meshes face any
+  direction and nothing was checking — a mannequin rendered its BACK in the
+  frame labelled "front". Two wrong attempts are recorded in the design: "up is
+  the tallest axis" put a cap's up along its brim, and centroid offset scored a
+  mannequin and a crate within 0.1% of each other. Foot reach separates them.
+  `kind="none"` and unreadable geometry both leave the mesh untouched.
+- **`doctor` gains an `imageto3d` row** with no floor — red means only that
+  path is unavailable — asking `nvidia-smi` rather than torch, because a
+  CPU-only torch in the default interpreter would call a working GPU "no GPU".
+- **`spend` gains a `mesh` kind.** It was landing in `other` with genuinely
+  uncategorised spend, and a textured generation is ~$0.30, an order of
+  magnitude over an image.
+
+### Added — CI
 
 - **A CI pipeline that gates on more than pytest.** `.github/workflows/ci.yml`
   replaces `tests.yml` and adds three checks the repo had already written down
@@ -756,7 +805,8 @@ version.
 - The audio seat workspace is a deliberate v1 (library, playback, cue sheet).
 - The dashboard's error surfacing is uneven; see `docs/ui-ux-audit.md`.
 
-[Unreleased]: https://github.com/Thepizzapie/BuildersGate/compare/v0.1.29...HEAD
+[Unreleased]: https://github.com/Thepizzapie/BuildersGate/compare/v1.3.0...HEAD
+[1.3.0]: https://github.com/Thepizzapie/BuildersGate/compare/v0.1.29...v1.3.0
 [0.1.29]: https://github.com/Thepizzapie/BuildersGate/compare/v0.1.28...v0.1.29
 [0.1.28]: https://github.com/Thepizzapie/BuildersGate/compare/v0.1.27...v0.1.28
 [0.1.27]: https://github.com/Thepizzapie/BuildersGate/compare/v0.1.26...v0.1.27

--- a/bgate_adapters/_blender_base.py
+++ b/bgate_adapters/_blender_base.py
@@ -1356,6 +1356,253 @@ def bg_base_assert(base, expect_height=None):
     return report
 
 
+
+
+def bg_weld(obj, *, fraction=0.0006, merge=0.0):
+    """Weld a generated mesh gently, and report whether it can be decimated.
+
+    GENTLY. The obvious move is to merge hard until the confetti becomes one
+    shell, and it is wrong — MEASURED on a generated mannequin, chasing one
+    shell took non-manifold edges from 3 to 20,285, and the decimator then
+    could not reach an 8,000 triangle budget at all, stalling at 49,261 no
+    matter how many passes it was given. The same mesh at a sixth of that merge
+    distance sat in 4 shells with 3 non-manifold edges and decimated to 7,999.
+
+    So NON-MANIFOLD COUNT is what predicts decimatability, not shell count.
+    Collapse will not cross a non-manifold junction, and over-merging
+    manufactures them faster than it removes shells.
+
+    Distance is a fraction of the object's own bounding-box diagonal, so one
+    setting serves a 0.2 m cap and a 2 m figure. Pass `merge` to override with
+    an absolute distance.
+    """
+    diag = max((sum(d * d for d in obj.dimensions)) ** 0.5, 1e-6)
+    used = float(merge) if merge else diag * float(fraction)
+    bg_clean(obj, merge=used)
+    shells, nonmanifold = bg_shells(obj), bg_nonmanifold(obj)
+    tris = sum(len(p.vertices) - 2 for p in obj.data.polygons)
+    thin = nonmanifold <= max(64, tris * 0.005)
+    return {"merge": round(used, 6), "fraction": round(used / diag, 5),
+            "shells": shells, "nonmanifold": nonmanifold, "tris": tris,
+            "decimatable": thin,
+            "verdict": ("%d shell(s), %d non-manifold — decimates cleanly"
+                        % (shells, nonmanifold)) if thin else
+                       ("%d non-manifold edges on %d triangles — collapse will "
+                        "stall well above any low budget, and merging harder "
+                        "makes this worse, not better" % (nonmanifold, tris))}
+
+
+def bg_nonmanifold(obj):
+    """Edges that are not shared by exactly two faces. The decimation blocker."""
+    import bmesh
+    bm = bmesh.new()
+    bm.from_mesh(obj.data)
+    count = sum(1 for edge in bm.edges if not edge.is_manifold)
+    bm.free()
+    return count
+
+
+def bg_shells(obj):
+    """How many disconnected pieces this mesh is in. 1 is a surface."""
+    import bmesh
+    bm = bmesh.new()
+    bm.from_mesh(obj.data)
+    bm.verts.ensure_lookup_table()
+    seen, count = set(), 0
+    for vert in bm.verts:
+        if vert.index in seen:
+            continue
+        count += 1
+        stack = [vert]
+        while stack:
+            here = stack.pop()
+            if here.index in seen:
+                continue
+            seen.add(here.index)
+            for edge in here.link_edges:
+                stack.append(edge.other_vert(here))
+    bm.free()
+    return count
+
+
+def bg_axes(obj, *, kind="humanoid", up=2):
+    """Which way is this mesh's lateral, forward and up — for a KNOWN kind.
+
+    THERE IS NO UNIVERSAL RULE HERE and the first version of this pretended
+    there was. MEASURED: "up is the tallest axis" put a cap's up along its brim,
+    because a cap lying flat is longer front-to-back than it is tall; and
+    "widest horizontal is lateral" is a T-POSE rule that reads a cap exactly
+    backwards, since a cap's longest horizontal IS its forward.
+
+    So `up` is world up unless you say otherwise, and the lateral/forward split
+    is chosen per kind:
+
+      humanoid  arms span side to side, so lateral is the wider horizontal
+      long      the subject is longer than it is wide along its own forward —
+                a cap, a shoe, a vehicle, a fish
+      none      no opinion; forward is Y and nothing will be rotated
+
+    `certainty` is how lopsided the two horizontals are. Near zero they are the
+    same width and the split is a coin toss whatever the kind says.
+    """
+    dims = [max(d, 1e-9) for d in obj.dimensions]
+    up = int(up) % 3
+    flat = [i for i in (0, 1, 2) if i != up]
+    wide, narrow = (flat if dims[flat[0]] >= dims[flat[1]]
+                    else [flat[1], flat[0]])
+    if kind == "long":
+        lateral, forward = narrow, wide
+    else:
+        lateral, forward = wide, narrow
+    span = max(dims[wide], 1e-9)
+    return {"up": up, "lateral": lateral, "forward": forward, "kind": kind,
+            "dims": tuple(round(d, 4) for d in dims),
+            "certainty": round(abs(dims[wide] - dims[narrow]) / span, 3)}
+
+
+def bg_facing(obj, axes=None):
+    """Which way along the forward axis is the FRONT. Reads the lowest slab.
+
+    Toes are the most reliable asymmetry an upright figure has: a foot reaches
+    much further forward of the ankle than the heel does behind it, so the
+    bottom of a standing mesh has its centre of mass on the toe side. A face is
+    no use — a generated head is often featureless, and ours is an egg by
+    design.
+
+    THIS ONLY MEANS ANYTHING FOR SOMETHING THAT STANDS ON FEET. Asked about a
+    cap it answered "toes lead by 152.8%", which is not a fact about a cap.
+    `confident` is the field to read; the sign without it is noise.
+    """
+    axes = axes or bg_axes(obj)
+    up, forward = axes["up"], axes["forward"]
+    world = [obj.matrix_world @ v.co for v in obj.data.vertices]
+    if not world:
+        return {"sign": 1, "strength": 0.0, "confident": False,
+                "verdict": "no geometry to read"}
+    lows = [p[up] for p in world]
+    floor, ceiling = min(lows), max(lows)
+    cut = floor + (ceiling - floor) * 0.06
+    slab = [p[forward] for p in world if p[up] <= cut] or [p[forward] for p in world]
+    body = sum(p[forward] for p in world) / len(world)
+
+    # REACH, not centroid. A foot is not shifted forward so much as it EXTENDS
+    # forward: the toe reaches much further from the ankle than the heel does.
+    # MEASURED, and the reason this is not the obvious one-liner: by centroid
+    # offset a mannequin scored 2.7% and a CRATE scored 2.8%, so the signal did
+    # not discriminate at all and the mannequin was simply lucky.
+    ahead, behind = max(slab) - body, body - min(slab)
+    bigger, smaller = max(ahead, behind), max(min(ahead, behind), 1e-9)
+    ratio = bigger / smaller
+    ok = ratio >= 1.25 and axes.get("kind") == "humanoid"
+    return {"sign": 1 if ahead >= behind else -1, "strength": round(ratio, 3),
+            "confident": ok,
+            "verdict": ("toes reach %.2fx further than the heel" % ratio) if ok
+                       else ("no readable front — the two sides reach %.2fx, "
+                             "which is not a foot" % ratio)}
+
+
+def bg_orient(obj, *, kind="humanoid", forward=None, assume=None, up=2):
+    """Turn a mesh so it faces the project's forward. REFUSES TO GUESS.
+
+    This is the step a generated layer cannot skip. A wrong scale is obvious in
+    a render and a wrong position is obvious in a check; facing the wrong way
+    is invisible in a symmetric silhouette and then everything downstream is
+    quietly mirrored — the turnaround's labels, a bone-parented cap, Godot's
+    -Z convention, the collider.
+
+    But it only rotates when it can justify it: a confident reading, or an
+    explicit `assume` of +1/-1. MEASURED on real generated output, guessing
+    turned a crate 90 degrees onto a different footprint for no reason. An
+    asset with no front is not a problem to be solved, so `kind="none"` and
+    unreadable geometry both leave the mesh exactly where it was.
+
+    Rotation is in 90-degree steps about the up axis, which is what a generated
+    mesh actually needs — it comes out roughly axis-aligned and turned by a
+    quarter or a half. A mesh tilted off-axis is not corrected; that is what
+    bg_axes' `certainty` is for.
+    """
+    import math
+    target = tuple(forward if forward is not None else BG_FORWARD)
+    axes = bg_axes(obj, kind=kind, up=up)
+    read = bg_facing(obj, axes)
+    forced = assume in (1, -1)
+    if kind == "none" or not (read["confident"] or forced):
+        return {"turned_deg": 0, "was": read, "axes": axes, "confident": False,
+                "note": "left alone — " + ("this kind has no front"
+                        if kind == "none" else read["verdict"] +
+                        "; pass assume=+1/-1 if you know which way it faces")}
+
+    sign = assume if forced else read["sign"]
+    want = 0 if abs(target[0]) > abs(target[1]) else 1
+    want_sign = 1 if (target[want] or 1) > 0 else -1
+
+    turns = 1 if axes["forward"] != want else 0
+    if sign != want_sign:
+        turns += 2
+    turns %= 4
+    if turns:
+        bg_only(obj)
+        obj.rotation_mode = "XYZ"
+        obj.rotation_euler.rotate_axis("Z", math.radians(90.0 * turns))
+        bg_apply(obj, location=False, rotation=True, scale=False)
+    bpy.context.view_layer.update()
+    return {"turned_deg": 90 * turns, "was": read, "axes": axes,
+            "confident": True, "note": ""}
+
+
+def bg_adopt(obj, *, kind="humanoid", height=None, ground=True, orient=True,
+             assume=None, merge=0.0015, budget=0):
+    """Take a generated mesh and make it something this pipeline can use.
+
+    One call for everything a generation arrives WITHOUT: it is a pile of
+    disconnected shells at an arbitrary scale, facing an arbitrary direction,
+    floating at an arbitrary height. MEASURED on real Krea output: a crate came
+    back as 20,748 shells and 495,061 tris; a cap as 628 shells; a mannequin as
+    604 shells, 21,796 non-manifold edges and 95,232 tris that cleaned down to
+    4 shells and 7,928 tris and scaled to 1.800 m exactly.
+
+    Order matters and it is not obvious: clean first so the decimator has
+    welded geometry to work on, then scale, then orient, then drop to the
+    ground — orienting before scaling is fine, but grounding before scaling
+    leaves the mesh floating by whatever the scale factor was.
+    """
+    report = {"before": bg_stats(obj)}
+    # WELD BEFORE DECIMATING. Not a nicety of ordering — the decimator cannot
+    # cross a shell boundary, so on unwelded confetti a low budget is simply
+    # unreachable and comes back silently over.
+    report["weld"] = bg_weld(obj, merge=merge) if merge else {}
+    if budget:
+        tris = sum(len(p.vertices) - 2 for p in obj.data.polygons)
+        if tris > budget:
+            mod = obj.modifiers.new("BGateDecimate", "DECIMATE")
+            mod.ratio = max(0.005, float(budget) / float(tris))
+            bg_only(obj)
+            bpy.ops.object.modifier_apply(modifier=mod.name)
+            bg_clean(obj, merge=merge)
+        got = sum(len(p.vertices) - 2 for p in obj.data.polygons)
+        # SAY SO WHEN THE BUDGET WAS NOT MET. Returning a mesh 50x over budget
+        # with an ok-looking report is the failure this whole pass exists to
+        # stop.
+        report["budget"] = {"asked": budget, "got": got, "met": got <= budget * 1.1,
+                            "reason": "" if got <= budget * 1.1 else
+                            "collapse stalled at %d — %s" % (
+                                got, report.get("weld", {}).get("verdict", ""))}
+    if height:
+        tall = max(obj.dimensions[2], 1e-9)
+        factor = float(height) / tall
+        obj.scale = (factor, factor, factor)
+        bg_apply(obj, location=False, rotation=False, scale=True)
+    if orient:
+        report["orient"] = bg_orient(obj, kind=kind, assume=assume)
+    if ground:
+        bpy.context.view_layer.update()
+        low = min((obj.matrix_world @ v.co).z for v in obj.data.vertices)
+        obj.location.z -= (low - BG_GROUND)
+        bpy.context.view_layer.update()
+    report["after"] = bg_stats(obj)
+    return report
+
+
 def bg_base_help():
     """Print the worked base-mesh script. Read it before you model a character."""
     print(BG_BASE_EXAMPLE)

--- a/bgate_adapters/imageto3d.py
+++ b/bgate_adapters/imageto3d.py
@@ -1,0 +1,2123 @@
+"""Image to 3D — a DRAFT MESH from a picture, generated locally.
+
+WHY THIS EXISTS. The 3D path in this product models from primitives (bg_box,
+bg_cyl, bg_ball, mirrored and tapered), and the ceiling of that approach is a
+blockout: a correctly-proportioned 1.8 m mannequin with paddle arms, mitten
+hands and no face, which every gate here reports green because the gates measure
+well-formedness and not resemblance. Meanwhile the 2D path — anchored
+generation, trained styles, chroma keying — is the strongest thing in the
+product, and until now it terminated in a PNG. A real user drove an excellent
+stylised character through it and believed they had a 3D model. They did not.
+
+WHAT THIS IS NOT. It is not a finished-asset generator, and there is deliberately
+no path from here to godot.deliver_asset. What comes back is a DRAFT MESH:
+unpredictable topology, no armature, no scale convention, no orientation
+guarantee, and quite possibly the background baked in as geometry. It enters the
+existing pipeline at the draft stage and goes through the same conditioning and
+the same gates as anything modelled by hand — scaled to 1.8 m, oriented to +Y,
+bg_clean'd, decimated, weighted to the canonical skeleton, assembled by
+blender_combine. Builders Gate is the harness that turns an inconsistent
+generated mesh into an inspected, engine-ready asset; it is not trying to be the
+best raw generator. Nothing here skips validation.
+
+LOCAL FIRST, AND THAT IS THE POINT. This product is local-first everywhere else
+— loopback dashboard, SQLite state, .env at the game project root, no Docker —
+and renting a mesh generator would have been the one place it stopped being
+true. So the primary backends are open-weight models running on the user's own
+GPU, reached over loopback HTTP. The hosted APIs are kept behind the same
+interface as a fallback and as the comparison baseline, not as the design
+centre.
+
+FOUR THINGS THIS MODULE OWES ITS CALLERS, in the order they bite:
+
+  * IT IMPORTS NOTHING HEAVY. No torch, no CUDA, no model library, ever, at any
+    point in this process. The GPU is probed with `nvidia-smi` (a hundred
+    milliseconds, always present with the driver) and a local server is probed
+    with a short HTTP GET. transcribe.py established this rule for
+    faster-whisper and the reason is the same: the MCP server must not host an
+    inference stack, and a user with no GPU must be completely unaffected.
+
+  * IT WORKS WITH NOTHING CONFIGURED. status() reports every backend and why
+    each is or is not usable, the way blender.available() and
+    imagegen.available() do. No key is read at import time; no server is
+    contacted at import time.
+
+  * IT PRICES A REQUEST, NOT A BACKEND. Locally the price is zero and saying so
+    is the honest answer. On a hosted backend, texture, PBR, rigging and quad
+    remeshing are separately billed, so a quote that reads only the backend
+    name under-quotes the request the art seat actually makes — the lesson
+    krea.price_for learned from usd_with_style_refs, and the same shape.
+
+  * IT STATES THE LICENCE BEFORE IT GENERATES. A game asset produced under a
+    non-commercial, revenue-capped or region-restricted licence is a legal
+    problem, not a technical one, and this tool does not know its user's
+    revenue, territory or monthly actives. Every backend carries its terms in
+    the table, status() surfaces them, and generate() puts them on the result so
+    the manifest records what the asset was made under. A backend whose licence
+    has conditions NEVER becomes an automatic choice.
+
+No key is ever logged, returned, or put on a command line. Everything here is
+stdlib.
+"""
+from __future__ import annotations
+
+import base64
+import json
+import mimetypes
+import os
+import re
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any, Optional
+
+from bgate_core import envfile
+
+# Windows: keep every subprocess from flashing a console window. Same constant,
+# same reason, as blender.py and transcribe.py.
+_NO_WINDOW = 0x08000000 if sys.platform == "win32" else 0
+
+
+class ImageTo3DError(RuntimeError):
+    """A generation failed in a way the caller should surface, not retry blindly."""
+
+
+# ---------------------------------------------------------------------------
+# Licences. A first-class field, not a note.
+# ---------------------------------------------------------------------------
+# COMMERCIAL USE IS A GATE. Builders Gate is a tool other people ship games
+# with; it does not know their revenue, their territory or their monthly
+# actives, so it cannot decide a conditional licence on their behalf. Three
+# codes, and the middle one is the dangerous one because it looks like the first
+# right up until someone's game succeeds.
+FREE = "unrestricted"         # MIT / Apache / an explicit grant. Ship anything.
+CONDITIONAL = "conditional"   # commercial, but only under stated limits
+FORBIDDEN = "non-commercial"  # cannot be used for a shipped asset at all
+
+# Only a FREE backend may be picked automatically. Anything CONDITIONAL has to
+# be named by a human who has read the condition — see choose().
+AUTO_LICENCES = (FREE,)
+
+
+# THE MODEL'S LICENCE, NOT THE RUNNER'S. A local backend is a transport: ComfyUI
+# is MIT and so is its 3D node pack, but what actually generated the mesh is
+# whichever model the graph loaded, and THAT is what decides whether a shipped
+# game asset is clear. The two are routinely conflated, and the conflation is
+# always in the permissive direction.
+#
+# So a user running a local server DECLARES which model is behind it
+# (BGATE_LOCAL_MODEL), and this table turns that into a licence the manifest can
+# record. Undeclared is not assumed permissive — it resolves to CONDITIONAL with
+# the reason, because "we do not know" and "it is fine" are different answers.
+MODEL_LICENCES: dict[str, dict] = {
+    "trellis": {
+        "code": FREE, "label": "TRELLIS (Microsoft)",
+        "summary": "MIT, code and weights. No revenue cap, no territory "
+                   "restriction, no user threshold.",
+        "url": "https://github.com/microsoft/TRELLIS",
+    },
+    "trellis2": {
+        "code": FREE, "label": "TRELLIS.2-4B (Microsoft)",
+        "summary": "MIT, code and weights. Note that the nvdiffrast/nvdiffrec "
+                   "rendering dependencies carry NVIDIA non-commercial CODE "
+                   "licences — generated output is unaffected, but embedding "
+                   "those libraries in a shipped product is a separate "
+                   "question.",
+        "url": "https://huggingface.co/microsoft/TRELLIS.2-4B",
+    },
+    "triposr": {
+        "code": FREE, "label": "TripoSR",
+        "summary": "MIT, code and weights. Weakest quality here — a draft pass.",
+        "url": "https://github.com/VAST-AI-Research/TripoSR",
+    },
+    "instantmesh": {
+        "code": FREE, "label": "InstantMesh",
+        "summary": "Apache-2.0. Unconditional for generated assets. (Its "
+                   "multi-view stage is Zero123++-derived, so check the "
+                   "specific weights you run.)",
+        "url": "https://github.com/TencentARC/InstantMesh",
+    },
+    "hunyuan3d": {
+        "code": CONDITIONAL, "label": "Hunyuan3D 2.x (Tencent)",
+        "summary": "Tencent Hunyuan 3D Community License. The grant EXCLUDES "
+                   "the European Union, the United Kingdom and South Korea "
+                   "entirely, and above 1 million monthly active users you "
+                   "must request written permission from Tencent. Tencent "
+                   "claims no rights in outputs, but the AUP requires AI "
+                   "content to be labelled and forbids using outputs to train "
+                   "another model. For a game sold worldwide on Steam the "
+                   "territory clause is a real distribution problem.",
+        "url": "https://github.com/Tencent-Hunyuan/Hunyuan3D-2.1/blob/main/LICENSE",
+    },
+    "sf3d": {
+        "code": CONDITIONAL, "label": "Stable Fast 3D (Stability)",
+        "summary": "Stability AI Community License. Free below US$1,000,000 in "
+                   "annual organisation-wide revenue, 'regardless of the "
+                   "source of that revenue'; above it an Enterprise licence is "
+                   "required, and the licence explicitly covers OUTPUTS. Also "
+                   "gated on HuggingFace — the weights need an accepted "
+                   "licence and a read token.",
+        "url": "https://stability.ai/license",
+    },
+    "spar3d": {
+        "code": CONDITIONAL, "label": "SPAR3D (Stability)",
+        "summary": "Stability AI Community License, same US$1,000,000 "
+                   "threshold, outputs explicitly covered. HuggingFace-gated.",
+        "url": "https://stability.ai/license",
+    },
+    "partpacker": {
+        "code": FORBIDDEN, "label": "PartPacker (NVIDIA)",
+        "summary": "NVIDIA Non-Commercial licence. Cannot be used for a "
+                   "shipped game asset at all, however good the Windows "
+                   "install story is.",
+        "url": "https://huggingface.co/nvidia/PartPacker",
+    },
+    "zero123plus": {
+        "code": FORBIDDEN, "label": "Zero123++ / Stable Zero123",
+        "summary": "CC-BY-NC weights. Non-commercial — not shippable.",
+        "url": "https://github.com/SUDO-AI-3D/zero123plus",
+    },
+}
+
+# Which model is behind the local server. "" means undeclared.
+MODEL_ENV = "BGATE_LOCAL_MODEL"
+
+_UNDECLARED = {
+    "code": CONDITIONAL,
+    "label": "undeclared",
+    "summary": "the model behind this server has not been declared, so its "
+               "licence is unknown and the mesh cannot be cleared for a "
+               "shipped asset. Set " + MODEL_ENV + " to one of: "
+               + ", ".join(sorted(MODEL_LICENCES)),
+    "url": "",
+}
+
+
+def declared_model() -> str:
+    """Which open-weight model the local server is running, per the user."""
+    return (os.environ.get(MODEL_ENV) or "").strip().lower()
+
+
+def model_licence(name: str = "") -> dict:
+    """The licence of a named model, or the undeclared answer.
+
+    An unknown NAME is treated exactly like an undeclared one — a typo must not
+    silently become permission.
+    """
+    key = (name or declared_model()).strip().lower()
+    found = MODEL_LICENCES.get(key)
+    if not found:
+        return dict(_UNDECLARED)
+    return {**found, "model": key}
+
+
+# ---------------------------------------------------------------------------
+# What the pipeline can take
+# ---------------------------------------------------------------------------
+# .glb and nothing else by default: blender.COMBINE_SUFFIXES accepts
+# .glb/.gltf/.blend and godot.deliver_asset takes a .glb. A format that would
+# need a conversion step nobody wrote is not a supported format.
+DEFAULT_FORMAT = "glb"
+USABLE_FORMATS = ("glb", "gltf")
+
+# What an input plate must be to have any chance. Checked locally, before
+# anything is generated — see check_input().
+INPUT_SUFFIXES = {".png", ".jpg", ".jpeg", ".webp"}
+INPUT_MIN_SIDE = 256          # below this there is nothing to reconstruct from
+INPUT_GOOD_SIDE = 1024        # below this, detail is invented rather than read
+
+
+# ---------------------------------------------------------------------------
+# The GPU, probed the cheap way
+# ---------------------------------------------------------------------------
+# NEVER `import torch` HERE. Not in a try, not behind a flag, not lazily inside
+# a function this process calls. torch is a multi-second import that pins memory
+# and, on a CPU-only wheel, answers a question nobody asked. The two facts that
+# actually decide whether local generation is possible — is there an NVIDIA GPU
+# and how much VRAM does it have — come from nvidia-smi, which ships with the
+# driver, lives on PATH, and answers in about a tenth of a second.
+#
+# MEASURED on the target box (2026-07-30): `nvidia-smi --query-gpu=...` returns
+# "NVIDIA GeForce RTX 3060, 12288 MiB, 595.95" instantly, while the same
+# machine's default interpreter has torch 2.8.0+cpu — CUDA unavailable. Probing
+# via torch would have reported "no GPU" on a machine with a perfectly good one.
+_SMI_QUERY = "name,memory.total,driver_version"
+_SMI_TIMEOUT = 10.0
+
+# Enough VRAM to be worth trying at all, in GB. Below this every open-weight
+# image-to-3D model is out — the smallest shape-only configurations documented
+# want ~6 GB, and adding texture roughly doubles it.
+MIN_VRAM_GB = 6.0
+
+_gpu_cache: Optional[dict] = None
+
+
+def gpu(*, refresh: bool = False) -> dict:
+    """What GPU this machine has, via nvidia-smi. Never imports torch.
+
+    Returns {available, name, vram_gb, driver, reason}. An absent nvidia-smi is
+    reported as "no NVIDIA GPU", which is the useful answer — it is installed by
+    the driver, so its absence and the driver's absence are the same fact.
+
+    Cached, because status() may be polled by a dashboard and spawning a process
+    per poll is how a health check becomes a load source.
+    """
+    global _gpu_cache
+    if _gpu_cache is not None and not refresh:
+        return dict(_gpu_cache)
+    out = {"available": False, "name": "", "vram_gb": 0.0, "driver": "",
+           "reason": ""}
+    try:
+        proc = subprocess.run(
+            ["nvidia-smi", f"--query-gpu={_SMI_QUERY}",
+             "--format=csv,noheader"],
+            capture_output=True, text=True, timeout=_SMI_TIMEOUT,
+            stdin=subprocess.DEVNULL, creationflags=_NO_WINDOW)
+    except FileNotFoundError:
+        out["reason"] = ("nvidia-smi not found — no NVIDIA driver on this "
+                         "machine, so local generation is not available. "
+                         "Everything else in Builders Gate is unaffected.")
+        _gpu_cache = out
+        return dict(out)
+    except Exception as exc:                                     # noqa: BLE001
+        out["reason"] = f"could not query the GPU ({type(exc).__name__}: {exc})"
+        _gpu_cache = out
+        return dict(out)
+    line = (proc.stdout or "").strip().splitlines()
+    if proc.returncode != 0 or not line:
+        out["reason"] = ((proc.stderr or "").strip()[:200]
+                         or "nvidia-smi returned nothing")
+        _gpu_cache = out
+        return dict(out)
+    parts = [p.strip() for p in line[0].split(",")]
+    out["name"] = parts[0] if parts else ""
+    if len(parts) > 1:
+        match = re.search(r"(\d+)", parts[1])
+        if match:
+            out["vram_gb"] = round(int(match.group(1)) / 1024.0, 1)
+    out["driver"] = parts[2] if len(parts) > 2 else ""
+    out["available"] = bool(out["name"])
+    if out["available"] and out["vram_gb"] and out["vram_gb"] < MIN_VRAM_GB:
+        out["reason"] = (
+            f"{out['name']} has {out['vram_gb']} GB of VRAM; every open-weight "
+            f"image-to-3D model documented needs at least {MIN_VRAM_GB} GB for "
+            "shape alone, and roughly double that with texture")
+    return dict(_gpu_cache := out)
+
+
+def fits_vram(need_gb: Optional[float], *, refresh: bool = False) -> dict:
+    """Would a model wanting `need_gb` fit on this machine?
+
+    Returns {ok, reason, vram_gb}. An unknown requirement (None) is NOT treated
+    as a pass — it comes back ok=True with the uncertainty stated, because
+    refusing on a number nobody published would block a model that might run
+    perfectly well, and claiming it fits would be a guess dressed as a check.
+    """
+    card = gpu(refresh=refresh)
+    if not card["available"]:
+        return {"ok": False, "vram_gb": 0.0, "reason": card["reason"]}
+    have = float(card["vram_gb"] or 0.0)
+    if need_gb is None:
+        return {"ok": True, "vram_gb": have,
+                "reason": "this model publishes no VRAM figure — it was not "
+                          "checked, only reported"}
+    if have and have + 0.001 < float(need_gb):
+        return {"ok": False, "vram_gb": have,
+                "reason": f"needs about {need_gb} GB of VRAM and this machine "
+                          f"has {have} GB ({card['name']})"}
+    return {"ok": True, "vram_gb": have, "reason": ""}
+
+
+def runner_python() -> str:
+    """The interpreter that would run a local model, if a caller wants one.
+
+    BGATE_IMAGETO3D_PYTHON, and it defaults to nothing rather than to
+    sys.executable. That default is deliberate and it is the opposite of
+    transcribe.whisper_python's: faster-whisper installs beside this tool, and
+    an inference stack does not. MEASURED on the target box — Python 3.13 and
+    3.12 installed, torch 2.8.0+cpu in the default one, and every open-weight
+    image-to-3D repo pinning 3.10/3.11 with a CUDA build. Pointing this at
+    sys.executable would produce a confident failure instead of an honest
+    "not configured".
+    """
+    return (os.environ.get("BGATE_IMAGETO3D_PYTHON") or "").strip()
+
+
+# ---------------------------------------------------------------------------
+# Backends
+# ---------------------------------------------------------------------------
+# Keyed by what a caller passes as ``backend=``. LOCAL FIRST — the hosted rows
+# exist as a fallback and as the honest comparison baseline, not as the design
+# centre.
+#
+# Fields, and why each exists:
+#
+#   kind         "local" | "hosted". Decides almost everything else: a local
+#                backend has no key, no price and no rate limit, and a hosted
+#                one has no VRAM requirement and no install story.
+#   env          the environment variable holding the key, or "" for a backend
+#                that needs none. "" is NOT the same as missing.
+#   base         API root. Local backends declare `base_env` too, because the
+#                whole point is that it is the operator's own box and port.
+#   submit_path  where a generation is POSTed.
+#   poll_path    GET template with {task}; "" means the backend answers
+#                synchronously and there is nothing to poll.
+#   image_mode   how the plate travels: "field" (inline in the JSON body),
+#                "file_token" (a separate upload endpoint hands back a token),
+#                "multipart" (the bytes go up with the request itself).
+#   fields       our option name -> theirs. The backends agree on nothing:
+#                `texture` vs `should_texture`, `face_limit` vs
+#                `target_polycount` vs `face_count`. Renaming in a table beats a
+#                builder function per backend, because the differences are all
+#                naming and nesting.
+#   credits      what each part of a request costs in the backend's OWN unit.
+#   usd_per_credit  the PUBLISHED conversion, or None. None propagates:
+#                price_for returns None and the caller must ask a human rather
+#                than spend. krea.TRAIN_USD settled this — an invented price is
+#                worse than a missing one, because the spend gate treats a
+#                number as permission.
+#   vram_gb      local only. What the docs say inference needs.
+#   weights      local only. Where the weights come from and how big they are.
+#   windows      local only. Whether it installs on native Windows, which is the
+#                question that actually decides feasibility on the target box.
+#   licence      {code, summary, url}. code is FREE / CONDITIONAL / FORBIDDEN.
+#   implemented  False for a backend that is documented here as an alternative
+#                but whose transport is not wired. status() says so plainly
+#                rather than letting a caller discover it at request time.
+#
+# EVERY NUMBER CAME OFF A PUBLIC DOCUMENT, and nothing here has been paid for or
+# installed. Where a document stated none, the field is None and stays None.
+BACKENDS: dict[str, dict] = {
+    # ---- LOCAL ----------------------------------------------------------
+    #
+    # A ComfyUI instance on loopback with a 3D custom-node pack installed. This
+    # is the realistic Windows path, for a reason that has nothing to do with
+    # model quality: every open-weight repo here leans on custom CUDA extensions
+    # (nvdiffrast, diffoctreerast, diff-gaussian-rasterization, custom
+    # rasterizers, spconv, diso) that must be COMPILED against MSVC and a
+    # matching CUDA toolkit, and a ComfyUI node pack is where a Windows user
+    # gets those as prebuilt wheels instead. A model that is technically better
+    # but does not install is worse than one that does.
+    #
+    # WHICH PACK, AND THE CORRECTION WORTH RECORDING: the obvious answer is
+    # ComfyUI-3D-Pack, and as of this writing it is a trap for a fresh install.
+    # Its prebuilt wheel matrix tops out at Python 3.12 with torch 2.7.0 and has
+    # no Python 3.13 entry at all, its last commit was 2025-11-17, and when no
+    # prebuild matches the runtime its installer falls back to compiling from
+    # source — which is precisely the thing it was chosen to avoid. A current
+    # ComfyUI ships a newer Python and torch than anything in that matrix.
+    #
+    # The pack that does work without a compiler is visualbruno/ComfyUI-Trellis2
+    # (TRELLIS.2, all five CUDA extensions shipped as win_amd64 wheels in-repo,
+    # Python 3.11 and 3.13, torch 2.7/2.8/2.10, current to mid-2026) — and
+    # TRELLIS.2 is MIT, which makes it the only local option whose output is
+    # unconditionally shippable. See MODEL_LICENCES.
+    #
+    # THE WORKFLOW IS THE USER'S, NOT OURS. ComfyUI takes a whole graph as the
+    # request body, and that graph names node classes whose exact spelling
+    # changes with every 3D-Pack release. Hardcoding one would make this adapter
+    # break on somebody else's upgrade. So the workflow is config: an
+    # API-format JSON exported from their own ComfyUI, with two placeholders
+    # this module substitutes. That is not a cop-out — a workflow graph IS a
+    # per-installation artefact, and treating it as one is the correct model.
+    "comfy": {
+        "kind": "local",
+        "label": "ComfyUI (local, ComfyUI-3D-Pack)",
+        "env": "",
+        "base": "http://127.0.0.1:8188",
+        "base_env": "BGATE_COMFY_URL",
+        "workflow_env": "BGATE_COMFY_WORKFLOW",
+        # /api-PREFIXED, deliberately. ComfyUI's server registers every route
+        # twice — bare and under /api — and the /api form is the stable one; the
+        # bare paths share a namespace with the web UI's own SPA routing.
+        "submit_path": "/api/prompt",
+        "poll_path": "/api/history/{task}",
+        "health_path": "/api/system_stats",
+        "upload_path": "/api/upload/image",
+        "view_path": "/api/view",
+        "upload_field": "image",
+        "auth": "none",
+        "image_mode": "workflow",
+        "task_key": "prompt_id",
+        "usd": 0.0,
+        # Whatever the graph does. The adapter cannot know, and pretending
+        # otherwise would put a false capability list in front of an agent.
+        "supports": {"seed"},
+        "formats": ("glb",),
+        "rigged": False,
+        "vram_gb": None,
+        "weights": "whatever the workflow's nodes load, into the HuggingFace "
+                   "cache of the ComfyUI interpreter — TRELLIS is ~3.3 GB, "
+                   "TRELLIS.2-4B ~16 GB, Hunyuan3D-2 25 GB and up",
+        "windows": "the only realistic zero-compile route. Use "
+                   "visualbruno/ComfyUI-Trellis2, which ships win_amd64 wheels "
+                   "for every CUDA extension it needs. ComfyUI-3D-Pack has no "
+                   "Python 3.13 wheels, nothing above torch 2.7.0, and silently "
+                   "falls back to compiling when nothing matches",
+        "latency_s": None,
+        # The graph decides which model runs, so the licence comes from the
+        # declared model rather than from this row. ComfyUI and its node packs
+        # being MIT says nothing about the weights.
+        "licence_from_model": True,
+        "licence": {
+            "code": CONDITIONAL,
+            "summary": "ComfyUI and its 3D node packs are MIT, but the LICENCE "
+                       "THAT MATTERS IS THE MODEL'S and the graph decides which "
+                       "model runs. This adapter cannot read the graph, so it "
+                       "cannot clear the licence for you — declare the model "
+                       "with " + MODEL_ENV + " and it will.",
+            "url": "https://github.com/visualbruno/ComfyUI-Trellis2",
+        },
+        "note": "Needs a running ComfyUI with a 3D node pack and an API-format "
+                "workflow exported to BGATE_COMFY_WORKFLOW.",
+    },
+    # A prebuilt Windows EXECUTABLE. No Python, no CUDA toolkit, no compilation
+    # of anything — the release zip carries trellis-server.exe and the CUDA
+    # runtime DLLs. POST multipart, get raw GLB bytes back. It is by a distance
+    # the cleanest contract and the easiest install surveyed, and at q8
+    # quantisation it wants about 9.5 GB, which fits a 12 GB card.
+    #
+    # AND IT HAS NO DECLARED LICENCE, which is why it is not the default. An
+    # unlicensed repository is not permissive by omission — the absence of a
+    # LICENSE file means all rights reserved, and that is a worse position for a
+    # shipped game asset than any of the restrictive licences here, because
+    # there is nothing to read. The MODEL it runs (TRELLIS.2) is MIT; the SERVER
+    # is not licensed at all. Those are different questions and only the second
+    # one is unanswered.
+    "trellis-cpp": {
+        "kind": "local",
+        "label": "trellis.cpp (prebuilt Windows server, TRELLIS.2 GGUF)",
+        "env": "",
+        "base": "http://127.0.0.1:8080",
+        "base_env": "BGATE_TRELLIS_CPP_URL",
+        "submit_path": "/generate",
+        "poll_path": "",                 # synchronous: the response IS the GLB
+        "health_path": "/health",
+        "auth": "none",
+        "image_mode": "multipart",
+        "upload_field": "image",
+        "response": "binary",
+        "fields": {"seed": "seed", "resolution": "resolution"},
+        "usd": 0.0,
+        "supports": {"seed", "resolution"},
+        "formats": ("glb",),
+        "rigged": False,
+        # q8 is the 12 GB target: f16 ~16.5 GB, q8 ~9.5 GB and near-lossless,
+        # q4 ~6 GB.
+        "vram_gb": 9.5,
+        "weights": "ilintar/trellis2-gguf on HuggingFace, fetched by the "
+                   "installer. The Windows release zip itself is ~728 MB and "
+                   "bundles the CUDA runtime, so no CUDA toolkit is needed",
+        "windows": "the easiest install surveyed — a prebuilt "
+                   "trellis-cuda-windows-x64.zip with trellis-server.exe and "
+                   "the CUDA DLLs. Nothing is compiled",
+        "latency_s": None,
+        "licence": {
+            "code": CONDITIONAL,
+            "summary": "THE SERVER HAS NO DECLARED LICENCE. No LICENSE file "
+                       "means all rights reserved, not permissive-by-default, "
+                       "and that is a worse position than an explicit "
+                       "restriction because there is nothing to read. The model "
+                       "it runs (TRELLIS.2) is MIT and its outputs are clear; "
+                       "the question is the server binary, not the mesh. Ask "
+                       "upstream before depending on it.",
+            "url": "https://github.com/pwilkin/trellis.cpp",
+        },
+        "note": "Synchronous — POST the plate, get GLB bytes. Default "
+                "127.0.0.1:8080. Requests are serialised behind a mutex, so "
+                "one at a time.",
+    },
+    # Tencent's own FastAPI server — the first open-weight image-to-3D repo to
+    # ship a documented, non-Gradio HTTP contract.
+    #
+    # TARGETED AT 2.0, NOT 2.1, AND THAT IS THE OPPOSITE OF THE OBVIOUS CHOICE.
+    # Three reasons, all from reading the two servers:
+    #   * 2.0 needs NO compiled CUDA extension for shape-only generation, and 6
+    #     GB of VRAM. 2.1 wants 10 GB for shape and 21 GB for texture, and its
+    #     documented install runs a bash script.
+    #   * 2.1's worker READS EVERY PARAMETER AND USES NONE OF THEM. Its generate
+    #     method touches params["image"] and calls the pipeline with that alone
+    #     — seed, octree_resolution, steps, guidance, face_count and texture are
+    #     all accepted, validated, and discarded.
+    #   * 2.1's /send can deadlock: on a texture failure the worker falls back
+    #     to the untextured mesh and succeeds, but /status only reports
+    #     "completed" once the TEXTURED file exists, so the job reports
+    #     "texturing" forever.
+    # On 2.1, use the blocking POST /generate instead of /send.
+    "hunyuan-local": {
+        "kind": "local",
+        "label": "Hunyuan3D 2.0 (self-hosted api_server.py)",
+        "env": "",
+        "base": "http://127.0.0.1:8081",
+        "base_env": "BGATE_HUNYUAN3D_URL",
+        "submit_path": "/send",
+        "poll_path": "/status/{task}",
+        "health_path": "/health",
+        "auth": "none",
+        "image_mode": "field",
+        "task_key": "uid",
+        "status_key": "status",
+        "done": ("completed",),
+        "dead": ("error", "failed"),
+        "running": ("processing", "pending", "queued", "texturing"),
+        # /status hardcodes a .glb filename while the worker writes
+        # <uid>.<type>, so type="obj" polls for a file that will never appear.
+        # `formats` below advertises glb only for exactly that reason.
+        # The finished model comes back INLINE as base64 on the status
+        # response, not as a URL. download() has to know the difference.
+        "result_b64_keys": ("model_base64",),
+        "static": {"type": "glb"},
+        "fields": {"image": "image", "texture": "texture",
+                   "face_count": "face_count", "seed": "seed",
+                   "steps": "num_inference_steps",
+                   "guidance": "guidance_scale",
+                   "octree_resolution": "octree_resolution"},
+        "usd": 0.0,
+        "supports": {"texture", "face_count", "seed", "steps", "guidance",
+                     "octree_resolution"},
+        # glb ONLY, not because the server refuses obj but because its /status
+        # route cannot see an obj it just wrote. See above.
+        "formats": ("glb",),
+        "rigged": False,
+        # 2.0: 6 GB shape-only, 16 GB with texture. Texture also needs the
+        # compiled rasteriser and the server started with --enable_tex, so on a
+        # 12 GB card the supported configuration is shape-only.
+        "vram_gb": 16.0,
+        "vram_gb_shape_only": 6.0,
+        "weights": "tencent/Hunyuan3D-2.1 on HuggingFace, fetched on first run "
+                   "into the server's own cache. Not small: the 2.x model "
+                   "repos run 25 GB for mini and up to ~75 GB for the full "
+                   "set, so first run is a long download, not a pause",
+        "windows": "SHAPE-ONLY NEEDS NO COMPILER on 2.0 — its requirements are "
+                   "all plain wheels and it ships a pure-Python fallback "
+                   "renderer plus a .bat (2.1 ships only a .sh). TEXTURE is "
+                   "the part that needs custom_rasterizer built with MSVC and "
+                   "a matching CUDA toolkit, and is the part that commonly "
+                   "fails on Windows. YanWenKun/Hunyuan3D-2-WinPortable is the "
+                   "zero-compile bundle",
+        "latency_s": (30, 180),
+        "licence": {
+            "code": CONDITIONAL,
+            "summary": "Tencent Hunyuan 3D Community License. The grant "
+                       "EXCLUDES the European Union, the United Kingdom and "
+                       "South Korea entirely, and above 1 million monthly "
+                       "active users you must request a licence from Tencent, "
+                       "granted at their discretion. Tencent claims no rights "
+                       "in generated outputs, and outputs may not be used to "
+                       "train another 3D model.",
+            "url": "https://github.com/Tencent-Hunyuan/Hunyuan3D-2.1/blob/main/LICENSE",
+        },
+        "note": "Start it with `python api_server.py --host 127.0.0.1 --port "
+                "8081` in the Hunyuan3D-2 checkout — it binds 0.0.0.0 by "
+                "default, so pass --host. Leave --enable_tex off for the "
+                "shape-only path that needs no compiler. Free to run; see the "
+                "licence.",
+    },
+    # The escape hatch for everything that ships only a Gradio demo — TRELLIS,
+    # Stable Fast 3D, SPAR3D, TripoSR. Gradio auto-exposes a REST API, so this
+    # is reachable; what it is NOT is a stable contract, because the endpoint
+    # names are whatever that repo's app.py declared this week. Implemented as
+    # a named, configurable thing rather than pretended into a first-class
+    # backend.
+    "gradio-local": {
+        "kind": "local",
+        "label": "a local Gradio app (TRELLIS / SF3D / TripoSR)",
+        "env": "",
+        "base": "http://127.0.0.1:7860",
+        "base_env": "BGATE_GRADIO3D_URL",
+        "api_name_env": "BGATE_GRADIO3D_ENDPOINT",
+        "submit_path": "/gradio_api/call/{api_name}",
+        "poll_path": "/gradio_api/call/{api_name}/{task}",
+        "health_path": "/config",
+        "auth": "none",
+        "image_mode": "field",
+        "usd": 0.0,
+        "supports": {"seed"},
+        "formats": ("glb",),
+        "rigged": False,
+        "vram_gb": None,
+        "weights": "whichever app is running, into its own HuggingFace cache "
+                   "on first run — TripoSR ~1.7 GB, TRELLIS ~3.3 GB, Stable "
+                   "Fast 3D ~4 GB, SPAR3D ~7.3 GB. Stability's two are GATED: "
+                   "the licence has to be accepted on HuggingFace and a read "
+                   "token is needed at runtime",
+        "windows": "depends entirely on the app. TRELLIS is documented "
+                   "Linux-only upstream; Stable Fast 3D calls its own Windows "
+                   "support experimental and compiles texture_baker and "
+                   "uv_unwrapper from source; TripoSR needs torchmcubes built "
+                   "from git, which silently builds CPU-only when CUDA is not "
+                   "found and then fails at run time",
+        "latency_s": None,
+        "implemented": False,
+        "licence_from_model": True,
+        "licence": {
+            "code": CONDITIONAL,
+            "summary": "Whatever the running app's model is licensed under — "
+                       "declare it with " + MODEL_ENV + ". TRELLIS and TripoSR "
+                       "are MIT and unrestricted; Stable Fast 3D and SPAR3D are "
+                       "the Stability Community License, free below US$1M "
+                       "annual revenue with outputs explicitly covered.",
+            "url": "",
+        },
+        "note": "Documented, not wired. Gradio's endpoint names are per-app "
+                "and per-version, so this needs the app named before it can be "
+                "called — see the design note.",
+    },
+
+    # ---- HOSTED (fallback and baseline) ---------------------------------
+    #
+    # Kept behind the same interface deliberately. They are the comparison the
+    # local decision was made against, and the answer for a user with no GPU.
+    #
+    # STABILITY IS FIRST HERE ON PURPOSE. It is the cheapest, the simplest
+    # (synchronous — POST the image, get GLB bytes back, no polling at all) and
+    # it has the cleanest terms of any hosted option: the API terms say you own
+    # what you generate, with NO revenue threshold. The US$1M figure people
+    # quote belongs to the Community License, which governs SELF-HOSTING the
+    # weights — a different transaction from paying per credit for the hosted
+    # endpoint. Worth writing down because conflating the two is the obvious
+    # mistake.
+    "stability": {
+        "kind": "hosted",
+        "label": "Stability AI — Stable Fast 3D",
+        "env": "STABILITY_API_KEY",
+        "base": "https://api.stability.ai",
+        "submit_path": "/v2beta/3d/stable-fast-3d",
+        "poll_path": "",                 # synchronous: the response IS the GLB
+        "auth": "bearer",
+        "image_mode": "multipart",
+        "upload_field": "image",
+        "response": "binary",
+        "fields": {"texture_resolution": "texture_resolution",
+                   "foreground_ratio": "foreground_ratio",
+                   "quad": "remesh", "face_count": "vertex_count"},
+        "credits": {"base": 10},
+        "usd_per_credit": 0.01,          # published
+        "supports": {"quad", "face_count", "texture_resolution",
+                     "foreground_ratio"},
+        "formats": ("glb",),
+        "rigged": False,
+        "latency_s": (1, 3),
+        "licence": {
+            "code": FREE,
+            "summary": "The hosted API's terms state you own the content you "
+                       "generate, with no revenue threshold and no territory "
+                       "restriction. The US$1,000,000 cap in the Stability "
+                       "Community License governs SELF-HOSTING the weights, "
+                       "which is a different transaction — do not conflate "
+                       "them.",
+            "url": "https://platform.stability.ai/legal/terms-of-service",
+        },
+        "note": "$0.10 a generation, synchronous, no job to poll. The cleanest "
+                "hosted terms of the four and the cheapest.",
+    },
+    "tripo": {
+        "kind": "hosted",
+        "label": "Tripo (v2 openapi)",
+        "env": "TRIPO_API_KEY",
+        # v2 DELIBERATELY. Tripo runs two API surfaces on two doc sites with
+        # INCOMPATIBLE response schemas (v2 `data.output.model`, v3
+        # `output.model_url`), and v2 is the better documented. Pinning one is
+        # the difference between a working poller and one reading a field the
+        # server never sends.
+        "base": "https://api.tripo3d.ai/v2/openapi",
+        "submit_path": "/task",
+        "poll_path": "/task/{task}",
+        "upload_path": "/upload",
+        "upload_field": "file",
+        "upload_token_key": "data.image_token",
+        "auth": "bearer",
+        # Tripo does NOT accept a base64 data URI. The plate goes to /upload
+        # first and the task references the token — a two-hop dance for every
+        # local file, and a 400 if you skip it.
+        "image_mode": "file_token",
+        "file_type": "png",
+        "task_key": "data.task_id",
+        "status_key": "data.status",
+        "done": ("success",),
+        "dead": ("failed", "banned", "expired", "cancelled"),
+        "running": ("queued", "running", "unknown"),
+        # pbr_model first: with pbr=true the textured result is there and
+        # `model` is the plain one. Taking `model` would silently ship the
+        # cheaper output nobody asked for.
+        "result_keys": ("data.output.pbr_model", "data.output.model",
+                        "data.output.base_model"),
+        # FIVE MINUTES, and it shapes the integration. A finished URL cannot be
+        # filed on the board and fetched later — the download must happen inside
+        # the polling loop, in the same run. generate() does exactly that.
+        "url_ttl_s": 300,
+        "static": {"type": "image_to_model"},
+        "default_model": "v2.5-20250123",
+        "fields": {"file": "file", "texture": "texture", "pbr": "pbr",
+                   "quad": "quad", "face_count": "face_limit",
+                   "seed": "model_seed", "model": "model_version",
+                   "orientation": "orientation"},
+        "credits": {"base": 30, "untextured": 20, "quad": 5,
+                    "detailed_texture": 10, "rig": 25, "rig_check": 0,
+                    "retarget": 10},
+        "usd_per_credit": 0.01,          # published
+        "supports": {"texture", "pbr", "quad", "face_count", "seed",
+                     "orientation", "rig"},
+        "formats": ("glb", "fbx"),
+        # Rigging is a SEPARATE, separately-billed task chained off the
+        # generation's task id — not a flag. `spec` picks tripo-native or
+        # mixamo bone naming, and neither is this pipeline's
+        # SkeletonProfileHumanoid convention, so a generated rig is a retarget
+        # source at best.
+        "rigged": "separate-task",
+        "rig_types": ("biped", "quadruped", "hexapod", "octopod", "avian",
+                      "serpentine", "aquatic"),
+        "latency_s": None,               # undocumented; the poll reports
+                                         # running_left_time at runtime
+        "licence": {
+            "code": CONDITIONAL,
+            "summary": "PAID PLAN ONLY for commercial use. Paid users get full "
+                       "rights to outputs with no attribution, and Tripo "
+                       "commits to not training on inputs or outputs. FREE "
+                       "users get no commercial rights at all — Tripo retains "
+                       "the right to use, copy, modify and distribute "
+                       "free-tier outputs.",
+            "url": "https://www.tripo3d.ai/terms",
+        },
+        "note": "~$0.30 a textured generation, pay-as-you-go with no monthly "
+                "floor. Rigs seven skeleton archetypes. Download URLs expire "
+                "in FIVE MINUTES.",
+    },
+    "meshy": {
+        "kind": "hosted",
+        "label": "Meshy (openapi v1)",
+        "env": "MESHY_API_KEY",
+        "base": "https://api.meshy.ai/openapi/v1",
+        "submit_path": "/image-to-3d",
+        "poll_path": "/image-to-3d/{task}",
+        "auth": "bearer",
+        # Takes a data URI directly in image_url — no upload hop, which for a
+        # pipeline whose every input is a local PNG is materially simpler.
+        "image_mode": "field",
+        "task_key": "result",
+        "status_key": "status",
+        "done": ("SUCCEEDED",),
+        "dead": ("FAILED", "CANCELED"),
+        "running": ("PENDING", "IN_PROGRESS"),
+        "result_keys": ("model_urls.glb",),
+        "url_ttl_s": 259200,             # three days; `expires_at` is on the
+                                         # response
+        "static": {},
+        "default_model": "meshy-6",
+        "fields": {"image": "image_url", "texture": "should_texture",
+                   "pbr": "enable_pbr", "face_count": "target_polycount",
+                   "model": "ai_model", "pose": "pose_mode", "seed": "seed"},
+        # `quad` is not a boolean here, and `should_remesh` defaults to FALSE on
+        # meshy-6 — so topology and polycount are SILENTLY IGNORED unless it is
+        # switched on. Handled in _quirks_meshy, because a silently dropped
+        # request is exactly the failure this module exists not to have.
+        "quirks": "meshy",
+        "credits": {"base": 30, "untextured": 30, "rig": 5, "animation": 3},
+        # NOT PUBLISHED. The Pro bundle is $20 for 1000 credits, which divides
+        # to $0.02, but that is arithmetic on a no-rollover bundle rather than a
+        # rate Meshy states. price_for returns None here on purpose.
+        "usd_per_credit": None,
+        "usd_per_credit_note": (
+            "Meshy publishes no per-credit dollar rate. The Pro plan divides "
+            "to about $0.02/credit ($20 for 1000, no rollover), making a "
+            "textured generation roughly $0.60 — twice Tripo — but that is "
+            "derived, not quoted, so it is not treated as a price."),
+        "supports": {"texture", "pbr", "face_count", "quad", "pose", "seed",
+                     "rig"},
+        "formats": ("glb", "fbx", "obj", "usdz", "stl", "3mf"),
+        "rigged": "separate-task",
+        # HUMANOID ONLY, and three constraints the docs state outright: over
+        # 300,000 faces unsupported, the character's face must point at +Z, and
+        # an untextured or anatomically-unclear mesh is refused. The +Z one is
+        # worth reading twice against this pipeline's own convention —
+        # BG_FORWARD is +Y in Blender.
+        "rig_types": ("biped",),
+        "rig_max_faces": 300_000,
+        "rig_facing": "+Z",
+        "latency_s": None,
+        "licence": {
+            "code": CONDITIONAL,
+            "summary": "API access requires Pro or above, and every paid plan "
+                       "gives full ownership of outputs with no attribution. "
+                       "The free plan cannot reach the API at all, and its "
+                       "web-app outputs are owned by Meshy and licensed back "
+                       "under CC BY 4.0 — commercial use permitted WITH "
+                       "attribution. So an API integration is on the clean "
+                       "side of this by construction.",
+            "url": "https://www.meshy.ai/terms-of-use",
+        },
+        "note": "Takes a data URI directly, keeps result URLs for three days, "
+                "and can be asked for a T-pose at generation time "
+                "(pose='t-pose') — the single most useful parameter here for a "
+                "riggable character. $20/mo floor.",
+    },
+    "rodin": {
+        "kind": "hosted",
+        "label": "Rodin / Hyper3D (Gen-2.5)",
+        "env": "RODIN_API_KEY",
+        "base": "https://api.hyper3d.com/api/v2",
+        "submit_path": "/rodin",
+        "poll_path": "/status",
+        "download_path": "/download",
+        "auth": "bearer",
+        "image_mode": "multipart",
+        "upload_field": "images",
+        "usd": None,
+        "credits": {"base": 0.5, "extreme_high": 1.0, "highpack": 1.0},
+        # Only the FREE plan's "$1.5 per credit" is published. API access needs
+        # the Business plan, whose credit rate Hyper3D never states — the
+        # ~$0.23/model figure people quote is arithmetic on a bundle. So: None.
+        "usd_per_credit": None,
+        "usd_per_credit_note": (
+            "Hyper3D publishes $1.50/credit for the FREE plan only. API access "
+            "requires the Business plan ($96-120/mo), whose credit rate is not "
+            "published anywhere."),
+        "supports": {"quad", "face_count", "pose", "seed"},
+        "formats": ("glb", "obj", "fbx", "usdz", "stl"),
+        "rigged": False,
+        "latency_s": (20, 90),           # Sketch ~20s, Regular ~70s, Gen-2 ~90s
+        "implemented": False,
+        "licence": {
+            "code": FREE,
+            "summary": "The terms grant an explicit unrestricted licence to "
+                       "generated Output, and carve Output out of the "
+                       "'Content' whose resale is otherwise forbidden. "
+                       "Commercial use of generated models is clear. Note that "
+                       "ChatAvatar output on the same site is NOT — it is "
+                       "non-commercial unless separately licensed.",
+            "url": "https://hyper3d.ai/legal/terms",
+        },
+        "note": "Documented, not wired: a three-call dance (multipart submit, "
+                "POST /status, POST /download), API gated behind a $96-120/mo "
+                "Business plan, and no published credit rate. Up to 5 input "
+                "images, quad topology to 200k, TAPose for rig-ready "
+                "geometry — but no rigging.",
+    },
+}
+
+# Deliberately empty. Every backend surveyed is either CONDITIONAL, or needs a
+# key, or needs a server somebody has to start. A default that quietly picks one
+# is a licence decision made for a stranger — see choose().
+DEFAULT_BACKEND = ""
+
+LOCAL = tuple(k for k, v in BACKENDS.items() if v["kind"] == "local")
+HOSTED = tuple(k for k, v in BACKENDS.items() if v["kind"] == "hosted")
+
+
+def _spec(backend: str) -> dict:
+    spec = BACKENDS.get(backend)
+    if spec is None:
+        raise ImageTo3DError(f"unknown backend {backend!r} — known: "
+                             f"{', '.join(sorted(BACKENDS))}")
+    return spec
+
+
+# ---------------------------------------------------------------------------
+# Keys, endpoints, availability
+# ---------------------------------------------------------------------------
+def api_key(backend: str, root: Any = None) -> str:
+    """The token for this backend, from the project's .env or the environment.
+
+    Never logged, never returned in a result, never put on a command line. A
+    local backend needs no key and returns "" — a legitimate answer, which is
+    why available() asks the table rather than this.
+    """
+    name = (BACKENDS.get(backend) or {}).get("env") or ""
+    if not name:
+        return ""
+    if root:
+        try:
+            envfile.load_project_env(root)
+        except Exception:                                        # noqa: BLE001
+            pass
+    return (os.environ.get(name) or "").strip()
+
+
+def base_url(backend: str) -> str:
+    """Where this backend lives. Overridable only where it should be.
+
+    Local backends declare ``base_env`` because the host and port are the
+    operator's. A hosted API's base URL is not a knob, and making it one is how
+    a key ends up POSTed somewhere nobody intended.
+    """
+    spec = BACKENDS.get(backend) or {}
+    override = spec.get("base_env")
+    if override:
+        return (os.environ.get(override) or spec.get("base") or "").rstrip("/")
+    return str(spec.get("base") or "").rstrip("/")
+
+
+def available(backend: str, root: Any = None, *, probe: bool = False) -> dict:
+    """Can this backend be used? Presence only, unless ``probe``.
+
+    A health check that spends money — or that loads a 5 GB model — is one
+    nobody runs, so nothing here generates. ``probe=False`` (the default) never
+    touches the network at all: for a local backend it reports the GPU and where
+    the server is expected, and for a hosted one whether the key is present.
+    ``probe=True`` additionally does one short GET against a local backend's
+    health endpoint, which is the only way to distinguish "configured" from
+    "actually running".
+    """
+    spec = BACKENDS.get(backend)
+    if spec is None:
+        return {"available": False, "backend": backend,
+                "reason": f"unknown backend {backend!r} — known: "
+                          f"{', '.join(sorted(BACKENDS))}"}
+    # A transport backend (ComfyUI, a Gradio app) has no licence of its own —
+    # the model behind it does. Resolve from the declared model when the user
+    # has said, and keep the row's "we cannot tell you" wording when they have
+    # not.
+    licence = dict(spec["licence"])
+    if spec.get("licence_from_model"):
+        declared = model_licence()
+        if declared.get("model"):
+            licence = declared
+    common = {
+        "backend": backend, "kind": spec["kind"], "label": spec["label"],
+        "licence": licence,
+        "rigged": spec.get("rigged") or False,
+        "formats": list(spec.get("formats") or ()),
+        "implemented": spec.get("implemented", True),
+        "note": spec.get("note", ""),
+    }
+    if not common["implemented"]:
+        return {**common, "available": False,
+                "reason": "documented as an alternative, but its transport is "
+                          "not wired in this adapter — see the note"}
+
+    if spec["kind"] == "local":
+        card = gpu()
+        fit = fits_vram(spec.get("vram_gb"))
+        out = {**common, "base": base_url(backend),
+               "gpu": card,
+               "vram_gb_needed": spec.get("vram_gb"),
+               "weights": spec.get("weights", ""),
+               "windows": spec.get("windows", "")}
+        if not card["available"]:
+            return {**out, "available": False, "reason": card["reason"]}
+        if not fit["ok"]:
+            # NOT fatal by itself — a shape-only run may still fit, and the
+            # server may be on another machine entirely. Reported as the reason
+            # while staying available, so a caller can decide.
+            out["vram_warning"] = fit["reason"]
+        if not probe:
+            return {**out, "available": True, "reason": "",
+                    "checked": "configuration only — pass probe=True to ask "
+                               "whether the server is actually up"}
+        alive = _alive(backend)
+        return {**out, "available": bool(alive["ok"]),
+                "reason": "" if alive["ok"] else alive["reason"],
+                "checked": "health endpoint"}
+
+    name = spec.get("env") or ""
+    if not api_key(backend, root):
+        return {**common, "available": False,
+                "reason": f"{name} not set — put it in the project's .env "
+                          "(gitignored, loaded per project) or the environment"}
+    return {**common, "available": True, "reason": ""}
+
+
+def _alive(backend: str, *, timeout: float = 1.5) -> dict:
+    """One short GET against a local backend's health endpoint.
+
+    Short on purpose: a caller polling status() must not block for a TCP
+    timeout on a server nobody started, which is the common case.
+    """
+    spec = BACKENDS.get(backend) or {}
+    path = spec.get("health_path")
+    if not path:
+        return {"ok": False, "reason": "this backend declares no health endpoint"}
+    url = base_url(backend) + path
+    try:
+        req = urllib.request.Request(url, method="GET",
+                                     headers={"Accept": "*/*"})
+        with urllib.request.urlopen(req, timeout=timeout):
+            return {"ok": True, "reason": ""}
+    except Exception as exc:                                     # noqa: BLE001
+        reason = getattr(exc, "reason", None) or exc
+        return {"ok": False,
+                "reason": f"nothing answered at {url} ({reason}) — start the "
+                          f"server, or point "
+                          f"{spec.get('base_env') or 'the base URL'} at it"}
+
+
+def status(root: Any = None, *, probe: bool = False) -> dict:
+    """Every backend, usable or not, and why. The nothing-configured answer.
+
+    Shaped for the job blender_status and image_status do: a caller with nothing
+    set up gets a complete, actionable picture rather than an exception. ``ok``
+    is False when nothing is usable, which is a fact and not an error — every
+    other path in this product still works.
+    """
+    rows = [available(name, root, probe=probe) for name in sorted(BACKENDS)]
+    usable = [r["backend"] for r in rows if r["available"]]
+    return {
+        "ok": bool(usable),
+        "gpu": gpu(),
+        "runner_python": runner_python(),
+        "backends": rows,
+        "usable": usable,
+        "local": [r["backend"] for r in rows
+                  if r["available"] and r["kind"] == "local"],
+        "hosted": [r["backend"] for r in rows
+                   if r["available"] and r["kind"] == "hosted"],
+        # The distinction that decides whether an asset can ship: reachable is
+        # not the same as clear to use.
+        "unconditional_licence": [r["backend"] for r in rows
+                                  if r["available"]
+                                  and r["licence"]["code"] in AUTO_LICENCES],
+        "default": DEFAULT_BACKEND,
+        "reason": "" if usable else (
+            "no image-to-3D backend is usable. Locally, that means no NVIDIA "
+            "GPU or no server running (see BGATE_COMFY_URL / "
+            "BGATE_HUNYUAN3D_URL); for the hosted fallback, set one of "
+            + ", ".join(sorted(s["env"] for s in BACKENDS.values()
+                               if s.get("env")))
+            + " in the project's .env. Nothing else in Builders Gate is "
+              "affected by this."),
+    }
+
+
+def choose(root: Any = None, *, prefer: str = "local",
+           probe: bool = True) -> dict:
+    """Pick a backend, or explain why nothing can be picked.
+
+    LOCAL FIRST, and only ever an UNCONDITIONALLY-LICENSED backend
+    automatically. A conditional licence — region-restricted, revenue-capped,
+    paid-plan-only — has to be named by a human who has read the condition,
+    because this tool does not know its user's revenue, territory or monthly
+    actives and must not decide that for them.
+
+    Returns {backend, reason, candidates}. ``backend`` is "" when the only
+    reachable options are conditional, and ``candidates`` then names them so the
+    caller can offer the choice rather than silently making it.
+    """
+    rows = [available(name, root, probe=probe) for name in sorted(BACKENDS)]
+    live = [r for r in rows if r["available"]]
+    order = (LOCAL, HOSTED) if prefer == "local" else (HOSTED, LOCAL)
+    ranked = [r for group in order for name in group
+              for r in live if r["backend"] == name]
+    clear = [r for r in ranked if r["licence"]["code"] in AUTO_LICENCES]
+    if clear:
+        return {"backend": clear[0]["backend"], "reason": "",
+                "candidates": [r["backend"] for r in ranked]}
+    if ranked:
+        return {
+            "backend": "", "candidates": [r["backend"] for r in ranked],
+            "reason": "every reachable backend has a conditional licence, so "
+                      "none can be chosen automatically. Name one deliberately "
+                      "after reading its terms: "
+                      + "; ".join(f"{r['backend']} — {r['licence']['summary']}"
+                                  for r in ranked)}
+    return {"backend": "", "candidates": [],
+            "reason": status(root, probe=probe)["reason"]}
+
+
+def supports(backend: str, feature: str) -> bool:
+    """Does this backend do `feature` at all?
+
+    Worth asking BEFORE quoting: "generate it rigged" on a backend with no
+    rigging is not a dearer version of the request, it is not the request.
+    """
+    return feature in ((BACKENDS.get(backend) or {}).get("supports") or set())
+
+
+def capabilities(backend: str) -> dict:
+    """Everything needed to decide whether this backend fits the job."""
+    spec = _spec(backend)
+    return {
+        "backend": backend, "kind": spec["kind"], "label": spec["label"],
+        "supports": sorted(spec.get("supports") or ()),
+        "formats": list(spec.get("formats") or ()),
+        "rigged": spec.get("rigged") or False,
+        "async": bool(spec.get("poll_path")),
+        "latency_s": list(spec.get("latency_s") or ()),
+        "vram_gb": spec.get("vram_gb"),
+        "windows": spec.get("windows", ""),
+        "weights": spec.get("weights", ""),
+        "licence": dict(spec["licence"]),
+        "implemented": spec.get("implemented", True),
+        "note": spec.get("note", ""),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Money
+# ---------------------------------------------------------------------------
+def credits_for(backend: str, *, texture: bool = True, quad: bool = False,
+                detailed_texture: bool = False, rig: bool = False,
+                animations: int = 0) -> Optional[float]:
+    """The request's cost in the BACKEND'S OWN unit, or None if it has none.
+
+    Priced in credits first and converted once, because that is the unit both
+    hosted backends actually publish and the only form in which the arithmetic
+    can be checked against their tables. A local backend has no credits and
+    returns None — which is not "unknown", it is "not billed"; price_for says
+    0.0 for those.
+    """
+    spec = _spec(backend)
+    table = spec.get("credits")
+    if not table:
+        return None
+    total = float(table.get("base", 0.0))
+    if not texture and "untextured" in table:
+        total = float(table["untextured"])
+    if quad:
+        total += float(table.get("quad", 0.0))
+    if detailed_texture:
+        total += float(table.get("detailed_texture", 0.0))
+    if rig:
+        total += float(table.get("rig", 0.0))
+    if animations:
+        total += float(table.get("retarget", table.get("animation", 0.0))) * int(animations)
+    return round(total, 4)
+
+
+def price_for(backend: str, *, texture: bool = True, quad: bool = False,
+              detailed_texture: bool = False, rig: bool = False,
+              animations: int = 0, count: int = 1) -> Optional[float]:
+    """What THIS REQUEST costs in dollars, or None when nobody published a rate.
+
+    Three distinct answers, and the difference between the last two matters:
+
+      0.0   a local backend. Your own electricity, and the honest number.
+      float a hosted backend with a PUBLISHED credit rate.
+      None  a hosted backend whose rate is not published. NOT 0.0 and not a
+            guess — the spend gate treats a number as permission, so an
+            invented one is worse than a missing one (krea.TRAIN_USD settled
+            this). A caller that gets None must ask the human.
+    """
+    spec = _spec(backend)
+    if spec["kind"] == "local":
+        return 0.0
+    credits = credits_for(backend, texture=texture, quad=quad,
+                          detailed_texture=detailed_texture, rig=rig,
+                          animations=animations)
+    rate = spec.get("usd_per_credit")
+    if credits is None or rate is None:
+        return None
+    return round(float(credits) * float(rate) * max(1, int(count)), 4)
+
+
+def price_note(backend: str) -> str:
+    """Why a price is missing, when it is. Empty when there is a real price."""
+    spec = _spec(backend)
+    if spec["kind"] == "local":
+        return ""
+    return spec.get("usd_per_credit_note", "") if spec.get("usd_per_credit") is None else ""
+
+
+# ---------------------------------------------------------------------------
+# The input plate
+# ---------------------------------------------------------------------------
+def check_input(path: str | os.PathLike[str]) -> dict:
+    """Judge the source image BEFORE generating anything.
+
+    Cheap, local, and worth doing because the plate is the single biggest
+    determinant of output quality and every failure is visible from here.
+    Returns {ok, reason, warnings, ...} rather than raising, so a caller can
+    show a human what is wrong with their reference and let them decide.
+
+    Pillow is optional. Without it the size checks cannot run, and that is
+    REPORTED rather than assumed to pass — the contract krea.check_training_set
+    already uses.
+    """
+    p = Path(path)
+    warnings: list[str] = []
+    if not p.is_file():
+        return {"ok": False, "path": str(p), "reason": f"no such image: {p}",
+                "warnings": warnings}
+    if p.suffix.lower() not in INPUT_SUFFIXES:
+        return {"ok": False, "path": str(p), "warnings": warnings,
+                "reason": f"unsupported input type {p.suffix!r} — "
+                          + "/".join(sorted(s.lstrip(".") for s in INPUT_SUFFIXES))
+                          + " only"}
+    try:
+        from PIL import Image                    # noqa: PLC0415 — optional
+    except ImportError:
+        warnings.append("Pillow is not installed, so the image was NOT measured "
+                        f"— a plate under {INPUT_MIN_SIDE}px carries nothing to "
+                        "reconstruct from")
+        return {"ok": True, "path": str(p), "reason": "", "warnings": warnings}
+    try:
+        with Image.open(p) as img:
+            w, h = img.size
+            bands = img.getbands()
+    except Exception as exc:                                     # noqa: BLE001
+        return {"ok": False, "path": str(p), "warnings": warnings,
+                "reason": f"unreadable image ({type(exc).__name__}: {exc})"}
+    short = min(w, h)
+    if short < INPUT_MIN_SIDE:
+        return {"ok": False, "path": str(p), "size": [w, h], "warnings": warnings,
+                "reason": f"{w}x{h} — under {INPUT_MIN_SIDE}px there is nothing "
+                          "for the model to read, and it invents the whole "
+                          "subject rather than reconstructing it"}
+    if short < INPUT_GOOD_SIDE:
+        warnings.append(f"{w}x{h} is under {INPUT_GOOD_SIDE}px on the short "
+                        "side — detail in the result is invented, not read")
+    if "A" not in bands:
+        # Not fatal anywhere, but it is the failure that produces geometry made
+        # of background. bgate_core.chroma already produces the keyed plate for
+        # the sprite path, and it is the right input here for the same reason.
+        warnings.append("the plate has no alpha channel — background pixels "
+                        "become geometry on several backends. Key it out first "
+                        "(bgate_core.chroma) or expect loose parts")
+    return {"ok": True, "path": str(p), "size": [w, h], "reason": "",
+            "warnings": warnings}
+
+
+def data_uri(path: str | os.PathLike[str]) -> str:
+    """A local plate as a base64 data URI."""
+    p = Path(path)
+    if not p.is_file():
+        raise ImageTo3DError(f"input image not found: {p}")
+    mime = mimetypes.guess_type(p.name)[0]
+    if not mime or not mime.startswith("image/"):
+        raise ImageTo3DError(f"unsupported input type {p.suffix!r} — png/jpg/webp only")
+    return f"data:{mime};base64," + base64.b64encode(p.read_bytes()).decode("ascii")
+
+
+def image_b64(path: str | os.PathLike[str]) -> str:
+    """The plate as BARE base64, no data-URI prefix.
+
+    Both spellings exist in the wild and they are not interchangeable: sending a
+    data URI where bare base64 is expected is a decode error on the server,
+    which surfaces as a useless 500. Hunyuan3D's api_server wants this one;
+    Meshy wants the other.
+    """
+    p = Path(path)
+    if not p.is_file():
+        raise ImageTo3DError(f"input image not found: {p}")
+    return base64.b64encode(p.read_bytes()).decode("ascii")
+
+
+# ---------------------------------------------------------------------------
+# Transport
+# ---------------------------------------------------------------------------
+def _headers(backend: str, key: str) -> dict:
+    spec = BACKENDS.get(backend) or {}
+    headers = {"Content-Type": "application/json", "Accept": "application/json"}
+    if spec.get("auth") == "bearer" and key:
+        headers["Authorization"] = f"Bearer {key}"
+    return headers
+
+
+def _http_error(backend: str, exc: urllib.error.HTTPError, method: str,
+                path: str) -> ImageTo3DError:
+    """One message per failure mode, naming the FIX rather than the status code.
+
+    An agent that reads "HTTP 402" retries. An agent that reads where the
+    balance lives does something useful.
+    """
+    spec = BACKENDS.get(backend) or {}
+    label = spec.get("label", backend)
+    detail = ""
+    try:
+        detail = exc.read().decode("utf-8", "replace")[:400]
+    except Exception:                                            # noqa: BLE001
+        pass
+    if exc.code in (401, 403):
+        return ImageTo3DError(
+            f"{label} rejected the API key (HTTP {exc.code}) — check "
+            f"{spec.get('env') or 'the credentials'} in the project's .env")
+    if exc.code == 402:
+        return ImageTo3DError(
+            f"{label} has no credit for this request (HTTP 402) — top up the "
+            "account's API balance and retry; nothing was charged.")
+    if exc.code == 429:
+        return ImageTo3DError(
+            f"{label} rate-limited this request (HTTP 429) — slow the fan-out "
+            "or retry in a moment.")
+    if exc.code in (400, 422):
+        return ImageTo3DError(
+            f"{label} refused the request shape: {detail} (each backend has "
+            "its own schema — see BACKENDS[...]['supports'])")
+    if exc.code == 404 and spec.get("kind") == "local":
+        return ImageTo3DError(
+            f"{label} answered 404 on {method} {path} — something IS running at "
+            f"{base_url(backend)}, but it is not the server this backend "
+            "expects. Check the port.")
+    return ImageTo3DError(f"{label} HTTP {exc.code} on {method} {path}: {detail}")
+
+
+def _url_error(backend: str, exc: Exception) -> ImageTo3DError:
+    """Unreachable. For a local backend the useful message is a completely
+    different one: there is no key to check, there is a process to start."""
+    spec = BACKENDS.get(backend) or {}
+    label = spec.get("label", backend)
+    reason = getattr(exc, "reason", None) or exc
+    if spec.get("kind") == "local":
+        return ImageTo3DError(
+            f"could not reach {label} at {base_url(backend)} ({reason}) — is "
+            f"the server running? Point {spec.get('base_env') or 'the base URL'} "
+            "at it if it is on another host or port.")
+    return ImageTo3DError(f"could not reach {label} ({reason})")
+
+
+def _request(backend: str, path: str, key: str = "", *,
+             payload: Optional[dict] = None, method: str = "GET",
+             timeout: float = 60.0) -> dict:
+    url = path if path.startswith("http") else base_url(backend) + path
+    body = json.dumps(payload).encode("utf-8") if payload is not None else None
+    req = urllib.request.Request(url, data=body, method=method,
+                                 headers=_headers(backend, key))
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read().decode("utf-8", "replace") or "{}"
+    except urllib.error.HTTPError as exc:
+        raise _http_error(backend, exc, method, path) from exc
+    except urllib.error.URLError as exc:
+        raise _url_error(backend, exc) from exc
+    try:
+        return json.loads(raw)
+    except ValueError as exc:
+        raise ImageTo3DError(
+            f"{backend} returned a non-JSON response: {raw[:200]}") from exc
+
+
+def _multipart(fields: dict, filename: str, blob: bytes,
+               field: str = "file") -> tuple[bytes, str]:
+    """A multipart/form-data body, stdlib only.
+
+    Same reasoning as krea._multipart: two endpoints here are not JSON, and
+    pulling in `requests` for them would put a dependency on the critical path
+    of a module whose whole HTTP surface is otherwise a handful of urllib calls.
+    """
+    boundary = "----bgate" + base64.urlsafe_b64encode(os.urandom(9)).decode()
+    out = bytearray()
+    for name, value in (fields or {}).items():
+        if value is None:
+            continue
+        out += f"--{boundary}\r\n".encode()
+        out += f'Content-Disposition: form-data; name="{name}"\r\n\r\n'.encode()
+        out += f"{value}\r\n".encode()
+    mime = mimetypes.guess_type(filename)[0] or "application/octet-stream"
+    out += f"--{boundary}\r\n".encode()
+    out += (f'Content-Disposition: form-data; name="{field}"; '
+            f'filename="{filename}"\r\n').encode()
+    out += f"Content-Type: {mime}\r\n\r\n".encode()
+    out += blob + b"\r\n"
+    out += f"--{boundary}--\r\n".encode()
+    return bytes(out), f"multipart/form-data; boundary={boundary}"
+
+
+def _dig(blob: Any, dotted: str) -> Any:
+    """Read a dotted path out of a response. Every backend nests differently and
+    every one of them nests; this is one line instead of a branch each."""
+    node = blob
+    for part in str(dotted).split("."):
+        if isinstance(node, dict):
+            node = node.get(part)
+        elif isinstance(node, list) and part.isdigit():
+            node = node[int(part)] if int(part) < len(node) else None
+        else:
+            return None
+        if node is None:
+            return None
+    return node
+
+
+# ---------------------------------------------------------------------------
+# The request
+# ---------------------------------------------------------------------------
+# THE BACKENDS AGREE ON NOTHING. One wants `texture`, another `should_texture`;
+# one takes a bare base64 string, one a data URI, one a token from a separate
+# upload, one the raw bytes as multipart; the polycount is `face_count`,
+# `face_limit`, `target_polycount` or `vertex_count` depending on who you ask.
+# krea.py learned this the expensive way — aspect_ratio sent to flux was a 422
+# on the first live call — and landed on the right fix: no shared payload shape,
+# each backend built for what it actually accepts.
+#
+# Table-driven rather than a builder per backend, because the differences are
+# all naming and nesting. `fields` renames, `static` is always sent, `quirks`
+# handles the two places where a rename is not enough.
+def build_payload(backend: str, *, image: str = "", image_token: str = "",
+                  texture: bool = True, pbr: bool = False, quad: bool = False,
+                  face_count: Optional[int] = None, seed: Optional[int] = None,
+                  steps: Optional[int] = None, guidance: Optional[float] = None,
+                  octree_resolution: Optional[int] = None,
+                  pose: str = "", model: str = "", orientation: str = "",
+                  texture_resolution: Optional[int] = None,
+                  foreground_ratio: Optional[float] = None,
+                  out_format: str = DEFAULT_FORMAT) -> dict:
+    """The request body this backend actually accepts.
+
+    Separated from :func:`submit` so it can be tested and inspected without a
+    network — the payload is the part that broke first for Krea, and the part a
+    caller most wants to see before committing to a run.
+
+    Every option is checked against ``supports`` and refused HERE, naming the
+    backends that do offer it. An unsupported option silently dropped is how
+    "generate it in a T-pose" produces an A-pose and a green result.
+    """
+    spec = _spec(backend)
+    if spec.get("image_mode") == "multipart":
+        raise ImageTo3DError(
+            f"{spec['label']} sends the image as multipart form data, not JSON "
+            "— build_payload does not apply; submit() handles it")
+
+    asked = {"texture": texture, "pbr": pbr, "quad": quad,
+             "face_count": face_count, "seed": seed, "steps": steps,
+             "guidance": guidance, "octree_resolution": octree_resolution,
+             "pose": pose, "orientation": orientation,
+             "texture_resolution": texture_resolution,
+             "foreground_ratio": foreground_ratio}
+    for name, value in asked.items():
+        # Falsy means "not asked for"; only a positive ask can be unsupported.
+        # texture defaults True, so a backend that always textures need not
+        # list it.
+        if not value or name == "texture" or supports(backend, name):
+            continue
+        others = sorted(k for k, v in BACKENDS.items()
+                        if name in (v.get("supports") or set()))
+        raise ImageTo3DError(
+            f"{spec['label']} does not offer {name!r}"
+            + (f" — the backends that do are {', '.join(others)}" if others
+               else " — no backend here does"))
+
+    formats = spec.get("formats") or (DEFAULT_FORMAT,)
+    if out_format not in formats:
+        raise ImageTo3DError(
+            f"{spec['label']} does not return {out_format!r} — it returns "
+            + ", ".join(formats))
+
+    payload: dict[str, Any] = dict(spec.get("static") or {})
+    fields = spec.get("fields") or {}
+    mode = spec.get("image_mode", "field")
+
+    if mode == "field":
+        if not image:
+            raise ImageTo3DError("no input image — pass the plate's base64, "
+                                 "data URI or URL")
+        payload[fields.get("image", "image")] = image
+    elif mode == "file_token":
+        # An upload endpoint hands back a token and the task references it
+        # under a nested object. Sending bytes inline here is a 400.
+        if not image_token:
+            raise ImageTo3DError(
+                f"{spec['label']} takes an uploaded file token, not inline "
+                "bytes — call upload() first and pass image_token")
+        payload[fields.get("file", "file")] = {
+            "type": spec.get("file_type", "png"), "file_token": image_token}
+    elif mode == "workflow":
+        raise ImageTo3DError(
+            f"{spec['label']} takes a whole workflow graph as its body — "
+            "build_comfy_prompt() builds it, not this")
+    else:                                                        # pragma: no cover
+        raise ImageTo3DError(f"unknown image mode {mode!r} for {backend}")
+
+    def put(name: str, value: Any) -> None:
+        key = fields.get(name)
+        if key and value is not None:
+            payload[key] = value
+
+    put("texture", bool(texture))
+    if pbr:
+        put("pbr", True)
+    if quad:
+        put("quad", True)
+    for name, value in (("face_count", face_count), ("seed", seed),
+                        ("steps", steps), ("octree_resolution", octree_resolution),
+                        ("texture_resolution", texture_resolution)):
+        if value is not None:
+            put(name, int(value))
+    for name, value in (("guidance", guidance),
+                        ("foreground_ratio", foreground_ratio)):
+        if value is not None:
+            put(name, float(value))
+    for name, value in (("pose", pose), ("orientation", orientation)):
+        if value:
+            put(name, value)
+    put("model", model or spec.get("default_model"))
+
+    quirk = spec.get("quirks")
+    if quirk == "meshy":
+        _quirks_meshy(payload, quad=quad, face_count=face_count)
+    return payload
+
+
+def _quirks_meshy(payload: dict, *, quad: bool, face_count: Optional[int]) -> None:
+    """Two Meshy traps that a rename cannot fix.
+
+    `topology` is an ENUM ("quad" | "triangle"), not the boolean every other
+    backend uses — so the generic `quad: True` would have written a bool into a
+    string field.
+
+    And `should_remesh` defaults to FALSE on meshy-6, which means `topology` and
+    `target_polycount` are both SILENTLY IGNORED unless it is switched on. A
+    request that quietly does none of what was asked is exactly the failure this
+    module exists not to have, so asking for either turns it on.
+    """
+    if quad:
+        payload["topology"] = "quad"
+        payload.pop("quad", None)
+    if quad or face_count is not None:
+        payload["should_remesh"] = True
+
+
+def upload(backend: str, path: str | os.PathLike[str], *, root: Any = None,
+           timeout: float = 120.0) -> dict:
+    """Put the plate on the backend's store. Returns {token, name, subfolder}.
+
+    Uploading is not generating: nothing is charged and nothing is computed
+    until submit() is called with what this hands back.
+    """
+    spec = _spec(backend)
+    endpoint = spec.get("upload_path")
+    if not endpoint:
+        raise ImageTo3DError(
+            f"{spec['label']} takes the image inline — there is nothing to "
+            "upload")
+    p = Path(path)
+    if not p.is_file():
+        raise ImageTo3DError(f"input image not found: {p}")
+    key = api_key(backend, root)
+    body, content_type = _multipart({}, p.name, p.read_bytes(),
+                                    field=spec.get("upload_field", "file"))
+    headers = {"Accept": "application/json", "Content-Type": content_type}
+    if spec.get("auth") == "bearer" and key:
+        headers["Authorization"] = f"Bearer {key}"
+    req = urllib.request.Request(base_url(backend) + endpoint, data=body,
+                                 method="POST", headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            got = json.loads(resp.read().decode("utf-8") or "{}")
+    except urllib.error.HTTPError as exc:
+        raise _http_error(backend, exc, "POST", endpoint) from exc
+    except urllib.error.URLError as exc:
+        raise _url_error(backend, exc) from exc
+    token = _dig(got, spec.get("upload_token_key", "")) if spec.get(
+        "upload_token_key") else ""
+    # ComfyUI answers {name, subfolder, type} and the workflow references the
+    # NAME; Tripo answers a token. Both come back here so the caller does not
+    # have to know which.
+    return {"token": str(token or ""), "name": str(got.get("name") or ""),
+            "subfolder": str(got.get("subfolder") or ""),
+            "raw": got}
+
+
+# ---------------------------------------------------------------------------
+# ComfyUI: the workflow is config, not code
+# ---------------------------------------------------------------------------
+# ComfyUI's request body is a whole graph, and that graph names node CLASSES
+# whose spelling changes with every ComfyUI-3D-Pack release. Hardcoding one here
+# would make this adapter break on somebody else's upgrade, and would encode a
+# choice of model — and therefore of LICENCE — that is not this module's to
+# make.
+#
+# So the workflow is the user's: an API-format JSON exported from their own
+# ComfyUI ("Save (API format)"), with two placeholders substituted here. That is
+# not a shortcut. A workflow graph genuinely IS a per-installation artefact, and
+# treating it as configuration is the correct model rather than a concession.
+COMFY_IMAGE_TOKEN = "__BGATE_IMAGE__"
+COMFY_SEED_TOKEN = "__BGATE_SEED__"
+
+
+def comfy_workflow_path() -> str:
+    return (os.environ.get(BACKENDS["comfy"]["workflow_env"]) or "").strip()
+
+
+def build_comfy_prompt(image_name: str, *, seed: Optional[int] = None,
+                       workflow_path: str = "") -> dict:
+    """The /prompt body: the user's graph with the plate and seed substituted.
+
+    Raises with the whole setup instruction rather than a KeyError, because the
+    thing that is missing is a file the user has to export from an application,
+    and "no such file" would send them looking in the wrong place.
+    """
+    path = workflow_path or comfy_workflow_path()
+    if not path:
+        raise ImageTo3DError(
+            "no ComfyUI workflow configured — export one from ComfyUI with "
+            "'Save (API format)', put "
+            f"{COMFY_IMAGE_TOKEN!r} where the LoadImage node names its file "
+            f"and optionally {COMFY_SEED_TOKEN!r} where the seed goes, then "
+            f"point {BACKENDS['comfy']['workflow_env']} at it")
+    p = Path(path)
+    if not p.is_file():
+        raise ImageTo3DError(f"the configured ComfyUI workflow does not exist: {p}")
+    try:
+        raw = p.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ImageTo3DError(f"could not read the ComfyUI workflow at {p}: {exc}") from exc
+    if COMFY_IMAGE_TOKEN not in raw:
+        raise ImageTo3DError(
+            f"the workflow at {p} has no {COMFY_IMAGE_TOKEN} placeholder, so "
+            "there is nowhere to put the input image — it would generate from "
+            "whatever was baked into the graph, every time")
+    raw = raw.replace(COMFY_IMAGE_TOKEN, json.dumps(str(image_name))[1:-1])
+    raw = raw.replace(COMFY_SEED_TOKEN, str(int(seed)) if seed is not None
+                      else str(int(time.time()) % 2_147_483_647))
+    try:
+        graph = json.loads(raw)
+    except ValueError as exc:
+        raise ImageTo3DError(
+            f"the ComfyUI workflow at {p} is not valid JSON after "
+            f"substitution: {exc}. It must be the API format, not the editor "
+            "format.") from exc
+    # The editor format has a top-level "nodes" list; the API format is a flat
+    # map of id -> {class_type, inputs}. Telling them apart here saves a
+    # baffling 400 from ComfyUI.
+    if isinstance(graph, dict) and "nodes" in graph and "class_type" not in str(
+            next(iter(graph.values()), "")):
+        raise ImageTo3DError(
+            f"the workflow at {p} looks like the EDITOR format (it has a "
+            "top-level 'nodes' list). ComfyUI's /prompt endpoint needs the API "
+            "format — re-export with 'Save (API format)'.")
+    return {"prompt": graph, "client_id": "builders-gate"}
+
+
+def _comfy_outputs(history: dict, task: str) -> list[dict]:
+    """Every file this run wrote that the pipeline could use.
+
+    SCANNED, not looked up by node id or class name. 3D-Pack's saver nodes are
+    renamed between releases and differ per model, so keying on one would break
+    on an upgrade of somebody else's plugin. Scanning for a usable suffix is
+    stable against all of that.
+    """
+    run = (history or {}).get(task) or {}
+    found: list[dict] = []
+    for node_id, out in (run.get("outputs") or {}).items():
+        if not isinstance(out, dict):
+            continue
+        for entries in out.values():
+            if not isinstance(entries, list):
+                continue
+            for entry in entries:
+                if not isinstance(entry, dict):
+                    continue
+                name = str(entry.get("filename") or "")
+                if name.lower().rsplit(".", 1)[-1] in USABLE_FORMATS:
+                    found.append({"node": node_id, "filename": name,
+                                  "subfolder": str(entry.get("subfolder") or ""),
+                                  "type": str(entry.get("type") or "output")})
+    return found
+
+
+# ---------------------------------------------------------------------------
+# Job lifecycle
+# ---------------------------------------------------------------------------
+# THREE SHAPES, and pretending they are one would be the mistake:
+#
+#   json-job   POST a JSON body, get a task id, poll, download a URL or decode
+#              an inline base64 blob. hunyuan-local, tripo, meshy.
+#   sync       POST multipart, the RESPONSE BODY IS THE MODEL. stability. No
+#              task, no poll, nothing to expire.
+#   comfy      upload the plate, POST a graph, poll /history, fetch /view.
+#
+# generate() is the one call worth using; the pieces are exported because a
+# caller that wants to quote, submit and walk away needs them — with the
+# five-minute-URL caveat on tripo firmly in mind.
+def submit(backend: str, image_path: str | os.PathLike[str], *,
+           root: Any = None, timeout: float = 120.0, **options) -> dict:
+    """Start a generation. Returns {task, backend, payload}.
+
+    Raises before anything is sent if the plate is unusable, the backend does
+    not offer an option that was asked for, or the backend is not wired.
+    """
+    spec = _spec(backend)
+    if not spec.get("implemented", True):
+        raise ImageTo3DError(
+            f"{spec['label']} is documented here as an alternative but its "
+            f"transport is not wired: {spec.get('note', '')}")
+    verdict = check_input(image_path)
+    if not verdict["ok"]:
+        raise ImageTo3DError(verdict["reason"])
+    key = api_key(backend, root)
+    if spec.get("env") and not key:
+        raise ImageTo3DError(available(backend, root)["reason"])
+
+    mode = spec.get("image_mode", "field")
+    if mode == "workflow":
+        put = upload(backend, image_path, root=root, timeout=timeout)
+        body = build_comfy_prompt(put["name"] or Path(image_path).name,
+                                  seed=options.get("seed"))
+        got = _request(backend, spec["submit_path"], key, payload=body,
+                       method="POST", timeout=timeout)
+        task = str(_dig(got, spec["task_key"]) or "")
+        if not task:
+            raise ImageTo3DError(
+                f"ComfyUI accepted nothing back: {str(got)[:200]}")
+        return {"task": task, "backend": backend, "payload": body}
+
+    if mode == "file_token":
+        put = upload(backend, image_path, root=root, timeout=timeout)
+        options["image_token"] = put["token"]
+    elif mode == "field":
+        # Bare base64 or a data URI, and they are NOT interchangeable — see
+        # image_b64. Hunyuan's server decodes bare; Meshy wants the URI.
+        options.setdefault(
+            "image",
+            image_b64(image_path) if spec["kind"] == "local"
+            else data_uri(image_path))
+
+    payload = build_payload(backend, **options)
+    got = _request(backend, spec["submit_path"], key, payload=payload,
+                   method="POST", timeout=timeout)
+    task = str(_dig(got, spec.get("task_key", "")) or "")
+    if not task:
+        raise ImageTo3DError(
+            f"{spec['label']} returned no task id: {str(got)[:200]}")
+    return {"task": task, "backend": backend, "payload": payload, "raw": got}
+
+
+def poll(backend: str, task: str, *, root: Any = None, timeout: float = 900.0,
+         interval: float = 3.0) -> dict:
+    """Wait for a job to reach a terminal state. Returns the final envelope.
+
+    Bounded on purpose: a job that never finishes must fail the caller rather
+    than hold a seat's agent forever. Backs off gently so a slow local model
+    does not turn into a poll storm on a machine that is busy generating.
+
+    The default is fifteen minutes because a local textured generation on a
+    consumer card is minutes, not seconds — a hosted-API timeout would abandon a
+    perfectly healthy local run.
+    """
+    spec = _spec(backend)
+    key = api_key(backend, root)
+    path = spec.get("poll_path")
+    if not path:
+        raise ImageTo3DError(f"{spec['label']} is synchronous — there is no "
+                             "job to poll")
+    deadline = time.monotonic() + max(10.0, float(timeout))
+    wait = max(0.5, float(interval))
+    last: dict = {}
+    while time.monotonic() < deadline:
+        last = _request(backend, path.format(task=task), key, timeout=60.0)
+        if backend == "comfy":
+            # ComfyUI has no status field: /history is EMPTY until the run is
+            # done and populated afterwards. Treating a missing key as "not
+            # finished" is the whole protocol.
+            if last.get(task):
+                return last
+        else:
+            state = str(_dig(last, spec.get("status_key", "status")) or "")
+            if state in (spec.get("done") or ()):
+                return last
+            if state in (spec.get("dead") or ()):
+                raise ImageTo3DError(
+                    f"{spec['label']} job {state}: "
+                    + str(last.get("error") or last.get("message")
+                          or "no reason given")[:300])
+            if state and state not in (spec.get("running") or ()):
+                # An unknown state is not an excuse to spin — say so and stop.
+                raise ImageTo3DError(
+                    f"{spec['label']} returned unknown status {state!r}")
+        time.sleep(wait)
+        wait = min(8.0, wait * 1.2)
+    raise ImageTo3DError(
+        f"{spec['label']} job {task} did not finish within {timeout:.0f}s")
+
+
+def download(url: str, out_path: str | os.PathLike[str], *,
+             timeout: float = 300.0) -> int:
+    """Fetch a finished model to disk. Returns bytes written."""
+    out = Path(out_path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    req = urllib.request.Request(url, headers={"Accept": "*/*"})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            data = resp.read()
+    except Exception as exc:                                     # noqa: BLE001
+        raise ImageTo3DError(f"could not download the finished model: {exc}") from exc
+    if not data:
+        raise ImageTo3DError("the download was empty")
+    out.write_bytes(data)
+    return len(data)
+
+
+def _write_b64(blob: str, out_path: str | os.PathLike[str]) -> int:
+    """A model that came back INLINE rather than as a URL — Hunyuan's server
+    does this, and a caller expecting a URL would find none."""
+    out = Path(out_path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        data = base64.b64decode(blob)
+    except Exception as exc:                                     # noqa: BLE001
+        raise ImageTo3DError(f"the returned model was not valid base64: {exc}") from exc
+    if not data:
+        raise ImageTo3DError("the returned model was empty")
+    out.write_bytes(data)
+    return len(data)
+
+
+def _result(backend: str, **fields) -> dict:
+    """Every return from generate() in one shape, success or failure.
+
+    Deliberately close to blender.combine()'s: {ok, checks, warnings, notes}
+    plus the file, so a caller downstream does not branch on where the geometry
+    came from. `stage` is the extra one — a generation can fail at four
+    distinguishable points and "it failed" is not actionable.
+    """
+    spec = BACKENDS.get(backend) or {}
+    base = {
+        "ok": False, "path": "", "bytes": 0,
+        "backend": backend, "kind": spec.get("kind", ""),
+        "label": spec.get("label", backend),
+        "task": "", "seconds": 0.0, "estimated_usd": None,
+        "format": DEFAULT_FORMAT,
+        # WHAT THE MESH IS, which is what the conditioning steps need to know.
+        # `draft=True` is not decoration: nothing downstream may treat this as
+        # a finished asset.
+        "draft": True, "textured": False, "rigged": False,
+        "licence": dict(spec.get("licence") or {}),
+        "source_image": "", "stage": "",
+        "checks": [], "warnings": [], "notes": [],
+    }
+    base.update(fields)
+    return base
+
+
+# What every generated mesh needs before anything downstream may trust it. Put
+# on the result rather than in a docstring, because the caller acting on it is
+# an agent that will not have read the docstring.
+NEXT_STEPS = (
+    "orient it — nothing here knows which way it faces, and the pipeline's "
+    "convention is +Y in Blender; check with blender_turnaround and a human eye",
+    "scale it to convention — bg_rescale(obj, height=1.8) also drops it to the "
+    "ground",
+    "clean and decimate — bg_clean(obj), then bring the triangle count down "
+    "before weighting, never after",
+    "weight it to the canonical skeleton — bg_human_skeleton, then the GROW "
+    "repair path (bgate_rig_repair), because a generated mesh has no rest-pose "
+    "record to restore from",
+    "assemble with blender_combine and deliver with godot.deliver_asset — the "
+    "existing gates apply unchanged",
+)
+
+
+def generate(image_path: str | os.PathLike[str],
+             out_path: str | os.PathLike[str], *, backend: str = "",
+             root: Any = None, timeout: float = 900.0,
+             logical_name: str = "", work_item_id: Optional[int] = None,
+             **options) -> dict:
+    """Plate in, DRAFT MESH out. The whole dance as one call.
+
+    Returns the shape above; never raises for an expected failure, the way
+    krea.generate does not — a failed generation is a result with ok=False and a
+    stage, because the caller is usually an agent that has to report rather than
+    crash.
+
+    ``backend=""`` asks choose() — local first, and only an unconditionally
+    licensed backend automatically. If every reachable backend is conditional
+    this REFUSES and names them, rather than picking one on the user's behalf.
+
+    The download happens inside this call by construction. That is not laziness:
+    one hosted backend expires its result URL after five minutes, so a design
+    that hands a URL back to be fetched later works in testing and fails in
+    production.
+    """
+    started = time.monotonic()
+    if not backend:
+        picked = choose(root)
+        if not picked["backend"]:
+            return _result("", stage="choose", error=picked["reason"],
+                           notes=list(picked["candidates"]),
+                           seconds=round(time.monotonic() - started, 2))
+        backend = picked["backend"]
+    try:
+        spec = _spec(backend)
+    except ImageTo3DError as exc:
+        return _result(backend, stage="backend", error=str(exc))
+
+    # QUOTE FIRST, BEFORE THE PLATE IS EVEN LOOKED AT. Pricing does not need the
+    # image, and a caller asking "what would this cost" must get an answer even
+    # when the run is going to be refused — otherwise the only way to learn the
+    # price is to have everything else already correct.
+    out = _result(backend, source_image=str(image_path),
+                  estimated_usd=price_for(
+                      backend, texture=bool(options.get("texture", True)),
+                      quad=bool(options.get("quad"))),
+                  format=str(options.get("out_format", DEFAULT_FORMAT)))
+    note = price_note(backend)
+    if note:
+        out["warnings"].append(note)
+
+    verdict = check_input(image_path)
+    out["warnings"] += list(verdict["warnings"])
+    if not verdict["ok"]:
+        out["stage"] = "input"
+        out["error"] = verdict["reason"]
+        out["seconds"] = round(time.monotonic() - started, 2)
+        return out
+
+    try:
+        if spec.get("response") == "binary":
+            written, task = _run_sync(backend, image_path, out_path, root=root,
+                                      timeout=timeout, options=options)
+        else:
+            written, task = _run_job(backend, image_path, out_path, root=root,
+                                     timeout=timeout, options=options)
+    except ImageTo3DError as exc:
+        out["stage"] = "generate"
+        out["error"] = str(exc)
+        out["seconds"] = round(time.monotonic() - started, 2)
+        return out
+
+    out.update({
+        "ok": True, "path": str(out_path), "bytes": written, "task": task,
+        "seconds": round(time.monotonic() - started, 2),
+        "textured": bool(options.get("texture", True)),
+        "rigged": False,
+        "stage": "draft",
+        "notes": list(NEXT_STEPS),
+    })
+    out["checks"].append({
+        "check": "is_a_draft",
+        "detail": "a generated mesh is unconditioned geometry — unknown "
+                  "orientation, unknown scale, no armature, possibly "
+                  "background residue. It is not an asset until it has been "
+                  "through the conditioning steps in `notes`.",
+        "fix": "run the conditioning sequence before blender_combine",
+    })
+    _account(out, root, logical_name, work_item_id)
+    return out
+
+
+def _run_job(backend: str, image_path, out_path, *, root, timeout: float,
+             options: dict) -> tuple[int, str]:
+    """submit -> poll -> fetch, for every backend that hands back a task id."""
+    spec = _spec(backend)
+    started = time.monotonic()
+    job = submit(backend, image_path, root=root,
+                 timeout=min(180.0, timeout), **options)
+    task = job["task"]
+    left = max(30.0, timeout - (time.monotonic() - started))
+    done = poll(backend, task, root=root, timeout=left)
+
+    if backend == "comfy":
+        files = _comfy_outputs(done, task)
+        if not files:
+            # NAME THE LIKELY CAUSE, because the generic version of this
+            # message sends people to look at their GPU. ComfyUI only records a
+            # node's outputs in /history when that node returns a `ui` dict, and
+            # ComfyUI-3D-Pack's Save_3D_Mesh returns a plain tuple — so a run
+            # that worked perfectly and wrote a file on disk reports
+            # "outputs": {} and is undiscoverable over HTTP. Core ComfyUI's own
+            # SaveGLB does return one, under the key "3d".
+            raise ImageTo3DError(
+                "the ComfyUI run finished but reported no .glb or .gltf. Either "
+                "the workflow has no node that SAVES the mesh, or it uses one "
+                "whose output ComfyUI does not record — ComfyUI-3D-Pack's "
+                "Save_3D_Mesh returns no UI entry, so its file exists on disk "
+                "but never appears in /history. Use core ComfyUI's SaveGLB "
+                "node, which does.")
+        first = files[0]
+        query = urllib.parse.urlencode({"filename": first["filename"],
+                                        "subfolder": first["subfolder"],
+                                        "type": first["type"]})
+        view = spec.get("view_path", "/api/view")
+        return download(f"{base_url(backend)}{view}?{query}", out_path,
+                        timeout=300.0), task
+
+    for key in spec.get("result_b64_keys") or ():
+        blob = _dig(done, key)
+        if blob:
+            return _write_b64(str(blob), out_path), task
+    for key in spec.get("result_keys") or ():
+        url = _dig(done, key)
+        if url:
+            return download(str(url), out_path, timeout=300.0), task
+    raise ImageTo3DError(
+        f"{spec['label']} reported the job finished but returned no model: "
+        f"{str(done)[:300]}")
+
+
+def _run_sync(backend: str, image_path, out_path, *, root, timeout: float,
+              options: dict) -> tuple[int, str]:
+    """POST the plate, get the model back in the same response. No task, no poll.
+
+    Stability's 3D endpoints work this way, and it is the simplest transport
+    here by a distance — there is no job to lose, no URL to expire, and no
+    status enum to misread.
+    """
+    spec = _spec(backend)
+    key = api_key(backend, root)
+    if spec.get("env") and not key:
+        raise ImageTo3DError(available(backend, root)["reason"])
+    fields = spec.get("fields") or {}
+    form: dict[str, Any] = {}
+    for name, value in options.items():
+        target = fields.get(name)
+        if target and value is not None:
+            form[target] = value
+    p = Path(image_path)
+    body, content_type = _multipart(form, p.name, p.read_bytes(),
+                                    field=spec.get("upload_field", "image"))
+    req = urllib.request.Request(
+        base_url(backend) + spec["submit_path"], data=body, method="POST",
+        headers={"Authorization": f"Bearer {key}", "Content-Type": content_type,
+                 # model/* is what these endpoints answer with; asking for JSON
+                 # gets a JSON-wrapped base64 instead, which is a second
+                 # decode for no reason.
+                 "Accept": "*/*"})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            data = resp.read()
+    except urllib.error.HTTPError as exc:
+        raise _http_error(backend, exc, "POST", spec["submit_path"]) from exc
+    except urllib.error.URLError as exc:
+        raise _url_error(backend, exc) from exc
+    if not data:
+        raise ImageTo3DError(f"{spec['label']} returned an empty model")
+    out = Path(out_path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_bytes(data)
+    return len(data), ""
+
+
+def _account(result: dict, root: Any, logical_name: str,
+             work_item_id: Optional[int]) -> None:
+    """Write the estimated spend to the ledger. Best-effort by construction:
+    losing a ledger row must never lose the mesh that was paid for. A local
+    generation costs nothing and records nothing."""
+    if not root or not result.get("ok") or not result.get("estimated_usd"):
+        return
+    try:
+        from bgate_core import spend
+
+        spend.record(root, float(result["estimated_usd"]),
+                     kind="other", work_item_id=work_item_id,
+                     logical_name=logical_name or "",
+                     detail=f"image-to-3d via {result.get('backend')}")
+    except Exception:                                            # noqa: BLE001
+        pass
+
+
+# ---------------------------------------------------------------------------
+# The health row
+# ---------------------------------------------------------------------------
+def doctor_row() -> dict:
+    """One row in bgate_core.doctor's shape: {available, path, version,
+    min_required, reason}.
+
+    AN ABSENT ROW HERE IS NOT A FAILURE. Local 3D generation is an optional
+    capability exactly like Blender, ffmpeg and whisper: without it that one
+    path is unavailable and every other thing in the product works. The reason
+    string says so, because `bgate doctor` exits non-zero on any missing row and
+    a user reading the exit code instead of the rows will otherwise think their
+    setup is broken.
+
+    Cheap by construction — nvidia-smi and nothing else. No torch import, no
+    model load, no network.
+    """
+    card = gpu()
+    if not card["available"]:
+        return {"available": False, "path": "", "version": "",
+                "min_required": f"{MIN_VRAM_GB} GB VRAM",
+                "reason": card["reason"] + " Optional: only local image-to-3D "
+                                           "is affected."}
+    if card["vram_gb"] and card["vram_gb"] < MIN_VRAM_GB:
+        return {"available": False, "path": card["name"],
+                "version": f"{card['vram_gb']} GB, driver {card['driver']}",
+                "min_required": f"{MIN_VRAM_GB} GB VRAM",
+                "reason": card["reason"] + " Optional: only local image-to-3D "
+                                           "is affected."}
+    return {"available": True, "path": card["name"],
+            "version": f"{card['vram_gb']} GB, driver {card['driver']}",
+            "min_required": f"{MIN_VRAM_GB} GB VRAM",
+            "reason": ""}

--- a/bgate_adapters/krea.py
+++ b/bgate_adapters/krea.py
@@ -28,6 +28,16 @@ brown gradient — but for Krea it is the ONLY path to a usable sprite, so any
 caller here doing sprite/sheet/gear work must go through chroma.generate rather
 than calling this module directly.
 
+KREA ALSO GENERATES 3D, and that is the only image-to-3D this product can reach
+— see MODELS_3D and generate_3d at the bottom. It runs the same open-weight
+models one would otherwise self-host (TRELLIS, TRELLIS 2, Hunyuan3D, Tripo)
+behind the key we already load, so it needs no GPU, no CUDA toolchain and no
+16 GB of weights. Two things make it unlike the image path and both are load
+bearing: its per-generation price is NOT PUBLISHED anywhere, so a 3D call
+cannot be quoted before it runs; and what comes back is geometry and texture
+with NO RIG, so it is a draft that still owes the pipeline a clean, a scale,
+an orientation and a skeleton before it is an asset.
+
 Everything here is stdlib — no SDK. One less dependency to pin, and the surface
 we use is four HTTP calls wide.
 """
@@ -913,16 +923,22 @@ def poll(job_id: str, *, root: Any = None, timeout: float = 300.0,
         f"{last.get('status') or 'unknown'})")
 
 
-def download(url: str, out_path: str, *, timeout: float = 120.0) -> int:
-    """Fetch the finished image to disk. Returns bytes written."""
+def download(url: str, out_path: str, *, timeout: float = 120.0,
+             accept: str = "image/*") -> int:
+    """Fetch the finished file to disk. Returns bytes written.
+
+    `accept` exists because this is also how a .glb comes back, and a server
+    that honours Accept would be within its rights to refuse `image/*` for a
+    model. Default unchanged, so every image caller is untouched.
+    """
     out = Path(out_path)
     out.parent.mkdir(parents=True, exist_ok=True)
-    req = urllib.request.Request(url, headers={"Accept": "image/*"})
+    req = urllib.request.Request(url, headers={"Accept": accept})
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:
             data = resp.read()
     except Exception as exc:
-        raise KreaError(f"could not download the finished image: {exc}") from exc
+        raise KreaError(f"could not download the finished file: {exc}") from exc
     if not data:
         raise KreaError("Krea returned an empty image")
     out.write_bytes(data)
@@ -996,3 +1012,332 @@ def generate(prompt: str, out_path: str, *, model: str = DEFAULT_MODEL,
         # for, so a post-pass that cannot run must degrade to a note.
         result["tileable"] = make_tileable(str(out_path))
     return result
+
+
+# ---------------------------------------------------------------------------
+# 3D. The same job/poll/download dance, a different family of models.
+# ---------------------------------------------------------------------------
+#
+# This is the only image-to-3D the product can reach, and it arrives through the
+# key that is already configured — no GPU, no CUDA toolchain, no weight
+# download. Krea runs the open-weight models one would otherwise self-host.
+#
+# TWO THINGS ARE NOT LIKE THE IMAGE PATH.
+#
+# 1. THERE IS NO PUBLISHED PRICE. Krea's API price list covers image, video and
+#    Topaz upscaling; no 3D model appears in it, and trellis-2's own API
+#    reference says so outright. The "compute token" figures in Krea's user
+#    guide are the WEB APP's subscription meter, which is a different currency
+#    from the API's USD prepaid balance — quoting them here would be inventing
+#    a number. So price_for_3d returns None, never 0.0, and generate_3d refuses
+#    to spend until a caller says confirm_unpriced=True. An unknown price that
+#    reads as free is how a budget gets spent without anyone deciding to.
+#
+# 2. NOTHING COMES BACK RIGGED. Geometry and texture, no armature, no unit
+#    convention, no guaranteed pose. Measured on a real user's character: 940
+#    fragmented shells, wrong pose, missing lettering. `decimation_target`
+#    (trellis-2) and `face_count` (hunyuan3d-3.1-pro) are the knobs aimed at
+#    exactly that, and are worth turning before writing any cleanup code.
+#
+# Per-model payload shapes differ as much as they do for images — trellis-2
+# takes a resolution tier and a decimation target, hunyuan3d-3.1-pro takes PBR
+# and seven extra view URLs, tripo takes neither. Sending the wrong pair is a
+# 422 "Unrecognized keys", so `supports` is enforced here rather than hoped for.
+MODELS_3D: dict[str, dict] = {
+    "trellis-2": {
+        "path": "/generate/3d/microsoft/trellis-2",
+        # MEASURED, not published: two text-to-3D jobs at default settings on
+        # 2026-07-31 each billed $0.30 on Krea's usage page, which labels the
+        # column "Estimated cost". Both ran the same parameters, so this is the
+        # DEFAULT-CONFIG price and nothing is known about how resolution,
+        # texture_size or decimation_target move it. Treat it as a floor.
+        "usd": 0.30,
+        "usd_measured": "2026-07-31, text-to-3D, default parameters",
+        "supports": {"seed", "input_mode", "generate_texture", "resolution",
+                     "texture_size", "decimation_target", "image_urls"},
+        "resolution": ("512", "1024", "1536"),
+        "texture_size": ("1024", "2048", "4096"),
+        "decimation_target": (100_000, 2_000_000),
+        "note": "the current best, and the only one with a decimation target — "
+                "the knob for a mesh that arrives as fragmented shells.",
+    },
+    "trellis": {
+        "path": "/generate/3d/microsoft/trellis",
+        "supports": {"seed", "input_mode", "generate_texture", "texture_size",
+                     "image_urls"},
+        "note": "the older TRELLIS. Keep for comparison; prefer trellis-2.",
+    },
+    "tripo": {
+        "path": "/generate/3d/tripo/tripo",
+        "supports": {"seed", "input_mode", "generate_texture", "image_urls"},
+        "note": "fewest knobs of the five — prompt, seed, texture on or off.",
+    },
+    "hunyuan3d-2.1": {
+        "path": "/generate/3d/tencent/hunyuan3d-2.1",
+        "supports": {"seed", "input_mode", "generate_texture", "image_urls"},
+        "note": "Tencent's 2.x line.",
+    },
+    "hunyuan3d-3.1-pro": {
+        "path": "/generate/3d/tencent/hunyuan3d-3.1-pro",
+        "supports": {"seed", "input_mode", "generate_texture", "enable_pbr",
+                     "face_count", "image_urls", "back_image_url",
+                     "left_image_url", "right_image_url", "top_image_url",
+                     "bottom_image_url", "left_front_image_url",
+                     "right_front_image_url"},
+        "face_count": (40_000, 1_500_000),
+        "views": ("back", "left", "right", "top", "bottom", "left_front",
+                  "right_front"),
+        "note": "the only MULTI-VIEW model here and the only one taking PBR. "
+                "Extra views are how a back nobody photographed stops being "
+                "invented — pass them when the subject has a defined back.",
+    },
+}
+
+DEFAULT_MODEL_3D = "trellis-2"
+
+
+def models_3d() -> dict:
+    """The 3D catalogue, for a caller choosing a model."""
+    return {name: {k: v for k, v in spec.items() if k != "supports"}
+            for name, spec in MODELS_3D.items()}
+
+
+def price_for_3d(model: str = DEFAULT_MODEL_3D) -> Optional[float]:
+    """USD where it has been MEASURED, None where it is still unknown.
+
+    Krea publishes no 3D price anywhere — not in the API price list, and the
+    trellis-2 reference says so outright. The only figures on the docs site are
+    "compute tokens", which are the WEB APP's subscription meter and not the
+    API's USD balance; quoting those would be inventing a number.
+
+    So a price here comes from a real invoice or it does not exist. None means
+    unknown and a spend gate can refuse on it; 0.0 is never returned, because
+    every budget check in the product would read that as free.
+    """
+    spec = MODELS_3D.get(model)
+    if not spec:
+        raise KreaError(f"unknown 3D model {model!r} — known: {sorted(MODELS_3D)}")
+    usd = spec.get("usd")
+    return float(usd) if usd is not None else None
+
+
+def _image_ref(source: str | os.PathLike) -> str:
+    """A local file becomes a data URI; a URL is passed through.
+
+    `image_urls` accepts external URLs, base64 data URIs and Krea asset URLs,
+    so a caller can hand this a path from disk or a URL it already holds.
+    """
+    text = str(source)
+    if text.startswith(("http://", "https://", "data:")):
+        return text
+    return data_uri(text)
+
+
+def submit_3d(prompt: str = "", *, model: str = DEFAULT_MODEL_3D,
+              images=(), seed: Optional[int] = None,
+              generate_texture: bool = True, resolution: str = "",
+              texture_size: str = "", decimation_target: Optional[int] = None,
+              face_count: Optional[int] = None,
+              enable_pbr: Optional[bool] = None,
+              views: Optional[dict] = None, webhook: str = "",
+              root: Any = None, timeout: float = 60.0) -> dict:
+    """Start a 3D generation. Returns the job envelope with `job_id`.
+
+    `images` are the input plate(s), local paths or URLs. Empty means
+    text-to-3D, and input_mode is set from that rather than making every caller
+    remember to. `views` maps extra angle names (back, left, right, top,
+    bottom, left_front, right_front) to sources and is hunyuan3d-3.1-pro only.
+
+    A parameter the chosen model does not declare is REFUSED, not dropped.
+    Dropping it would send the request, charge for it, and hand back the
+    default — so a caller who asked for a decimation target on a model that has
+    none would get exactly the fragmented mesh they were trying to avoid, with
+    nothing saying why.
+    """
+    spec = MODELS_3D.get(model)
+    if not spec:
+        raise KreaError(f"unknown 3D model {model!r} — known: {sorted(MODELS_3D)}")
+
+    # SHAPE FIRST, KEY SECOND. Checking the key up here would answer a bad
+    # decimation_target with "KREA_API_KEY not set", which names the wrong
+    # problem and makes every refusal below untestable without a live key.
+    # Building the payload costs nothing and touches no network.
+    plates = [_image_ref(p) for p in (images or ())]
+    if not plates and not str(prompt).strip():
+        raise KreaError("a 3D generation needs an image or a prompt — got neither")
+
+    payload: dict = {"prompt": prompt or "",
+                     "input_mode": "image" if plates else "text",
+                     "generate_texture": bool(generate_texture)}
+    if plates:
+        payload["image_urls"] = plates
+    if seed is not None:
+        payload["seed"] = int(seed)
+
+    def _want(field: str, value, allowed=()) -> None:
+        if value in (None, ""):
+            return
+        if field not in spec["supports"]:
+            takes = sorted(n for n, s in MODELS_3D.items()
+                           if field in s["supports"])
+            raise KreaError(
+                f"{model} does not take {field} — it would be ignored and you "
+                f"would be charged for the default. Models that do: {takes}")
+        if allowed and str(value) not in allowed:
+            raise KreaError(
+                f"{field}={value!r} is not one of {list(allowed)} for {model}")
+        payload[field] = value
+
+    def _ranged(field: str, value) -> None:
+        if value is None:
+            return
+        lo, hi = spec.get(field, (0, 0))
+        if lo and not (lo <= int(value) <= hi):
+            raise KreaError(f"{field} must be {lo}..{hi} for {model}, got {value}")
+        _want(field, int(value))
+
+    _want("resolution", resolution, spec.get("resolution", ()))
+    _want("texture_size", texture_size, spec.get("texture_size", ()))
+    _ranged("decimation_target", decimation_target)
+    _ranged("face_count", face_count)
+    if enable_pbr is not None:
+        _want("enable_pbr", bool(enable_pbr))
+    for name, source in (views or {}).items():
+        field = name if name.endswith("_image_url") else f"{name}_image_url"
+        _want(field, _image_ref(source))
+
+    key = api_key(root)
+    if not key:
+        raise KreaError(available(root)["reason"])
+
+    path = spec["path"]
+    if not webhook:
+        return _request(path, key, payload=payload, method="POST", timeout=timeout)
+    # A webhook is a HEADER, and _request has no header hook. One narrow
+    # duplicate beats widening the shared helper for a single caller.
+    body = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(API_BASE + path, data=body, method="POST",
+                                 headers={"Authorization": f"Bearer {key}",
+                                          "Content-Type": "application/json",
+                                          "Accept": "application/json",
+                                          "X-Webhook-URL": webhook})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return json.loads(resp.read().decode("utf-8") or "{}")
+    except urllib.error.HTTPError as exc:
+        raise KreaError(f"Krea HTTP {exc.code} on POST {path}") from exc
+    except urllib.error.URLError as exc:
+        raise KreaError(f"could not reach Krea ({exc.reason})") from exc
+
+
+def _model_url(result: dict) -> str:
+    """Dig the .glb URL out of a completed 3D job.
+
+    MEASURED on the first live call, which is the only reason this is not one
+    line: the image path documents `result.urls` as an array of STRINGS, and
+    the 3D path returns an array of OBJECTS. Passing one to urllib raised
+    "unknown url type: {'type'" after the generation had already been paid
+    for. The 3D job's completed body is not published, so this reads the
+    documented shape, the measured shape, and the obvious singular fields,
+    and gives up loudly rather than guessing further.
+    """
+    def _one(entry) -> str:
+        if isinstance(entry, str):
+            return entry
+        if isinstance(entry, dict):
+            for field in ("url", "signed_url", "href", "download_url"):
+                value = entry.get(field)
+                if isinstance(value, str) and value:
+                    return value
+        return ""
+
+    for entry in (result.get("urls") or []):
+        found = _one(entry)
+        if found:
+            return found
+    for field in ("model_url", "glb_url", "url", "asset_url", "model", "glb"):
+        found = _one(result.get(field))
+        if found:
+            return found
+    return ""
+
+
+def generate_3d(out_path: str, *, prompt: str = "", images=(),
+                model: str = DEFAULT_MODEL_3D, seed: Optional[int] = None,
+                generate_texture: bool = True, resolution: str = "",
+                texture_size: str = "", decimation_target: Optional[int] = None,
+                face_count: Optional[int] = None,
+                enable_pbr: Optional[bool] = None, views: Optional[dict] = None,
+                confirm_unpriced: bool = False, timeout: float = 900.0,
+                root: Any = None) -> dict:
+    """Submit, wait, download a .glb. The 3D twin of :func:`generate`.
+
+    WHAT COMES BACK IS A DRAFT, NOT AN ASSET, and `draft` is True in the result
+    to say so. Geometry and texture, no armature, no unit convention, no
+    guaranteed pose. It still owes the pipeline a clean, a scale to the
+    project's convention, an orientation and a weighting before combine or
+    delivery will make anything of it.
+
+    `confirm_unpriced` is not ceremony. Krea publishes no 3D price, so unlike
+    every other spend in this module the cost cannot be quoted first and the
+    caller has to accept an unknown charge out loud. `estimated_usd` stays None
+    throughout — never 0.0, which reads as free.
+
+    The timeout defaults high because a 3D job runs in minutes where an image
+    runs in seconds.
+    """
+    started = time.monotonic()
+    quote = price_for_3d(model)
+    base = {"provider": "krea", "model": model, "kind": "3d",
+            "estimated_usd": quote, "draft": True}
+    job_id = ""
+    finished: dict = {}
+
+    # The gate is for an UNKNOWN price, not for spending. A model with a
+    # measured rate quotes itself and runs like any other paid call; only the
+    # ones nobody has invoiced yet need a caller to accept a blind charge.
+    if quote is None and not confirm_unpriced:
+        return {**base, "ok": False, "seconds": 0.0,
+                "error": f"no measured price for {model} — Krea publishes none "
+                         "for 3D, so this call cannot be quoted before it runs "
+                         "and nothing has been spent. Pass confirm_unpriced=True "
+                         "to accept an unknown charge against the API balance.",
+                "price_note": "the compute-token figures in Krea's user guide "
+                              "are the web app's subscription meter, not the "
+                              "API's USD balance — they do not apply here"}
+    try:
+        job = submit_3d(prompt, model=model, images=images, seed=seed,
+                        generate_texture=generate_texture,
+                        resolution=resolution, texture_size=texture_size,
+                        decimation_target=decimation_target,
+                        face_count=face_count, enable_pbr=enable_pbr,
+                        views=views, root=root)
+        job_id = job.get("job_id") or job.get("id")
+        if not job_id:
+            raise KreaError(f"Krea did not return a job id: {str(job)[:200]}")
+        finished = poll(str(job_id), root=root, timeout=timeout)
+        result = finished.get("result") or {}
+        url = _model_url(result)
+        if not url:
+            raise KreaError("Krea reported completed with no model URL — the "
+                            f"result body was {str(result)[:300]}")
+        written = download(url, out_path, accept="model/gltf-binary,*/*",
+                           timeout=300.0)
+    except KreaError as exc:
+        # CARRY THE JOB. A 3D generation is minutes of paid compute, and the
+        # first live call failed at the DOWNLOAD, after the job had completed
+        # and been charged for — dropping the id here made a finished result
+        # unrecoverable and cost a second generation to learn the same thing.
+        # `GET /jobs/<id>` still has it.
+        return {**base, "ok": False, "error": str(exc),
+                "job_id": str(job_id), "result": (finished or {}).get("result"),
+                "recover": (f"the job is done and paid for — poll /jobs/{job_id} "
+                            "and download from its result") if job_id else "",
+                "seconds": round(time.monotonic() - started, 2)}
+    return {**base, "ok": True, "path": str(out_path), "bytes": written,
+            "job_id": str(job_id), "url": url,
+            "seconds": round(time.monotonic() - started, 2),
+            "next_steps": ("merge and clean the shells",
+                           "scale to the project's unit convention",
+                           "orient forward", "weight to a skeleton",
+                           "then combine or deliver")}

--- a/bgate_core/doctor.py
+++ b/bgate_core/doctor.py
@@ -48,7 +48,7 @@ _NO_WINDOW = 0x08000000 if sys.platform == "win32" else 0
 
 # The order is the report order — cheap/local first, subprocess-spawning last.
 CHECKS = ("python", "openai_key", "ffmpeg", "ffprobe", "blender", "godot",
-          "godot_web_templates", "whisper")
+          "godot_web_templates", "whisper", "imageto3d")
 
 # What the code in this repo actually assumes, not aspirational floors.
 # blender: the default warmup engine is BLENDER_EEVEE_NEXT, which is 4.2+.
@@ -63,6 +63,12 @@ MIN_REQUIRED = {
     "godot": "4.0",
     "godot_web_templates": "",
     "whisper": "0.10",
+    # No floor. A red row here means image-to-3D is unavailable and every
+    # other path still works — same status as ffmpeg or whisper. It reports a
+    # GPU, not a binary, and it asks nvidia-smi rather than torch: this
+    # machine's default interpreter carries torch 2.8.0+cpu, so a torch probe
+    # would call a perfectly good RTX 3060 "no GPU" and never recover.
+    "imageto3d": "",
 }
 
 CACHE_SECONDS = 5.0
@@ -249,6 +255,24 @@ def _probe_whisper() -> dict:
     return _finish("whisper", probe.get("python", ""), probe.get("version", ""))
 
 
+def _probe_imageto3d() -> dict:
+    """GPU capable of local image-to-3D, or the reason there is none.
+
+    Imported inside the function on purpose. The adapter is careful never to
+    pull torch, but doctor is on the startup path of every CLI invocation and
+    an adapter import belongs behind the probe that needs it, not above it.
+    """
+    try:
+        from bgate_adapters import imageto3d
+    except Exception as exc:                       # adapter absent or broken
+        return _missing("imageto3d", f"adapter unavailable: {exc}")
+    row = imageto3d.doctor_row()
+    return _row(available=bool(row.get("available")),
+                path=row.get("path", ""), version=row.get("version", ""),
+                min_required=row.get("min_required", ""),
+                reason=row.get("reason", ""))
+
+
 _PROBES: dict[str, Callable[[], dict]] = {
     "python": _probe_python,
     "openai_key": _probe_openai_key,
@@ -258,6 +282,7 @@ _PROBES: dict[str, Callable[[], dict]] = {
     "godot": _probe_godot,
     "godot_web_templates": _probe_godot_web_templates,
     "whisper": _probe_whisper,
+    "imageto3d": _probe_imageto3d,
 }
 
 

--- a/bgate_core/spend.py
+++ b/bgate_core/spend.py
@@ -16,7 +16,11 @@ from typing import Optional
 
 from bgate_core import db
 
-KINDS = ("agent", "image", "audio", "other")
+# "mesh" is image-to-3D. It was landing under "other" alongside genuinely
+# uncategorised spend, which is the one bucket nobody reads — and a textured
+# generation is ~$0.30, an order of magnitude over an image, so it is exactly
+# the line an author wants to find when the month looks wrong.
+KINDS = ("agent", "image", "audio", "mesh", "other")
 
 
 def budget(root: str | os.PathLike[str]) -> dict:

--- a/bgate_mcp/server.py
+++ b/bgate_mcp/server.py
@@ -847,12 +847,50 @@ def recall(query: str, limit: int = 10, kind: Optional[str] = None) -> dict:
 # ---------------------------------------------------------------------------
 @_tool
 def blender_status() -> dict:
-    """Is Blender available to this machine, and which version? Check before modeling."""
+    """Is Blender available to this machine, and which version? Check before modeling.
+
+    Also reports `generate`: whether image-to-3D is reachable, and from where.
+    Folded in here rather than given its own tool — one question ("what can I
+    build with?") should cost one call.
+    """
     try:
         probe = _blender.available()
-        return {**probe, **(_blender.version() if probe["available"] else {})}
+        out = {**probe, **(_blender.version() if probe["available"] else {})}
+        out["generate"] = _imageto3d_summary()
+        return out
     except Exception as exc:
         return _fail(exc)
+
+
+def _imageto3d_summary() -> dict:
+    """A few lines, not the whole catalogue.
+
+    imageto3d.status() carries every backend's full licence prose — right for
+    a doctor row a human reads once, far too expensive to hand an agent on
+    every status call. Names what is usable and why the rest is not, and
+    leaves the reading to blender_generate's own failure.
+    """
+    try:
+        from bgate_adapters import imageto3d as _i3d
+    except Exception:
+        return {"available": False, "reason": "adapter unavailable"}
+    try:
+        full = _i3d.status()
+    except Exception as exc:
+        return {"available": False, "reason": f"{type(exc).__name__}: {exc}"}
+    gpu = full.get("gpu") or {}
+    usable = list(full.get("usable") or [])
+    blocked = {b["backend"]: b.get("reason", "")
+               for b in full.get("backends") or []
+               if not b.get("available") and b.get("implemented")}
+    return {"available": bool(usable), "usable": usable,
+            "gpu": gpu.get("name", ""), "vram_gb": gpu.get("vram_gb"),
+            "blocked": blocked,
+            "note": ("nothing configured — see .env.example; a generated mesh "
+                     "is a DRAFT and still has to be cleaned, scaled, oriented "
+                     "and rigged before it is an asset")
+            if not usable else
+            "a generated mesh is a DRAFT: clean, scale, orient and rig it"}
 
 
 @_tool
@@ -1265,6 +1303,83 @@ def blender_turnaround(model: str, out_dir: str, stem: str = "turnaround",
                            + (f", {unreadable} unreadable" if unreadable else ""),
                  ref=str(out_dir))
         return result
+    except Exception as exc:
+        return _fail(exc)
+
+
+@_tool
+def blender_generate(image: str, out_path: str, backend: str = "",
+                     label: str = "", timeout: int = 900,
+                     dry_run: bool = False,
+                     options: Optional[dict] = None) -> dict:
+    """Turn ONE generated image into a draft mesh. The other way to get geometry.
+
+    The primitive path (blender_run + the kit) is for props, vehicles, terrain
+    and block-out — things made of boxes and cylinders. It tops out at a
+    proportioned blockout with no face and no fingers, so a hero character
+    seen close up comes from here instead: generate the plate with
+    image_generate, then hand it over.
+
+    WHAT COMES BACK IS A DRAFT, NOT AN ASSET. Expect dense, unpredictable
+    topology, no armature, no unit convention, and possibly baked lighting in
+    the texture. It has to be scaled to 1.8 m, faced +Y, cleaned, unwrapped
+    and weighted to a skeleton before blender_combine will make anything of
+    it — bg_human's rig is the one to weight it to. `draft` is True in the
+    result and `next_steps` says so; there is no path straight to
+    godot_deliver_asset and that is deliberate.
+
+    Nothing runs until you configure a backend (see .env.example) — this
+    machine ships no model and downloads none. blender_status reports what is
+    reachable. A local backend costs nothing per generation; a hosted one is
+    priced before it submits, and `dry_run=True` returns that quote plus the
+    licence verdict without spending anything.
+
+    LICENCE IS PART OF THE RESULT. A local server is only a transport, so the
+    model must be declared (BGATE_LOCAL_MODEL) — undeclared reads as unknown,
+    never as permission. Some grants exclude whole territories and some
+    forbid commercial use outright, which is a shipping problem rather than a
+    technical one, so read `licence` before building on the mesh.
+    """
+    try:
+        from bgate_adapters import imageto3d as _i3d
+    except Exception as exc:
+        return _fail(exc)
+    try:
+        root = _root()
+    except Exception:
+        root = None                        # modelling before project_init is allowed
+    try:
+        plate = _i3d.check_input(image)
+        if not plate.get("ok"):
+            return {"ok": False, "error": plate.get("reason", "unusable plate"),
+                    "input": plate}
+        picked = backend or (_i3d.choose(root) or {}).get("backend", "")
+        if not picked:
+            return {"ok": False, "error": "no image-to-3D backend is configured "
+                    "— see .env.example; blender_status reports what is reachable",
+                    "status": _imageto3d_summary()}
+        opts = dict(options or {})
+        quote = {"backend": picked,
+                 "usd": _i3d.price_for(picked, **{k: v for k, v in opts.items()
+                                                  if k in ("texture", "quad", "rig")}),
+                 "licence": _i3d.model_licence(_i3d.declared_model())}
+        if dry_run:
+            return {"ok": True, "dry_run": True, "quote": quote,
+                    "input": plate, "next_steps": list(_i3d.NEXT_STEPS)}
+        got = _i3d.generate(image, out_path, backend=picked, root=root,
+                            timeout=float(timeout), logical_name=label,
+                            **opts)
+        got.setdefault("quote", quote)
+        if got.get("ok") and root and got.get("out_path"):
+            try:
+                got["artifact"] = _register_artifact(
+                    root, got["out_path"], label or _Path(out_path).stem,
+                    producer="blender_generate", refs=[str(image)],
+                    metadata={"backend": picked, "draft": True,
+                              "licence": quote["licence"], "plate": str(image)})
+            except Exception:
+                pass                       # a mesh on disk beats a bookkeeping raise
+        return got
     except Exception as exc:
         return _fail(exc)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "builders-gate"
-version = "0.1.29"
+version = "1.3.0"
 description = "Agentic game development pipeline — design bible, lore canon, and DCC/engine adapters over MCP."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/test_blender_adopt.py
+++ b/tests/test_blender_adopt.py
@@ -1,0 +1,169 @@
+"""Taking a GENERATED mesh and making it usable: weld, orient, budget.
+
+A generation does not arrive as an asset. It arrives as a pile of disconnected
+shells at an arbitrary scale facing an arbitrary direction. Everything here was
+written against real Krea output and the numbers in the docstrings are measured,
+not illustrative.
+
+Two of them are corrections to my own first attempt, and both are the reason
+these tests exist:
+
+  * "weld until it is one shell" is WRONG. On a generated mannequin it took
+    non-manifold edges from 3 to 20,285 and the decimator then could not reach
+    an 8,000 triangle budget at all, stalling at 49,261 however many passes it
+    got. The same mesh merged six times more gently sat in 4 shells with 3
+    non-manifold edges and decimated to 7,999. Non-manifold count predicts
+    decimatability; shell count does not.
+
+  * "which way does this face" has NO universal geometric answer. Reading it
+    from the bounding box rotated a crate 90 degrees onto a different footprint
+    for no reason. It has to refuse to guess.
+"""
+from __future__ import annotations
+
+import shutil
+
+import pytest
+
+from bgate_adapters import blender
+
+requires_blender = pytest.mark.skipif(
+    not shutil.which("blender") and not blender.available().get("available"),
+    reason="needs a real Blender")
+
+
+def run(body: str) -> dict:
+    """Run a kit script and hand back the printed lines by their first word."""
+    result = blender.run_script("bg_wipe()\n" + body, kit=True, timeout=300)
+    assert result.get("ok"), result.get("traceback") or result.get("error")
+    out: dict = {}
+    for line in (result.get("print") or "").splitlines():
+        parts = line.split(" ", 1)
+        if parts[0].isupper() and len(parts) > 1:
+            out[parts[0]] = parts[1].strip()
+    return out
+
+
+@requires_blender
+class TestFacingRefusesToGuess:
+    def test_a_shape_that_stands_on_feet_is_read_from_its_toes(self):
+        """A foot reaches much further forward of the ankle than the heel does
+        behind it, which is the only asymmetry a featureless figure reliably
+        has — a generated head is often an egg, so a face is no use."""
+        got = run('''
+base = bg_human(height=1.8, pose="a")
+read = bg_facing(base["obj"])
+print("SIGN", read["sign"])
+print("CONF", read["confident"])
+print("STR", read["strength"])
+''')
+        assert got["SIGN"] == "1", "the base faces +Y, so its toes lead that way"
+        assert got["CONF"] == "True"
+        assert float(got["STR"]) >= 1.25, "below the threshold this is a guess"
+
+    def test_something_with_no_front_is_left_alone(self):
+        """MEASURED: guessing turned a generated crate 90 degrees onto a
+        different footprint. An asset with no front is not a problem to solve."""
+        got = run('''
+box = bg_box("Crate", size=(1.0, 0.8, 0.6))
+before = tuple(round(d, 4) for d in box.dimensions)
+rep = bg_orient(box, kind="none")
+print("TURNED", rep["turned_deg"])
+print("SAME", before == tuple(round(d, 4) for d in box.dimensions))
+print("NOTE", rep["note"][:60])
+''')
+        assert got["TURNED"] == "0"
+        assert got["SAME"] == "True"
+
+    def test_an_unreadable_front_refuses_rather_than_rotating(self):
+        got = run('''
+ball = bg_ball("Ball", radius=0.5)
+rep = bg_orient(ball, kind="humanoid")
+print("TURNED", rep["turned_deg"], "CONF", rep["confident"])
+''')
+        assert got["TURNED"].startswith("0")
+        assert "False" in got["TURNED"] or "False" in got.get("CONF", "")
+
+    def test_an_explicit_assume_is_obeyed_when_geometry_cannot_say(self):
+        got = run('''
+ball = bg_ball("Ball", radius=0.5)
+rep = bg_orient(ball, kind="humanoid", assume=-1)
+print("TURNED", rep["turned_deg"], "CONF", rep["confident"])
+''')
+        assert got["TURNED"].split(" ")[0] in {"0", "90", "180", "270"}
+        assert "True" in got["TURNED"]
+
+    def test_up_is_world_up_not_the_tallest_axis(self):
+        """MEASURED: "up is the tallest axis" put a cap's up along its brim,
+        because a cap lying flat is longer front-to-back than it is tall."""
+        got = run('''
+flat = bg_box("Flat", size=(0.6, 1.0, 0.2))
+print("UP", bg_axes(flat)["up"])
+''')
+        assert got["UP"] == "2"
+
+
+@requires_blender
+class TestWeldingIsGentle:
+    def test_welding_reports_whether_the_mesh_can_be_decimated(self):
+        """Non-manifold count is the signal. Collapse will not cross a
+        non-manifold junction, and merging harder manufactures them faster than
+        it removes shells."""
+        got = run('''
+base = bg_human(height=1.8)
+rep = bg_weld(base["obj"])
+print("NM", rep["nonmanifold"], "DEC", rep["decimatable"], "SH", rep["shells"])
+''')
+        assert "True" in got["NM"]
+
+    def test_the_merge_distance_scales_with_the_object(self):
+        """One setting has to serve a 0.2 m cap and a 2 m figure, so it is a
+        fraction of the bounding-box diagonal rather than an absolute."""
+        got = run('''
+small = bg_box("S", size=(0.2, 0.2, 0.2))
+big = bg_box("B", size=(2.0, 2.0, 2.0))
+a, b = bg_weld(small)["merge"], bg_weld(big)["merge"]
+print("RATIO", round(b / max(a, 1e-9), 1))
+''')
+        assert float(got["RATIO"]) > 5
+
+
+@requires_blender
+class TestAdoptSaysWhenItFailed:
+    def test_a_budget_that_was_met_says_so(self):
+        got = run('''
+base = bg_human(height=1.8, detail=2)
+rep = bg_adopt(base["obj"], kind="humanoid", height=1.8, budget=1200)
+print("MET", rep["budget"]["met"], "GOT", rep["budget"]["got"])
+''')
+        assert "True" in got["MET"]
+
+    def test_a_budget_that_could_not_be_met_is_reported_not_hidden(self):
+        """Returning a mesh far over budget with an ok-looking report is the
+        exact failure this whole pass exists to stop. MEASURED on a generated
+        crate: asked 2,000, got 97,954, because 78,618 non-manifold edges stop
+        collapse dead at every merge distance."""
+        got = run('''
+box = bg_box("B", size=(1, 1, 1))
+rep = bg_adopt(box, kind="none", budget=2)
+b = rep["budget"]
+print("ASKED", b["asked"], "GOT", b["got"], "MET", b["met"])
+print("REASON", (b["reason"] or "none")[:70])
+''')
+        assert got["ASKED"].startswith("2 ")
+        assert "MET" in got["ASKED"] or "GOT" in got["ASKED"]
+
+    def test_adopt_grounds_what_it_scaled(self):
+        """Grounding before scaling leaves the mesh floating by whatever the
+        scale factor was, which is why the order in bg_adopt is fixed."""
+        got = run('''
+base = bg_human(height=1.8)
+obj = base["obj"]
+obj.location.z += 3.0
+bg_adopt(obj, kind="humanoid", height=1.8)
+import bpy
+bpy.context.view_layer.update()
+low = min((obj.matrix_world @ v.co).z for v in obj.data.vertices)
+print("SOLE", round(low, 4), "TALL", round(obj.dimensions[2], 3))
+''')
+        assert abs(float(got["SOLE"].split(" ")[0])) < 0.01

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -50,6 +50,15 @@ def everything_present(monkeypatch):
     monkeypatch.setattr("bgate_adapters.transcribe.available",
                         lambda: {"available": True, "python": "C:/py.exe",
                                  "version": "1.2.1"})
+    # A GPU, stubbed like everything else here. The imageto3d row asks
+    # nvidia-smi, and `shutil.which` above answers None for it — so on a
+    # machine WITH a GPU this fixture was accidentally honest and on a CI
+    # runner it was not, which is exactly how this test passed on two
+    # developer machines and failed on every runner.
+    monkeypatch.setattr("bgate_adapters.imageto3d.doctor_row",
+                        lambda: {"available": True, "path": "nvidia-smi",
+                                 "version": "NVIDIA GeForce RTX 3060 (12.0 GB)",
+                                 "min_required": "", "reason": ""})
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test-key")
 
 
@@ -68,6 +77,10 @@ def nothing_present(monkeypatch):
     monkeypatch.setattr("bgate_adapters.transcribe.available",
                         lambda: {"available": False, "python": "C:/py.exe",
                                  "reason": "faster-whisper not installed"})
+    monkeypatch.setattr("bgate_adapters.imageto3d.doctor_row",
+                        lambda: {"available": False, "path": "", "version": "",
+                                 "min_required": "",
+                                 "reason": "nvidia-smi not found"})
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
 
 
@@ -99,16 +112,24 @@ def test_present_binaries_report_available_with_a_path(everything_present):
 
 
 def test_absent_binaries_report_a_reason_not_an_exception(nothing_present):
+    """DERIVED FROM doctor.CHECKS, not a list written out again here.
+
+    This used to name the seven rows and assert the string "7 unavailable".
+    Adding the imageto3d row broke both halves, and only on machines without a
+    GPU — so it passed on the two boxes it was written on and failed on every
+    runner. A count and a list that have to be edited in step with CHECKS will
+    be forgotten again; asking CHECKS cannot be.
+    """
     report = doctor.check()
-    for name in ("blender", "godot", "godot_web_templates", "ffmpeg", "ffprobe",
-                 "whisper", "openai_key"):
+    absent = [n for n in doctor.CHECKS if n != "python"]
+    for name in absent:
         row = report[name]
         assert row["available"] is False, name
         assert row["reason"], name
         assert row["path"] in ("", "C:/py.exe"), name
     # python is the interpreter running this — it is always there.
     assert report["python"]["available"]
-    assert "7 unavailable" in doctor.summary(report)
+    assert f"{len(absent)} unavailable" in doctor.summary(report)
 
 
 def test_export_templates_must_match_the_editor_version(monkeypatch, tmp_path):

--- a/tests/test_imageto3d.py
+++ b/tests/test_imageto3d.py
@@ -1,0 +1,746 @@
+"""The image-to-3D adapter, offline.
+
+Nothing here touches the network, spawns nvidia-smi for real, or loads a model.
+What is under test is the part that will actually bite:
+
+  * the ZERO-CONFIGURATION answer. This is an optional capability on a machine
+    that may have no GPU and no keys, and "nothing is set up" has to be a
+    complete, actionable report rather than an exception or a crash.
+  * PRICING, which is three-valued. 0.0 for a local backend, a real number for a
+    hosted one that publishes a rate, and None for one that does not — and None
+    must never quietly become 0.0, because the spend gate reads a number as
+    permission.
+  * PAYLOAD SHAPE PER BACKEND. Each has its own schema and sending the wrong one
+    is a 400, not a default. This is the failure krea.py hit on its first live
+    call (aspect_ratio to flux) and the reason these are pinned per backend
+    rather than against one shared shape.
+  * LICENCE, which is a gate. A backend with a conditional licence must never be
+    selected automatically, because this tool does not know its user's revenue,
+    territory or monthly actives.
+"""
+from __future__ import annotations
+
+import base64
+import json
+import subprocess
+import urllib.error
+
+import pytest
+
+from bgate_adapters import imageto3d
+
+
+ALL_KEYS = ("TRIPO_API_KEY", "MESHY_API_KEY", "STABILITY_API_KEY",
+            "RODIN_API_KEY")
+
+
+@pytest.fixture(autouse=True)
+def _clean(monkeypatch):
+    """No keys, no cached GPU, no inherited overrides.
+
+    The GPU probe caches on purpose — a dashboard polling status() must not
+    spawn a process per poll — so every test has to clear it or the first one to
+    run decides the answer for all the others.
+    """
+    monkeypatch.setattr(imageto3d, "_gpu_cache", None, raising=False)
+    for name in ALL_KEYS + ("BGATE_IMAGETO3D_PYTHON", "BGATE_COMFY_URL",
+                            "BGATE_COMFY_WORKFLOW", "BGATE_HUNYUAN3D_URL",
+                            imageto3d.MODEL_ENV):
+        monkeypatch.delenv(name, raising=False)
+
+
+@pytest.fixture()
+def no_gpu(monkeypatch):
+    """A machine with no NVIDIA driver — nvidia-smi is not on PATH."""
+    def boom(*a, **k):
+        raise FileNotFoundError("nvidia-smi")
+    monkeypatch.setattr(imageto3d.subprocess, "run", boom)
+    monkeypatch.setattr(imageto3d, "_gpu_cache", None, raising=False)
+
+
+@pytest.fixture()
+def has_gpu(monkeypatch):
+    """The target box: RTX 3060, 12 GB, driver 595.95."""
+    def fake(*a, **k):
+        return subprocess.CompletedProcess(
+            a[0] if a else [], 0,
+            stdout="NVIDIA GeForce RTX 3060, 12288 MiB, 595.95\n", stderr="")
+    monkeypatch.setattr(imageto3d.subprocess, "run", fake)
+    monkeypatch.setattr(imageto3d, "_gpu_cache", None, raising=False)
+
+
+@pytest.fixture()
+def plate(tmp_path):
+    """A plate that check_input ACCEPTS, with or without Pillow.
+
+    Written as a real 512x512 PNG when Pillow is there, because check_input
+    measures it and a 1x1 file would be refused for being under the floor —
+    which would make every test using this fixture pass for the wrong reason.
+    Without Pillow the size checks do not run, so any bytes will do.
+    """
+    f = tmp_path / "hero.png"
+    try:
+        from PIL import Image
+    except ImportError:
+        f.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 64)
+        return f
+    Image.new("RGBA", (512, 512), (0, 0, 0, 0)).save(f)
+    return f
+
+
+# ---------------------------------------------------------------------------
+class TestNothingConfigured:
+    """The answer a user with no GPU and no keys gets. It must be complete."""
+
+    def test_status_reports_every_backend_rather_than_raising(self, no_gpu):
+        got = imageto3d.status()
+        assert got["ok"] is False
+        assert {row["backend"] for row in got["backends"]} == set(imageto3d.BACKENDS)
+        assert got["usable"] == []
+
+    def test_the_reason_names_what_to_set_and_says_nothing_else_breaks(self, no_gpu):
+        reason = imageto3d.status()["reason"]
+        for key in ALL_KEYS:
+            assert key in reason
+        # The known bgate doctor trap in reverse: a missing optional capability
+        # must not read as a broken install.
+        assert "affected" in reason
+
+    def test_every_backend_carries_a_reason_when_it_is_unavailable(self, no_gpu):
+        for row in imageto3d.status()["backends"]:
+            assert row["available"] is False
+            assert row["reason"], f"{row['backend']} refused without saying why"
+
+    def test_no_gpu_is_reported_as_a_fact_not_an_error(self, no_gpu):
+        card = imageto3d.gpu()
+        assert card["available"] is False
+        assert "nvidia-smi not found" in card["reason"]
+        assert "unaffected" in card["reason"]
+
+    def test_an_unknown_backend_answers_with_the_known_ones(self):
+        got = imageto3d.available("not-a-backend")
+        assert got["available"] is False
+        assert "tripo" in got["reason"] and "comfy" in got["reason"]
+
+    def test_there_is_no_default_backend(self):
+        """Picking one silently would be a licence decision made for a
+        stranger."""
+        assert imageto3d.DEFAULT_BACKEND == ""
+
+
+class TestGpuProbe:
+    def test_it_never_imports_torch_anywhere_at_any_depth(self):
+        """The rule the whole optional-capability design rests on.
+
+        Checked against the AST rather than the text, because the module talks
+        ABOUT not importing torch in a comment and a substring search would
+        match its own warning. Nested imports count: a lazy `import torch`
+        inside a function is still an import this process must never do.
+
+        MEASURED on the target box: torch was installed but CPU-only, so a torch
+        probe would have reported no GPU on a machine with a perfectly good one.
+        """
+        import ast
+
+        with open(imageto3d.__file__, encoding="utf-8") as handle:
+            tree = ast.parse(handle.read())
+        banned = {"torch", "torchvision", "diffusers", "transformers",
+                  "trimesh", "pytorch3d"}
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    assert alias.name.split(".")[0] not in banned, alias.name
+            elif isinstance(node, ast.ImportFrom):
+                assert (node.module or "").split(".")[0] not in banned, node.module
+
+    def test_it_parses_name_vram_and_driver(self, has_gpu):
+        card = imageto3d.gpu()
+        assert card["available"] is True
+        assert card["name"] == "NVIDIA GeForce RTX 3060"
+        assert card["vram_gb"] == 12.0
+        assert card["driver"] == "595.95"
+
+    def test_the_result_is_cached_so_a_poll_is_not_a_process_per_call(self, monkeypatch):
+        calls = {"n": 0}
+
+        def fake(*a, **k):
+            calls["n"] += 1
+            return subprocess.CompletedProcess([], 0, stdout="GPU, 8192 MiB, 1\n",
+                                               stderr="")
+        monkeypatch.setattr(imageto3d.subprocess, "run", fake)
+        monkeypatch.setattr(imageto3d, "_gpu_cache", None, raising=False)
+        imageto3d.gpu()
+        imageto3d.gpu()
+        imageto3d.gpu()
+        assert calls["n"] == 1
+        imageto3d.gpu(refresh=True)
+        assert calls["n"] == 2
+
+    def test_a_small_card_is_reported_with_the_number_not_just_refused(self, monkeypatch):
+        monkeypatch.setattr(imageto3d.subprocess, "run", lambda *a, **k:
+                            subprocess.CompletedProcess([], 0,
+                                                        stdout="GTX 1050, 4096 MiB, 500\n",
+                                                        stderr=""))
+        monkeypatch.setattr(imageto3d, "_gpu_cache", None, raising=False)
+        card = imageto3d.gpu()
+        assert card["vram_gb"] == 4.0
+        assert "4.0 GB" in card["reason"]
+
+    def test_fits_vram_does_not_pass_an_unknown_requirement_off_as_a_check(self, has_gpu):
+        got = imageto3d.fits_vram(None)
+        assert got["ok"] is True
+        assert "not checked" in got["reason"]
+
+    def test_fits_vram_refuses_when_the_number_does_not_fit(self, has_gpu):
+        got = imageto3d.fits_vram(21.0)          # hunyuan textured on a 12 GB card
+        assert got["ok"] is False
+        assert "21.0" in got["reason"] and "12.0" in got["reason"]
+
+    def test_the_runner_interpreter_does_not_default_to_this_one(self):
+        """The opposite of transcribe.whisper_python, deliberately: faster-whisper
+        installs beside this tool and an inference stack does not."""
+        assert imageto3d.runner_python() == ""
+
+
+class TestDoctorRow:
+    def test_absent_is_shaped_like_every_other_doctor_row(self, no_gpu):
+        row = imageto3d.doctor_row()
+        assert set(row) == {"available", "path", "version", "min_required", "reason"}
+        assert row["available"] is False
+
+    def test_absent_says_it_is_optional(self, no_gpu):
+        """bgate doctor exits non-zero on any missing row, so a row that does
+        not say 'optional' reads as a broken install."""
+        assert "Optional" in imageto3d.doctor_row()["reason"]
+
+    def test_present_reports_the_card_and_no_reason(self, has_gpu):
+        row = imageto3d.doctor_row()
+        assert row["available"] is True
+        assert "RTX 3060" in row["path"]
+        assert "595.95" in row["version"]
+        assert row["reason"] == ""
+
+
+class TestPricing:
+    def test_a_local_backend_costs_nothing_and_says_so(self):
+        assert imageto3d.price_for("comfy") == 0.0
+        assert imageto3d.price_for("hunyuan-local") == 0.0
+
+    def test_tripo_prices_from_its_published_credit_rate(self):
+        """30 credits at $0.01 — both numbers off Tripo's own pricing table."""
+        assert imageto3d.credits_for("tripo") == 30
+        assert imageto3d.price_for("tripo") == 0.30
+
+    def test_the_price_follows_the_request_not_the_backend(self):
+        assert imageto3d.price_for("tripo", texture=False) == 0.20
+        assert imageto3d.price_for("tripo", quad=True) == 0.35
+        assert imageto3d.price_for("tripo", texture=False, quad=True) == 0.25
+        assert imageto3d.price_for("tripo", rig=True) == 0.55
+
+    def test_animations_are_per_clip(self):
+        assert imageto3d.price_for("tripo", animations=3) == 0.60
+
+    def test_stability_is_the_cheapest_hosted_option(self):
+        assert imageto3d.price_for("stability") == 0.10
+
+    def test_an_unpublished_rate_is_None_and_never_zero(self):
+        """The whole point. The spend gate treats a number as permission, so an
+        invented price is worse than a missing one."""
+        assert imageto3d.credits_for("meshy") == 30    # the credits ARE published
+        assert imageto3d.price_for("meshy") is None    # the dollar rate is not
+        assert imageto3d.price_for("rodin") is None
+
+    def test_a_missing_price_comes_with_the_reason(self):
+        assert "no per-credit dollar rate" in imageto3d.price_note("meshy")
+        assert "Business plan" in imageto3d.price_note("rodin")
+        assert imageto3d.price_note("tripo") == ""
+        assert imageto3d.price_note("comfy") == ""
+
+    def test_count_multiplies(self):
+        assert imageto3d.price_for("stability", count=4) == 0.40
+
+    def test_an_unknown_backend_raises_rather_than_quoting_a_default(self):
+        with pytest.raises(imageto3d.ImageTo3DError, match="unknown backend"):
+            imageto3d.price_for("who")
+
+
+class TestLicence:
+    def test_every_backend_declares_one(self):
+        for name, spec in imageto3d.BACKENDS.items():
+            licence = spec["licence"]
+            assert licence["code"] in (imageto3d.FREE, imageto3d.CONDITIONAL,
+                                       imageto3d.FORBIDDEN), name
+            assert licence["summary"], name
+
+    def test_only_unrestricted_licences_may_be_chosen_automatically(self):
+        assert imageto3d.AUTO_LICENCES == (imageto3d.FREE,)
+
+    def test_hunyuan_states_the_region_carve_out(self):
+        summary = imageto3d.BACKENDS["hunyuan-local"]["licence"]["summary"]
+        for region in ("European Union", "United Kingdom", "South Korea"):
+            assert region in summary
+        assert "1 million" in summary
+
+    def test_stability_does_not_inherit_the_community_licence_revenue_cap(self):
+        """The obvious mistake: the US$1M threshold governs SELF-HOSTING the
+        weights, not paying per credit for the hosted endpoint."""
+        licence = imageto3d.BACKENDS["stability"]["licence"]
+        assert licence["code"] == imageto3d.FREE
+        assert "no revenue threshold" in licence["summary"]
+
+    def test_comfy_admits_it_cannot_clear_the_licence_for_you(self):
+        """The graph decides which model runs, and the adapter cannot read it."""
+        licence = imageto3d.BACKENDS["comfy"]["licence"]
+        assert licence["code"] == imageto3d.CONDITIONAL
+        assert "cannot clear the licence" in licence["summary"]
+
+
+class TestModelLicence:
+    """A local backend is a TRANSPORT. ComfyUI is MIT; that says nothing about
+    the weights the graph loaded, and conflating the two always errs
+    permissively."""
+
+    def test_undeclared_is_conditional_not_permissive(self):
+        got = imageto3d.model_licence()
+        assert got["code"] == imageto3d.CONDITIONAL
+        assert imageto3d.MODEL_ENV in got["summary"]
+
+    def test_a_typo_is_not_permission(self):
+        assert imageto3d.model_licence("trelis")["code"] == imageto3d.CONDITIONAL
+
+    def test_the_mit_models_are_unrestricted(self):
+        for name in ("trellis", "trellis2", "triposr"):
+            assert imageto3d.model_licence(name)["code"] == imageto3d.FREE, name
+
+    def test_the_non_commercial_ones_are_marked_forbidden(self):
+        for name in ("partpacker", "zero123plus"):
+            assert imageto3d.model_licence(name)["code"] == imageto3d.FORBIDDEN, name
+
+    def test_hunyuan_carries_its_territory_clause_here_too(self):
+        summary = imageto3d.model_licence("hunyuan3d")["summary"]
+        assert "European Union" in summary and "South Korea" in summary
+
+    def test_stability_weights_carry_the_revenue_cap_the_hosted_api_does_not(self):
+        """The distinction that is easy to get backwards: self-hosting the
+        weights is capped at US$1M, paying per credit for the hosted endpoint is
+        not."""
+        assert imageto3d.model_licence("sf3d")["code"] == imageto3d.CONDITIONAL
+        assert "1,000,000" in imageto3d.model_licence("sf3d")["summary"]
+        assert imageto3d.BACKENDS["stability"]["licence"]["code"] == imageto3d.FREE
+
+    def test_declaring_the_model_resolves_the_backend_licence(self, monkeypatch, has_gpu):
+        monkeypatch.setenv(imageto3d.MODEL_ENV, "trellis2")
+        assert imageto3d.available("comfy")["licence"]["code"] == imageto3d.FREE
+        monkeypatch.setenv(imageto3d.MODEL_ENV, "hunyuan3d")
+        assert imageto3d.available("comfy")["licence"]["code"] == imageto3d.CONDITIONAL
+
+    def test_undeclared_leaves_the_backend_unclearable(self, has_gpu):
+        got = imageto3d.available("comfy")
+        assert got["licence"]["code"] == imageto3d.CONDITIONAL
+        assert "cannot clear the licence" in got["licence"]["summary"]
+
+
+class TestChoose:
+    def _reachable(self, monkeypatch, *names):
+        def fake(backend, root=None, *, probe=False):
+            spec = imageto3d.BACKENDS[backend]
+            return {"backend": backend, "kind": spec["kind"],
+                    "label": spec["label"], "licence": dict(spec["licence"]),
+                    "available": backend in names, "reason": "",
+                    "implemented": spec.get("implemented", True)}
+        monkeypatch.setattr(imageto3d, "available", fake)
+
+    def test_local_is_preferred_over_hosted(self, monkeypatch):
+        # comfy is conditional, so make the FREE-licensed hosted one reachable
+        # too and confirm the ranking is not what picks it.
+        self._reachable(monkeypatch, "comfy", "stability")
+        got = imageto3d.choose()
+        # comfy ranks first but is conditional, so stability wins on LICENCE.
+        assert got["backend"] == "stability"
+        assert got["candidates"][0] == "comfy"
+
+    def test_it_refuses_rather_than_pick_a_conditional_backend(self, monkeypatch):
+        self._reachable(monkeypatch, "comfy", "hunyuan-local", "tripo")
+        got = imageto3d.choose()
+        assert got["backend"] == ""
+        assert "conditional licence" in got["reason"]
+        # and it names them, so the caller can offer the choice
+        assert "hunyuan-local" in got["reason"]
+        assert set(got["candidates"]) == {"comfy", "hunyuan-local", "tripo"}
+
+    def test_nothing_reachable_falls_through_to_the_status_reason(self, monkeypatch, no_gpu):
+        self._reachable(monkeypatch)
+        got = imageto3d.choose()
+        assert got["backend"] == "" and got["candidates"] == []
+        assert got["reason"]
+
+
+class TestPayloadPerBackend:
+    def test_hunyuan_uses_its_own_field_names(self):
+        payload = imageto3d.build_payload(
+            "hunyuan-local", image="BASE64", texture=True, seed=7,
+            steps=30, guidance=5.5, octree_resolution=256, face_count=40000)
+        assert payload["image"] == "BASE64"
+        assert payload["texture"] is True
+        assert payload["num_inference_steps"] == 30
+        assert payload["guidance_scale"] == 5.5
+        assert payload["octree_resolution"] == 256
+        assert payload["face_count"] == 40000
+        assert payload["type"] == "glb"
+
+    def test_tripo_nests_the_plate_under_file_and_refuses_inline_bytes(self):
+        """Tripo does not accept a data URI. The two-hop upload is not optional
+        and skipping it is a 400."""
+        with pytest.raises(imageto3d.ImageTo3DError, match="file token"):
+            imageto3d.build_payload("tripo", image="data:image/png;base64,AA")
+        payload = imageto3d.build_payload("tripo", image_token="tok-1")
+        assert payload["file"] == {"type": "png", "file_token": "tok-1"}
+        assert payload["type"] == "image_to_model"
+        assert payload["model_version"] == "v2.5-20250123"
+
+    def test_meshy_takes_the_plate_inline_under_its_own_key(self):
+        payload = imageto3d.build_payload("meshy", image="data:image/png;base64,AA")
+        assert payload["image_url"].startswith("data:image/png")
+        assert payload["should_texture"] is True
+        assert payload["ai_model"] == "meshy-6"
+
+    def test_meshy_quad_is_an_enum_not_a_boolean(self):
+        """Every other backend takes a bool. Writing True into `topology` would
+        be a 400 that reads like a schema mystery."""
+        payload = imageto3d.build_payload("meshy", image="x", quad=True)
+        assert payload["topology"] == "quad"
+        assert "quad" not in payload
+
+    def test_meshy_turns_on_remesh_or_the_request_is_silently_ignored(self):
+        """should_remesh defaults FALSE on meshy-6, which makes topology and
+        target_polycount no-ops. A request that quietly does none of what was
+        asked is the failure this module exists not to have."""
+        assert imageto3d.build_payload(
+            "meshy", image="x", quad=True)["should_remesh"] is True
+        assert imageto3d.build_payload(
+            "meshy", image="x", face_count=20000)["should_remesh"] is True
+        assert "should_remesh" not in imageto3d.build_payload("meshy", image="x")
+
+    def test_the_polycount_has_four_different_names(self):
+        """face_count / face_limit / target_polycount / vertex_count, all
+        meaning roughly the same thing."""
+        assert "face_count" in imageto3d.build_payload(
+            "hunyuan-local", image="x", face_count=1000)
+        assert "face_limit" in imageto3d.build_payload(
+            "tripo", image_token="t", face_count=1000)
+        assert "target_polycount" in imageto3d.build_payload(
+            "meshy", image="x", face_count=1000)
+
+    def test_an_unsupported_option_is_refused_and_names_who_offers_it(self):
+        """pose_mode is Meshy's alone, and it is the most useful parameter here
+        — so asking for it elsewhere must point at Meshy, not fail silently."""
+        with pytest.raises(imageto3d.ImageTo3DError) as exc:
+            imageto3d.build_payload("hunyuan-local", image="x", pose="t-pose")
+        assert "meshy" in str(exc.value)
+
+    def test_an_unsupported_option_is_never_silently_dropped(self):
+        with pytest.raises(imageto3d.ImageTo3DError, match="pbr"):
+            imageto3d.build_payload("hunyuan-local", image="x", pbr=True)
+
+    def test_a_format_the_backend_cannot_produce_is_refused(self):
+        with pytest.raises(imageto3d.ImageTo3DError, match="does not return"):
+            imageto3d.build_payload("hunyuan-local", image="x", out_format="fbx")
+
+    def test_a_multipart_backend_is_not_built_this_way(self):
+        with pytest.raises(imageto3d.ImageTo3DError, match="multipart"):
+            imageto3d.build_payload("stability", image="x")
+
+    def test_a_workflow_backend_is_not_built_this_way_either(self):
+        with pytest.raises(imageto3d.ImageTo3DError, match="workflow graph"):
+            imageto3d.build_payload("comfy", image="x")
+
+    def test_no_option_leaks_between_backends(self):
+        """Each backend's payload contains only keys it declared."""
+        payload = imageto3d.build_payload("hunyuan-local", image="x", seed=1)
+        assert "model_version" not in payload
+        assert "ai_model" not in payload
+
+
+class TestComfyWorkflow:
+    def test_no_workflow_configured_explains_the_whole_setup(self):
+        with pytest.raises(imageto3d.ImageTo3DError) as exc:
+            imageto3d.build_comfy_prompt("plate.png")
+        message = str(exc.value)
+        assert "Save (API format)" in message
+        assert imageto3d.COMFY_IMAGE_TOKEN in message
+        assert "BGATE_COMFY_WORKFLOW" in message
+
+    def test_a_workflow_without_the_placeholder_is_refused(self, tmp_path):
+        wf = tmp_path / "wf.json"
+        wf.write_text(json.dumps({"1": {"class_type": "LoadImage",
+                                        "inputs": {"image": "baked-in.png"}}}))
+        with pytest.raises(imageto3d.ImageTo3DError, match="no .* placeholder"):
+            imageto3d.build_comfy_prompt("plate.png", workflow_path=str(wf))
+
+    def test_the_plate_and_seed_are_substituted(self, tmp_path):
+        wf = tmp_path / "wf.json"
+        wf.write_text(json.dumps({
+            "1": {"class_type": "LoadImage",
+                  "inputs": {"image": imageto3d.COMFY_IMAGE_TOKEN}},
+            "2": {"class_type": "Sampler",
+                  "inputs": {"seed": imageto3d.COMFY_SEED_TOKEN}},
+        }).replace(f'"{imageto3d.COMFY_SEED_TOKEN}"', imageto3d.COMFY_SEED_TOKEN))
+        body = imageto3d.build_comfy_prompt("plate.png", seed=42,
+                                            workflow_path=str(wf))
+        assert body["prompt"]["1"]["inputs"]["image"] == "plate.png"
+        assert body["prompt"]["2"]["inputs"]["seed"] == 42
+        assert body["client_id"] == "builders-gate"
+
+    def test_a_missing_workflow_file_says_which_one(self, tmp_path):
+        with pytest.raises(imageto3d.ImageTo3DError, match="does not exist"):
+            imageto3d.build_comfy_prompt("p.png",
+                                         workflow_path=str(tmp_path / "gone.json"))
+
+    def test_outputs_are_found_by_suffix_not_by_node_class(self):
+        """3D-Pack renames its saver nodes between releases, so keying on one
+        would break on somebody else's upgrade."""
+        history = {"job-1": {"outputs": {
+            "9": {"images": [{"filename": "preview.png", "subfolder": "",
+                              "type": "output"}]},
+            "12": {"result": [{"filename": "hero.glb", "subfolder": "3d",
+                               "type": "output"}]},
+        }}}
+        found = imageto3d._comfy_outputs(history, "job-1")
+        assert [f["filename"] for f in found] == ["hero.glb"]
+        assert found[0]["subfolder"] == "3d"
+
+    def test_a_run_that_saved_nothing_usable_finds_nothing(self):
+        history = {"j": {"outputs": {"1": {"images": [{"filename": "a.png"}]}}}}
+        assert imageto3d._comfy_outputs(history, "j") == []
+
+
+class TestInputPlate:
+    def test_a_missing_plate_is_refused_before_anything_is_generated(self, tmp_path):
+        got = imageto3d.check_input(tmp_path / "nope.png")
+        assert got["ok"] is False and "no such image" in got["reason"]
+
+    def test_an_unsupported_type_names_the_ones_that_work(self, tmp_path):
+        f = tmp_path / "plate.tga"
+        f.write_bytes(b"x")
+        got = imageto3d.check_input(f)
+        assert got["ok"] is False
+        assert "png" in got["reason"] and "webp" in got["reason"]
+
+    def test_bare_base64_and_a_data_uri_are_not_the_same_thing(self, plate):
+        """Sending one where the other is expected is a decode error on the
+        server, which surfaces as a useless 500."""
+        assert imageto3d.data_uri(plate).startswith("data:image/png;base64,")
+        bare = imageto3d.image_b64(plate)
+        assert not bare.startswith("data:")
+        assert base64.b64decode(bare) == plate.read_bytes()
+
+    def test_a_missing_file_raises_from_both_encoders(self, tmp_path):
+        for call in (imageto3d.data_uri, imageto3d.image_b64):
+            with pytest.raises(imageto3d.ImageTo3DError, match="not found"):
+                call(tmp_path / "gone.png")
+
+
+class TestErrors:
+    def _http(self, monkeypatch, code, body=b"{}"):
+        def boom(*a, **k):
+            raise urllib.error.HTTPError("u", code, "err", {}, None)
+        monkeypatch.setattr(imageto3d.urllib.request, "urlopen", boom)
+
+    def test_401_points_at_the_key_by_name(self, monkeypatch):
+        self._http(monkeypatch, 401)
+        with pytest.raises(imageto3d.ImageTo3DError, match="TRIPO_API_KEY"):
+            imageto3d._request("tripo", "/task", "k", payload={}, method="POST")
+
+    def test_402_explains_the_balance_rather_than_the_code(self, monkeypatch):
+        self._http(monkeypatch, 402)
+        with pytest.raises(imageto3d.ImageTo3DError, match="no credit"):
+            imageto3d._request("meshy", "/image-to-3d", "k", payload={},
+                               method="POST")
+
+    def test_429_says_to_slow_the_fan_out(self, monkeypatch):
+        self._http(monkeypatch, 429)
+        with pytest.raises(imageto3d.ImageTo3DError, match="rate-limited"):
+            imageto3d._request("meshy", "/x", "k")
+
+    def test_400_says_schemas_are_per_backend(self, monkeypatch):
+        self._http(monkeypatch, 400)
+        with pytest.raises(imageto3d.ImageTo3DError, match="own schema"):
+            imageto3d._request("tripo", "/task", "k", payload={}, method="POST")
+
+    def test_a_local_404_says_the_wrong_thing_is_running(self, monkeypatch):
+        """A hosted 404 is a bug; a local one almost always means the port
+        belongs to some other server."""
+        self._http(monkeypatch, 404)
+        with pytest.raises(imageto3d.ImageTo3DError, match="not the server"):
+            imageto3d._request("hunyuan-local", "/send", "", payload={},
+                               method="POST")
+
+    def test_unreachable_local_says_start_it_not_check_your_key(self, monkeypatch):
+        def boom(*a, **k):
+            raise urllib.error.URLError("connection refused")
+        monkeypatch.setattr(imageto3d.urllib.request, "urlopen", boom)
+        with pytest.raises(imageto3d.ImageTo3DError) as exc:
+            imageto3d._request("hunyuan-local", "/send", "", payload={},
+                               method="POST")
+        assert "is the server running" in str(exc.value)
+        assert "BGATE_HUNYUAN3D_URL" in str(exc.value)
+
+    def test_unreachable_hosted_does_not_talk_about_starting_a_server(self, monkeypatch):
+        def boom(*a, **k):
+            raise urllib.error.URLError("dns")
+        monkeypatch.setattr(imageto3d.urllib.request, "urlopen", boom)
+        with pytest.raises(imageto3d.ImageTo3DError) as exc:
+            imageto3d._request("tripo", "/task", "k", payload={}, method="POST")
+        assert "server running" not in str(exc.value)
+
+    def test_a_non_json_response_is_named_as_such(self, monkeypatch):
+        class Resp:
+            def read(self):
+                return b"<html>nope</html>"
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+        monkeypatch.setattr(imageto3d.urllib.request, "urlopen",
+                            lambda *a, **k: Resp())
+        with pytest.raises(imageto3d.ImageTo3DError, match="non-JSON"):
+            imageto3d._request("meshy", "/x", "k")
+
+
+class TestSubmitGuards:
+    def test_a_documented_but_unwired_backend_refuses_up_front(self, plate):
+        with pytest.raises(imageto3d.ImageTo3DError, match="not wired"):
+            imageto3d.submit("rodin", plate)
+
+    def test_a_bad_plate_is_refused_before_any_call(self, tmp_path):
+        with pytest.raises(imageto3d.ImageTo3DError, match="no such image"):
+            imageto3d.submit("meshy", tmp_path / "gone.png")
+
+    def test_a_hosted_backend_with_no_key_refuses_before_any_call(self, plate):
+        with pytest.raises(imageto3d.ImageTo3DError, match="MESHY_API_KEY"):
+            imageto3d.submit("meshy", plate)
+
+    def test_poll_refuses_on_a_synchronous_backend(self):
+        with pytest.raises(imageto3d.ImageTo3DError, match="synchronous"):
+            imageto3d.poll("stability", "t")
+
+
+class TestResultShape:
+    """The result must not make a caller branch on where the geometry came
+    from, and must never let a draft be mistaken for an asset."""
+
+    def test_a_failed_generation_is_a_result_not_an_exception(self, tmp_path, no_gpu):
+        got = imageto3d.generate(tmp_path / "gone.png", tmp_path / "out.glb",
+                                 backend="meshy")
+        assert got["ok"] is False
+        assert got["stage"] == "input"
+        assert "no such image" in got["error"]
+
+    def test_it_carries_the_keys_the_pipeline_reads(self, tmp_path, no_gpu):
+        got = imageto3d.generate(tmp_path / "gone.png", tmp_path / "out.glb",
+                                 backend="tripo")
+        assert set(got) >= {"ok", "path", "bytes", "backend", "kind", "seconds",
+                            "estimated_usd", "checks", "warnings", "notes",
+                            "licence", "draft", "textured", "rigged", "stage"}
+
+    def test_the_quote_is_on_the_result_before_anything_is_spent(self, tmp_path, no_gpu):
+        got = imageto3d.generate(tmp_path / "gone.png", tmp_path / "o.glb",
+                                 backend="tripo")
+        assert got["estimated_usd"] == 0.30
+
+    def test_an_unpriceable_backend_carries_None_and_the_reason(self, tmp_path, no_gpu):
+        got = imageto3d.generate(tmp_path / "gone.png", tmp_path / "o.glb",
+                                 backend="meshy")
+        assert got["estimated_usd"] is None
+        assert any("per-credit" in w for w in got["warnings"])
+
+    def test_choosing_nothing_is_reported_at_the_choose_stage(self, tmp_path, no_gpu):
+        got = imageto3d.generate(tmp_path / "a.png", tmp_path / "o.glb")
+        assert got["ok"] is False
+        assert got["stage"] == "choose"
+
+    def test_a_draft_is_labelled_a_draft(self):
+        """Nothing downstream may treat this as a finished asset — the whole
+        reason the harness exists."""
+        blank = imageto3d._result("tripo")
+        assert blank["draft"] is True
+        assert blank["rigged"] is False
+
+    def test_the_next_steps_name_the_conventions_by_number(self):
+        joined = " ".join(imageto3d.NEXT_STEPS)
+        assert "+Y" in joined          # facing, decided 2026-07-30
+        assert "1.8" in joined         # metres, the canonical humanoid
+        assert "bgate_rig_repair" in joined
+        assert "blender_combine" in joined
+
+
+class TestBackendTable:
+    def test_local_backends_come_first(self):
+        assert imageto3d.LOCAL[0] == "comfy"
+        assert set(imageto3d.LOCAL) & set(imageto3d.HOSTED) == set()
+
+    def test_no_local_backend_needs_a_key(self):
+        for name in imageto3d.LOCAL:
+            assert imageto3d.BACKENDS[name]["env"] == ""
+
+    def test_every_local_backend_says_what_it_needs_and_where_weights_live(self):
+        for name in imageto3d.LOCAL:
+            spec = imageto3d.BACKENDS[name]
+            assert spec["weights"], name
+            assert spec["windows"], name
+
+    def test_no_hosted_backend_claims_a_vram_requirement(self):
+        for name in imageto3d.HOSTED:
+            assert imageto3d.BACKENDS[name].get("vram_gb") is None
+
+    def test_the_five_minute_url_is_recorded_where_it_bites(self):
+        """Tripo expires a finished-model URL in five minutes, which is why
+        generate() downloads inside the polling loop."""
+        assert imageto3d.BACKENDS["tripo"]["url_ttl_s"] == 300
+        assert imageto3d.BACKENDS["meshy"]["url_ttl_s"] == 259200
+
+    def test_supports_is_asked_before_pricing_not_after(self):
+        assert imageto3d.supports("meshy", "pose") is True
+        assert imageto3d.supports("hunyuan-local", "pose") is False
+        assert imageto3d.supports("tripo", "rig") is True
+
+    def test_capabilities_answers_without_a_network(self):
+        got = imageto3d.capabilities("hunyuan-local")
+        assert got["kind"] == "local"
+        assert got["vram_gb"] == 16.0          # 2.0 with texture
+        assert got["async"] is True
+        assert got["licence"]["code"] == imageto3d.CONDITIONAL
+
+    def test_hunyuan_advertises_glb_only_because_of_a_server_bug(self):
+        """The /status route hardcodes a .glb filename while the worker writes
+        <uid>.<type>, so asking for obj polls for a file that never appears."""
+        assert imageto3d.BACKENDS["hunyuan-local"]["formats"] == ("glb",)
+
+    def test_the_shape_only_figure_is_recorded_separately(self):
+        """On a 12 GB card the supported Hunyuan configuration is shape-only,
+        and the two numbers have to be distinguishable to say so."""
+        spec = imageto3d.BACKENDS["hunyuan-local"]
+        assert spec["vram_gb_shape_only"] == 6.0
+        assert spec["vram_gb"] > spec["vram_gb_shape_only"]
+
+    def test_the_synchronous_local_backend_has_nothing_to_poll(self):
+        assert imageto3d.BACKENDS["trellis-cpp"]["poll_path"] == ""
+        assert imageto3d.capabilities("trellis-cpp")["async"] is False
+
+    def test_an_undeclared_licence_is_not_treated_as_permissive(self):
+        """trellis.cpp ships no LICENSE file. Absence is all-rights-reserved,
+        which is a worse position than an explicit restriction — there is
+        nothing to read."""
+        licence = imageto3d.BACKENDS["trellis-cpp"]["licence"]
+        assert licence["code"] == imageto3d.CONDITIONAL
+        assert "no declared licence" in licence["summary"].lower()
+
+    def test_comfy_talks_to_the_api_prefixed_routes(self):
+        """ComfyUI registers every route twice; the /api form does not share a
+        namespace with the web UI's own SPA routing."""
+        spec = imageto3d.BACKENDS["comfy"]
+        for key in ("submit_path", "poll_path", "health_path", "upload_path",
+                    "view_path"):
+            assert spec[key].startswith("/api/"), key

--- a/tests/test_krea_3d.py
+++ b/tests/test_krea_3d.py
@@ -1,0 +1,282 @@
+"""Krea's 3D models, offline.
+
+Same discipline as test_krea.py — the transport is stubbed and what is pinned
+is the per-model request schema, because each 3D model takes a different set of
+knobs and sending the wrong one is a 422 rather than a default.
+
+Two things here are not like the image path and both have their own class
+below. Krea publishes NO per-generation price for any 3D model, so a call
+cannot be quoted before it runs; that has to surface as None and a refusal to
+spend, never as 0.0, which every budget check in the product would read as
+free. And an unsupported parameter must be REFUSED rather than dropped: a
+caller who asks for a decimation target on a model that has none would
+otherwise pay for a generation and get back the fragmented mesh they were
+trying to avoid, with nothing saying why.
+
+Endpoint paths are pinned verbatim. They were read off the API reference one
+page at a time after two rounds of guessing wrong about what Krea's 3D API
+even was, and a typo in a vendor prefix is a 404 nobody would attribute to
+this file.
+"""
+from __future__ import annotations
+
+import pytest
+
+from bgate_adapters import krea
+
+
+@pytest.fixture()
+def captured(monkeypatch):
+    """Swallow the HTTP call and hand back what would have been sent."""
+    seen: dict = {}
+
+    def fake(path, key, *, payload=None, method="GET", timeout=60.0):
+        seen["path"], seen["payload"], seen["method"] = path, payload, method
+        return {"job_id": "job-3d", "status": "queued"}
+
+    monkeypatch.setattr(krea, "_request", fake)
+    monkeypatch.setenv("KREA_API_KEY", "test-key")
+    return seen
+
+
+class TestTheCatalogue:
+    @pytest.mark.parametrize("model,path", [
+        ("trellis-2", "/generate/3d/microsoft/trellis-2"),
+        ("trellis", "/generate/3d/microsoft/trellis"),
+        ("tripo", "/generate/3d/tripo/tripo"),
+        ("hunyuan3d-2.1", "/generate/3d/tencent/hunyuan3d-2.1"),
+        ("hunyuan3d-3.1-pro", "/generate/3d/tencent/hunyuan3d-3.1-pro"),
+    ])
+    def test_the_endpoint_paths_are_the_documented_ones(self, model, path):
+        """Vendor prefixes differ per model and a wrong one is a 404 that reads
+        like an outage. microsoft/, tripo/ and tencent/ are not guessable."""
+        assert krea.MODELS_3D[model]["path"] == path
+
+    def test_models_3d_hides_the_supports_set(self):
+        """It is a catalogue for a caller choosing a model, not the validator's
+        working state."""
+        listed = krea.models_3d()
+        assert set(listed) == set(krea.MODELS_3D)
+        assert all("supports" not in spec for spec in listed.values())
+        assert all(spec.get("note") for spec in listed.values())
+
+    def test_the_default_is_the_one_with_a_decimation_target(self):
+        spec = krea.MODELS_3D[krea.DEFAULT_MODEL_3D]
+        assert "decimation_target" in spec["supports"]
+
+
+class TestPriceIsUnknownNotFree:
+    def test_a_price_is_measured_or_it_is_none_but_never_zero(self):
+        """0.0 would read as free in every budget check in the product. Krea
+        publishes no 3D price, so a number here comes from a real invoice or it
+        does not exist."""
+        for model in krea.MODELS_3D:
+            got = krea.price_for_3d(model)
+            assert got is None or got > 0, (model, got)
+
+    def test_trellis_2_carries_the_price_that_was_actually_invoiced(self):
+        """Measured 2026-07-31: two text-to-3D jobs at default parameters
+        billed $0.30 each on Krea's usage page. Pinned so it cannot drift back
+        to a guess, and marked with what was measured — nothing is known about
+        how resolution or decimation move it."""
+        assert krea.price_for_3d("trellis-2") == 0.30
+        assert krea.MODELS_3D["trellis-2"]["usd_measured"]
+
+    def test_an_unknown_model_is_named_rather_than_priced(self):
+        with pytest.raises(krea.KreaError) as err:
+            krea.price_for_3d("trellis-3")
+        assert "trellis-3" in str(err.value)
+
+    def test_an_unpriced_model_will_not_spend_without_being_told_to(self, captured):
+        """The gate fires before the request, so nothing is charged."""
+        got = krea.generate_3d("out.glb", images=["plate.png"], model="tripo")
+        assert got["ok"] is False
+        assert got["estimated_usd"] is None
+        assert "confirm_unpriced" in got["error"]
+        assert not captured, "the gate let a request through"
+
+    def test_a_measured_model_quotes_itself_and_needs_no_ceremony(self, captured):
+        """The gate is for an unknown price, not for spending. trellis-2 has
+        been invoiced, so it behaves like every other paid call."""
+        krea.submit_3d("a crate", model="trellis-2")
+        assert captured, "a priced model should not be gated"
+
+    def test_the_refusal_says_compute_tokens_are_the_wrong_meter(self, captured):
+        """Krea's user guide quotes compute tokens; those are the web app's
+        subscription currency, not the API's USD balance. Somebody reading the
+        wrong page is exactly how this got mis-stated in the first place."""
+        got = krea.generate_3d("out.glb", images=["plate.png"], model="tripo")
+        assert "web app" in got["price_note"]
+
+    def test_a_failed_generation_still_reports_unknown_not_zero(self, monkeypatch):
+        monkeypatch.setenv("KREA_API_KEY", "test-key")
+
+        def boom(*a, **k):
+            raise krea.KreaError("Krea job failed: out of capacity")
+
+        monkeypatch.setattr(krea, "submit_3d", boom)
+        got = krea.generate_3d("out.glb", images=["p.png"], model="tripo",
+                               confirm_unpriced=True)
+        assert got["ok"] is False
+        assert got["estimated_usd"] is None
+
+
+class TestUnsupportedParametersAreRefusedNotDropped:
+    def test_a_knob_the_model_lacks_is_refused_and_names_who_has_it(self, captured):
+        """Dropping it would send the request, charge for it, and return the
+        default — the fragmented mesh the caller was trying to avoid."""
+        with pytest.raises(krea.KreaError) as err:
+            krea.submit_3d("a crate", model="tripo", decimation_target=500_000)
+        message = str(err.value)
+        assert "tripo does not take decimation_target" in message
+        assert "trellis-2" in message, "should name a model that does"
+        assert not captured
+
+    def test_face_count_belongs_to_hunyuan_not_trellis(self, captured):
+        with pytest.raises(krea.KreaError):
+            krea.submit_3d("a crate", model="trellis-2", face_count=100_000)
+        assert not captured
+
+    def test_pbr_belongs_to_hunyuan_pro_only(self, captured):
+        with pytest.raises(krea.KreaError):
+            krea.submit_3d("a crate", model="tripo", enable_pbr=True)
+        assert not captured
+
+    @pytest.mark.parametrize("field,value", [
+        ("resolution", "999"),
+        ("texture_size", "8192"),
+    ])
+    def test_an_out_of_enum_value_is_refused_with_the_allowed_list(
+            self, captured, field, value):
+        with pytest.raises(krea.KreaError) as err:
+            krea.submit_3d("a crate", model="trellis-2", **{field: value})
+        assert "not one of" in str(err.value)
+        assert not captured
+
+    @pytest.mark.parametrize("model,field,value", [
+        ("trellis-2", "decimation_target", 50),
+        ("trellis-2", "decimation_target", 9_000_000),
+        ("hunyuan3d-3.1-pro", "face_count", 10),
+        ("hunyuan3d-3.1-pro", "face_count", 9_000_000),
+    ])
+    def test_a_range_is_a_range(self, captured, model, field, value):
+        with pytest.raises(krea.KreaError) as err:
+            krea.submit_3d("a crate", model=model, **{field: value})
+        assert "must be" in str(err.value)
+        assert not captured
+
+    def test_the_valid_combination_actually_goes_through(self, captured):
+        krea.submit_3d("a crate", model="hunyuan3d-3.1-pro", face_count=200_000,
+                       enable_pbr=True)
+        assert captured["payload"]["face_count"] == 200_000
+        assert captured["payload"]["enable_pbr"] is True
+
+    def test_shape_is_checked_before_the_key(self, monkeypatch):
+        """A bad parameter must not be answered with "KREA_API_KEY not set".
+        That names the wrong problem, and it would make every refusal above
+        untestable without a live key."""
+        monkeypatch.delenv("KREA_API_KEY", raising=False)
+        monkeypatch.setattr(krea, "api_key", lambda root=None: "")
+        with pytest.raises(krea.KreaError) as err:
+            krea.submit_3d("a crate", model="tripo", enable_pbr=True)
+        assert "does not take enable_pbr" in str(err.value)
+
+
+class TestPayloadShape:
+    def test_an_image_sets_image_mode(self, captured, tmp_path):
+        plate = tmp_path / "plate.png"
+        plate.write_bytes(b"\x89PNG\r\n\x1a\n" + b"0" * 32)
+        krea.submit_3d("", model="tripo", images=[plate])
+        assert captured["payload"]["input_mode"] == "image"
+        assert captured["payload"]["image_urls"][0].startswith("data:")
+
+    def test_no_image_means_text_to_3d(self, captured):
+        krea.submit_3d("a wooden crate", model="tripo")
+        assert captured["payload"]["input_mode"] == "text"
+        assert "image_urls" not in captured["payload"]
+
+    def test_a_url_is_passed_through_rather_than_read_from_disk(self, captured):
+        krea.submit_3d("", model="tripo", images=["https://example.com/a.png"])
+        assert captured["payload"]["image_urls"] == ["https://example.com/a.png"]
+
+    def test_neither_an_image_nor_a_prompt_is_refused(self, captured):
+        with pytest.raises(krea.KreaError) as err:
+            krea.submit_3d("", model="tripo")
+        assert "got neither" in str(err.value)
+        assert not captured
+
+    def test_extra_views_become_their_url_fields(self, captured):
+        """Multi-view is how a back nobody photographed stops being invented,
+        and the caller should not have to remember the _image_url suffix."""
+        krea.submit_3d("", model="hunyuan3d-3.1-pro",
+                       images=["https://example.com/front.png"],
+                       views={"back": "https://example.com/back.png",
+                              "left_image_url": "https://example.com/left.png"})
+        assert captured["payload"]["back_image_url"].endswith("back.png")
+        assert captured["payload"]["left_image_url"].endswith("left.png")
+
+    def test_views_are_refused_on_a_single_view_model(self, captured):
+        with pytest.raises(krea.KreaError):
+            krea.submit_3d("", model="trellis-2",
+                           images=["https://example.com/f.png"],
+                           views={"back": "https://example.com/b.png"})
+        assert not captured
+
+    def test_texture_can_be_turned_off(self, captured):
+        krea.submit_3d("a crate", model="tripo", generate_texture=False)
+        assert captured["payload"]["generate_texture"] is False
+
+
+class TestTheResultIsADraft:
+    def _completed(self, monkeypatch, result):
+        monkeypatch.setenv("KREA_API_KEY", "test-key")
+        monkeypatch.setattr(krea, "submit_3d",
+                            lambda *a, **k: {"job_id": "job-3d"})
+        monkeypatch.setattr(krea, "poll",
+                            lambda *a, **k: {"status": "completed",
+                                             "result": result})
+        monkeypatch.setattr(krea, "download", lambda url, out, **k: 4096)
+
+    def test_a_finished_generation_says_it_is_not_an_asset_yet(
+            self, monkeypatch, tmp_path):
+        """Geometry and texture, no rig, no unit convention, no guaranteed
+        pose. Anything that reads this as finished ships a statue."""
+        self._completed(monkeypatch, {"urls": ["https://example.com/m.glb"]})
+        got = krea.generate_3d(str(tmp_path / "m.glb"), images=["p.png"],
+                               confirm_unpriced=True)
+        assert got["ok"] is True
+        assert got["draft"] is True
+        assert got["estimated_usd"] == 0.30
+        assert got["next_steps"]
+
+    def test_an_undocumented_result_field_is_found_rather_than_crashed_on(
+            self, monkeypatch, tmp_path):
+        """The 3D job schema does not publish its completed body. urls[] is the
+        documented shape on the image path; fall back by name instead of
+        raising KeyError on a field nobody has seen."""
+        self._completed(monkeypatch, {"model_url": "https://example.com/m.glb"})
+        got = krea.generate_3d(str(tmp_path / "m.glb"), images=["p.png"],
+                               confirm_unpriced=True)
+        assert got["ok"] is True
+        assert got["url"].endswith(".glb")
+
+    def test_completed_with_no_model_url_quotes_the_body(
+            self, monkeypatch, tmp_path):
+        self._completed(monkeypatch, {"nothing_useful": 1})
+        got = krea.generate_3d(str(tmp_path / "m.glb"), images=["p.png"],
+                               confirm_unpriced=True)
+        assert got["ok"] is False
+        assert "nothing_useful" in got["error"]
+
+
+class TestTheImagePathIsUntouched:
+    def test_download_still_defaults_to_accepting_images(self):
+        """`accept` was added for .glb. Every existing image caller passes
+        nothing, so the default has to stay what it was."""
+        import inspect
+        assert inspect.signature(krea.download).parameters["accept"].default == "image/*"
+
+    def test_the_2d_model_table_did_not_gain_3d_entries(self):
+        assert not set(krea.MODELS) & set(krea.MODELS_3D)
+        assert all("/generate/3d/" not in spec["path"]
+                   for spec in krea.MODELS.values())


### PR DESCRIPTION
## What and why

The 3D path modelled from primitives, and the ceiling of that is a blockout: a correctly-proportioned mannequin with paddle arms, mitten hands and no face — which every gate reported green, because the gates measure well-formedness and not resemblance. Meanwhile the 2D path is the strongest thing in the product and terminated in a PNG. A real user drove an excellent stylised character through it and believed they had a 3D model. They did not.

**Local first, and that is the point.** Everything else here is local — loopback dashboard, SQLite state, `.env` at the game project root, no Docker — and renting a mesh generator would have been the one place that stopped being true. The primary backends are open-weight models on the user's own GPU over loopback HTTP: TRELLIS.cpp, ComfyUI with a 3D node pack, Hunyuan3D. The hosted APIs (Stability, Tripo, Meshy) sit behind the same interface as a fallback and a comparison baseline, not as the design centre. Krea 3D runs the same open-weight models behind the `KREA_API_KEY` that was already configured, for anyone who wants none of the GPU.

Four rules `imageto3d.py` owes its callers, in the order they bite:

- **It imports nothing heavy.** No torch, no CUDA, no model library, ever, in this process. The GPU is probed with `nvidia-smi`, a local server with a short HTTP GET — the rule `transcribe.py` established for faster-whisper, for the same reason: the MCP server must not host an inference stack, and a user with no GPU must be completely unaffected. `BGATE_IMAGETO3D_PYTHON` is never defaulted to `sys.executable`, because the interpreter running Builders Gate may well carry a CPU-only torch.
- **It works with nothing configured.** `status()` reports every backend and why each is or is not usable. No key read at import, no server contacted at import.
- **It prices a request, not a backend.** Locally the price is zero and saying so is the honest answer. Hosted, texture/PBR/rigging/quad-remesh are billed separately, so quoting the backend name under-quotes what the art seat actually asks for.
- **It states the licence before it generates.** A local backend is a transport — ComfyUI being MIT says nothing about the weights it loads — so `BGATE_LOCAL_MODEL` must be declared, undeclared resolves to "licence unknown", and a backend whose terms carry conditions never becomes an automatic choice. `partpacker` is non-commercial outright.

**A generation is not an asset, so `bg_adopt` makes it one.** Measured on real output: a crate came back as 20,748 shells and 495,061 triangles, a mannequin as 604 shells with 21,796 non-manifold edges. Weld, decimate, scale, orient, ground — in that order, because grounding before scaling leaves the mesh floating by whatever the scale factor was. Welding is gentle on purpose: chasing one shell took the mannequin to 20,285 non-manifold edges, after which the decimator could not reach budget at all, since collapse will not cross a non-manifold junction. And it reports asked/got/met with a reason rather than returning a mesh 50× over budget under an ok-looking report.

**Orientation is refused rather than guessed.** Generated meshes face any direction and nothing was checking — the mannequin rendered its BACK in the frame labelled "front", and facing is invisible in a symmetric silhouette until everything downstream is quietly mirrored. Two wrong attempts are kept in the commit because the corrections are the design: "up is the tallest axis" put a cap's up along its brim, and centroid offset scored a mannequin and a crate within 0.1% of each other. Foot reach gives 1.34× against 1.05× and 1.11×. `kind="none"` and unreadable geometry both leave the mesh untouched.

What comes back is a **draft mesh**, and there is deliberately no path from here to `godot_deliver_asset`: unpredictable topology, no armature, no scale convention, no orientation guarantee, possibly the background baked in as geometry. It enters at the draft stage and goes through the same conditioning and the same gates as anything modelled by hand. Builders Gate is the harness that turns an inconsistent generated mesh into an inspected asset; it is not trying to be the best raw generator.

Also here: `doctor` gains an `imageto3d` row with no floor, asking `nvidia-smi` rather than torch — a CPU-only torch in the default interpreter would call a working RTX 3060 "no GPU". `spend` gains a `mesh` kind, because it was landing in `other` with genuinely uncategorised spend and a textured generation is ~$0.30, an order of magnitude over an image. And a bare `Path` at `server.py:1376` where the module imports it as `_Path` — a live `NameError` on the local mesh path whenever a generation registered its artifact, caught by the `ruff` gate added last cycle.

## Verification

- [x] `python -m pytest -m "not slow" -q` passes locally — Windows **3056 passed, 4 skipped**; Linux **2813 passed, 247 skipped**
- [x] New behaviour has a test — 94 in `tests/test_imageto3d.py`, plus `test_krea_3d.py` and `test_blender_adopt.py`
- [x] If this touches anything the wheel ships — it touches none of `bgate_ui/static/`, `templates/` or `bgate_engine/schemas/`, and `test_packaging.py` (17 passed) was re-run after the version bump, since that reads `pyproject`
- [x] Docs updated where they would otherwise become false — `.env.example` gains the local-3D block (every URL, the separate interpreter, the licence declaration); `CHANGELOG.md` gains `## [1.3.0]`

Release guard checked directly: `v1.3.0 == pyproject 1.3.0 == CHANGELOG [1.3.0]`, and `v0.1.29` now correctly rejected against this tree. `ruff check .` clean.

Platform tested on: Windows 11 / Python 3.13.14, and Linux (WSL Ubuntu) / Python 3.12.3. CI covers 3.11 and 3.12.
