### PR TITLE
chore: version 0.1.30, not 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,13 @@ repository at first publication. There is no earlier release history to record.
 
 ## [Unreleased]
 
-## [1.3.0] - 2026-07-31
+## [0.1.30] - 2026-07-31
 
-The version jumps from `0.1.29` because the 3D path stopped being a blockout
-generator. Everything below `### Added — 3D` is the difference between "a
-correctly-proportioned mannequin with paddle arms and no face" and a generated
-mesh that survives the same gates as one modelled by hand.
+The 3D path stops being a blockout generator. Everything below `### Added — 3D`
+is the difference between "a correctly-proportioned mannequin with paddle arms
+and no face" and a generated mesh that survives the same gates as one modelled
+by hand. It stays on the `0.x` line: the design is still moving, which is what
+`CONTRIBUTING.md` tells contributors and what the version should keep saying.
 
 ### Added — 3D
 
@@ -805,8 +806,8 @@ version.
 - The audio seat workspace is a deliberate v1 (library, playback, cue sheet).
 - The dashboard's error surfacing is uneven; see `docs/ui-ux-audit.md`.
 
-[Unreleased]: https://github.com/Thepizzapie/BuildersGate/compare/v1.3.0...HEAD
-[1.3.0]: https://github.com/Thepizzapie/BuildersGate/compare/v0.1.29...v1.3.0
+[Unreleased]: https://github.com/Thepizzapie/BuildersGate/compare/v0.1.30...HEAD
+[0.1.30]: https://github.com/Thepizzapie/BuildersGate/compare/v0.1.29...v0.1.30
 [0.1.29]: https://github.com/Thepizzapie/BuildersGate/compare/v0.1.28...v0.1.29
 [0.1.28]: https://github.com/Thepizzapie/BuildersGate/compare/v0.1.27...v0.1.28
 [0.1.27]: https://github.com/Thepizzapie/BuildersGate/compare/v0.1.26...v0.1.27

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "builders-gate"
-version = "1.3.0"
+version = "0.1.30"
 description = "Agentic game development pipeline — design bible, lore canon, and DCC/engine adapters over MCP."
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
The tag was wrong. 0.1.29 was the previous release and nothing here justifies a major-version jump — the 3D work is substantial but the design is still moving, which is exactly what CONTRIBUTING tells contributors and what a 0.x line is for. 1.3.0 claimed stability this project has not reached.

pyproject, the changelog section and the compare links all move to 0.1.30, and the paragraph that explained the jump is replaced with one that explains why the version stays on 0.x. The v1.3.0 tag and its release are removed.

guard: v0.1.30 == pyproject 0.1.30 == CHANGELOG [0.1.30], and v1.3.0 now fails against this tree on both counts.

