### PR TITLE
fix(rig-qa): the quality gates passed everything, then failed everything

### DIFF
--- a/bgate_adapters/animcurves.py
+++ b/bgate_adapters/animcurves.py
@@ -30,7 +30,7 @@ import json
 import math
 import struct
 from pathlib import Path
-from typing import Any, Optional
+from typing import Optional
 
 _COMPONENT_FORMATS = {
     5120: ("b", 1), 5121: ("B", 1), 5122: ("h", 2),

--- a/bgate_adapters/animcurves.py
+++ b/bgate_adapters/animcurves.py
@@ -30,7 +30,7 @@ import json
 import math
 import struct
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
 
 _COMPONENT_FORMATS = {
     5120: ("b", 1), 5121: ("B", 1), 5122: ("h", 2),
@@ -159,6 +159,38 @@ def _speed(times: list[float], values: list) -> list[float]:
 # Arcs: does a translation path bow, or cut a straight line
 # ---------------------------------------------------------------------------
 
+def _finite(values) -> bool:
+    """Is every number in this sample list a real number.
+
+    NaN POISONS EVERY GATE IN THIS MODULE AND POISONS IT GREEN. Each verdict
+    below is a `>` or `<` against a threshold, and every comparison against NaN
+    is False, so a single non-finite value in an export turns the whole module
+    into an unconditional pass. Checked up front and reported as unmeasured
+    instead, because an unreadable curve is an unknown and an unknown is not a
+    pass — the same call artifacts.register makes when it cannot read a
+    project's settings.
+    """
+    for v in values:
+        for x in (v if isinstance(v, (tuple, list)) else (v,)):
+            if not math.isfinite(x):
+                return False
+    return True
+
+
+def _unmeasured(reason: str, **extra) -> dict:
+    """A measurement that could not be taken, marked so its verdict refuses."""
+    return {"measured": False, "reason": reason, **extra}
+
+
+def _refuse(result: dict, **extra) -> Optional[dict]:
+    """The verdict for an unmeasured result, or None if there is one to judge."""
+    if result.get("measured", True):
+        return None
+    return {"passed": False, "issues": [{"kind": "unmeasured",
+                                         "note": result.get("reason", "not measured")}],
+            **extra}
+
+
 def arc_deviation(times: list[float], positions: list) -> dict:
     """How far a VEC3 path bows from the straight chord between its endpoints,
     as a fraction of the chord's own length.
@@ -215,16 +247,31 @@ def velocity_profile(times: list[float], values: list, *,
     near-zero second derivative at a segment boundary is exactly what a
     dominant near-peak-speed duration also measures, from the other end.
     """
+    if not _finite(values) or not _finite(times):
+        return _unmeasured("this track carries NaN or infinity — every "
+                           "threshold below would compare False against it "
+                           "and report a pass",
+                           peak_speed=0.0, cruising_fraction=0.0)
     speed = _speed(times, values)
     n = len(speed)
     if n < 2 or len(times) < 2:
-        return {"speed": [round(s, 5) for s in speed], "peak_speed": 0.0,
-                "cruising_fraction": 0.0}
-    peak = max(speed) or 1e-9
+        return _unmeasured(f"{len(times)} samples — too few for a speed profile",
+                           peak_speed=0.0, cruising_fraction=0.0)
     duration = times[-1] - times[0]
     if duration <= 1e-9:
-        return {"speed": [round(s, 5) for s in speed], "peak_speed": round(peak, 5),
-                "cruising_fraction": 0.0}
+        return _unmeasured("every sample carries the same timestamp — this "
+                           "track has no duration to spend anywhere",
+                           peak_speed=0.0, cruising_fraction=0.0)
+    peak = max(speed)
+    # ZERO MOTION IS NOT SMOOTH MOTION. `peak or 1e-9` made the near-peak
+    # threshold 8.5e-10, which no speed of exactly 0.0 clears, so a track of 60
+    # identical samples reported cruising_fraction 0.0 and sailed through the
+    # gate. A bone that never moves is not an eased bone.
+    if peak <= 1e-9:
+        return _unmeasured("nothing on this track moves — a dead channel has "
+                           "no easing to judge, and 0.0 here is absence, not "
+                           "a clean result",
+                           peak_speed=0.0, cruising_fraction=0.0)
     threshold = near_peak_ratio * peak
     near_peak_time = 0.0
     for i in range(n - 1):
@@ -235,6 +282,9 @@ def velocity_profile(times: list[float], values: list, *,
 
 
 def velocity_profile_verdict(profile: dict, *, max_cruising_fraction: float = 0.6) -> dict:
+    refusal = _refuse(profile, threshold=max_cruising_fraction)
+    if refusal:
+        return refusal
     frac = profile.get("cruising_fraction", 0.0)
     issues = []
     if frac > max_cruising_fraction:
@@ -285,16 +335,25 @@ def sparc(times: list[float], values: list, *, freq_cutoff: float = 10.0,
     `freq_cutoff`, which is SPARC's own adaptive-cutoff definition rather
     than a fixed window.
     """
+    if not _finite(values) or not _finite(times):
+        return _unmeasured("this track carries NaN or infinity — no spectrum "
+                           "can be taken of it", sparc=0.0, samples=0)
     speed = _speed(times, values)
     n = len(speed)
     if n < 4 or not times:
-        return {"sparc": 0.0, "samples": n}
+        return _unmeasured(f"{n} samples — too few for a spectrum",
+                           sparc=0.0, samples=n)
     duration = max(times) - min(times)
     if duration <= 1e-9:
-        return {"sparc": 0.0, "samples": n}
+        return _unmeasured("every sample carries the same timestamp — there is "
+                           "no time axis to transform", sparc=0.0, samples=n)
     fs = (n - 1) / duration
     mag = _dft_magnitude(speed)
-    peak = max(mag) or 1e-9
+    peak = max(mag)
+    if peak <= 1e-12:
+        return _unmeasured("nothing on this track moves — a flat speed profile "
+                           "has no spectral arc, and 0.0 is the smoothest "
+                           "value this returns", sparc=0.0, samples=n)
     norm = [m / peak for m in mag]
     freqs = [k * fs / n for k in range(len(mag))]
     cutoff_idx = 0
@@ -304,6 +363,15 @@ def sparc(times: list[float], values: list, *, freq_cutoff: float = 10.0,
         cutoff_idx = i
         if m < amplitude_threshold:
             break
+    # A CUTOFF OF 0 MEANS THE ARC LOOP NEVER RAN, hence sparc 0.0 — the
+    # smoothest value this can return, handed to short clips whose first bin
+    # spacing (1/duration) already exceeds freq_cutoff. Five samples of pure
+    # white noise over 0.09s scored a clean 0.0 this way.
+    if cutoff_idx < 1:
+        return _unmeasured(f"this track's frequency resolution ({fs / n:.1f} Hz "
+                           f"per bin over {duration:.3f}s) is coarser than the "
+                           f"{freq_cutoff} Hz band being measured — too short "
+                           "to judge for jitter", sparc=0.0, samples=n)
     arc = 0.0
     for i in range(cutoff_idx):
         df = freqs[i + 1] - freqs[i]
@@ -319,6 +387,9 @@ def sparc_verdict(result: dict, *, min_sparc: float = -8.0) -> dict:
     checked against known-good output, the same caveat the research behind
     this module raised for every judge in this space.
     """
+    refusal = _refuse(result, threshold=min_sparc)
+    if refusal:
+        return refusal
     value = result.get("sparc", 0.0)
     issues = []
     if value < min_sparc:
@@ -345,8 +416,23 @@ def foot_skate(times: list[float], positions: list, *, ground_axis: int = 1,
     never actually plants (a jump, a kick) as having no contact frames at
     all, which is the conservative failure direction.
     """
+    if not _finite(positions):
+        return _unmeasured("this track carries NaN or infinity — no contact "
+                           "can be classified from it",
+                           contact_frames=0, skating_frames=0, worst_slide=0.0)
     if len(positions) < 3:
-        return {"contact_frames": 0, "skating_frames": 0, "worst_slide": 0.0}
+        return _unmeasured(f"{len(positions)} samples — too few to see a foot "
+                           "hold still and slide",
+                           contact_frames=0, skating_frames=0, worst_slide=0.0)
+    # A DEAD CHANNEL IS PLANTED AND NOT SLIDING, and so is a perfect footfall.
+    # Without this a bone of 60 identical samples reports 60 contact frames and
+    # 0 skating frames — the single cleanest result this function can produce.
+    if all(p == positions[0] for p in positions):
+        return _unmeasured("nothing on this track moves — a bone that holds "
+                           "one position is not a foot that plants well, it is "
+                           "a foot that was never animated",
+                           contact_frames=len(positions), skating_frames=0,
+                           worst_slide=0.0)
     heights = [p[ground_axis] for p in positions]
     floor = min(heights)
     contact = [h - floor <= contact_band for h in heights]
@@ -358,11 +444,26 @@ def foot_skate(times: list[float], positions: list, *, ground_axis: int = 1,
             if d > skate_tolerance:
                 skating += 1
                 worst = max(worst, d)
+    # NEVER PLANTING IS NOT NEVER SKATING. The docstring calls a foot that
+    # never touches down "the conservative failure direction", but conservative
+    # here meant reporting a pass: zero contact frames yields zero skating
+    # frames, which is the same output as a perfectly planted foot. Say which
+    # one it is.
+    if sum(contact) < 2:
+        return _unmeasured("this bone never rests near its own lowest point — "
+                           "nothing here plants, so there is no planted foot "
+                           "to catch sliding. Wrong ground_axis on a Z-up "
+                           "export looks exactly like this.",
+                           contact_frames=sum(contact), skating_frames=0,
+                           worst_slide=0.0)
     return {"contact_frames": sum(contact), "skating_frames": skating,
             "worst_slide": round(worst, 4)}
 
 
 def foot_skate_verdict(result: dict, *, max_skating_frames: int = 0) -> dict:
+    refusal = _refuse(result)
+    if refusal:
+        return refusal
     issues = []
     if result.get("skating_frames", 0) > max_skating_frames:
         issues.append({"kind": "foot_skate", "value": result["skating_frames"],
@@ -528,11 +629,25 @@ def anticipation_verdict(times: list[float], values: list[float], *,
     transitions classical anticipation actually applies to (a wind-up
     before a strike), least trustworthy on quick twitches.
     """
+    if not _finite(values) or not _finite(times):
+        return {"passed": False, "events": 0, "sigma": 0.0,
+                "issues": [{"kind": "unmeasured",
+                            "note": "this track carries NaN or infinity — no "
+                                    "curvature can be read from it"}]}
     lr = log_response(times, values, sigma_samples=sigma_samples)
     resp, grid = lr["response"], lr["times"]
     n = len(resp)
     if n < 8:
-        return {"passed": True, "issues": [], "events": 0, "sigma": lr["sigma"]}
+        return {"passed": False, "events": 0, "sigma": lr["sigma"],
+                "issues": [{"kind": "unmeasured",
+                            "note": f"{n} samples after resampling — too few "
+                                    "to tell a shaped transition from a corner"}]}
+    if max(abs(x) for x in resp) < 1e-12:
+        return {"passed": False, "events": 0, "sigma": lr["sigma"],
+                "issues": [{"kind": "unmeasured",
+                            "note": "this track has no curvature anywhere — it "
+                                    "holds a constant value, and there is no "
+                                    "transition here to have been shaped"}]}
     peaks = _peaks(resp, min_prominence_frac=min_prominence_frac)
     issues = []
     for p in peaks:

--- a/bgate_adapters/blender.py
+++ b/bgate_adapters/blender.py
@@ -3580,6 +3580,30 @@ def flex_verdict(report: dict, *, volume_tolerance: float = 0.18,
                            "intersect": intersect_tolerance}}
 
 
+def _unmeasured(report: dict, measured, empty_note: str) -> list[dict]:
+    """The guard every verdict in this file needs before it judges anything.
+
+    AN UNKNOWN IS NOT A PASS. Each of these verdicts is a loop over a
+    collection that appends an issue per fault and returns `passed=not issues`,
+    which means an empty collection — a failed run, a model with no armature, a
+    bind with no weights, a sweep where every pose was skipped — sails through
+    as a clean bill of health. flex_verdict shipped exactly this bug and had an
+    inertness clause added after a real run passed a mesh that was never bound
+    to the skeleton sitting inside it; these three then reintroduced it, and a
+    green `passed` with `checked: 0` is the least useful thing a gate can say.
+
+    Returns the issues to refuse with, or [] when there is something to judge.
+    """
+    if not report.get("ok", False):
+        return [{"kind": "unmeasured",
+                 "note": "the measurement itself did not run — "
+                         + (str(report.get("error") or "no report") )
+                         + "; nothing was checked, so nothing can pass"}]
+    if not measured:
+        return [{"kind": "unmeasured", "note": empty_note}]
+    return []
+
+
 _WEIGHTS_MARK = "BGATE_WEIGHTS:"
 
 _WEIGHTS_SCRIPT = '''
@@ -3589,24 +3613,52 @@ import bmesh
 P = json.loads(r"""__PAYLOAD__""")
 
 
-def islands(bm, indices):
-    """Connected components of a vertex-index subset, via mesh EDGE adjacency.
+def adjacency(bm):
+    """Vertex adjacency over mesh edges, with EXACTLY coincident vertices fused.
 
-    Edges, not spatial proximity: two vertices can sit a millimetre apart
-    across a seam and share no edge, which is exactly the case a weight
-    painted right up to a seam should NOT be flagged for.
+    Mesh edges alone are the intuitive graph, and on a file that has been
+    through glTF they are the wrong one. The exporter SPLITS a vertex wherever
+    normals or UVs differ across it, so a single point on the surface comes
+    back as two to six vertices at an identical position with no edge joining
+    them. Measured on this project's own bind fixture: 940 authored vertices
+    exported and re-imported as 1559, and every bone's weight set duly fell
+    apart along those seams — RightUpperLeg read 14 islands where the welded
+    graph shows 2. Uncorrected, this flags every bone of every clean automatic
+    bind, which is worse than not checking at all: a gate that is always red
+    teaches the agent to ignore it.
+
+    Fusing only EXACT position matches is the point, and it keeps the promise
+    the edge-only version was written to keep: two vertices a millimetre apart
+    across a genuine seam still share no edge and still count separately. An
+    exporter split is not a millimetre apart — it is one coordinate written
+    twice, bit for bit, because both copies came from the same source vertex.
     """
+    at = {}
+    for v in bm.verts:
+        at.setdefault(tuple(v.co), []).append(v.index)
+    adj = {v.index: set() for v in bm.verts}
+    for e in bm.edges:
+        a, b = e.verts[0].index, e.verts[1].index
+        adj[a].add(b)
+        adj[b].add(a)
+    for same_point in at.values():
+        if len(same_point) > 1:
+            for i in same_point:
+                adj[i].update(j for j in same_point if j != i)
+    return adj
+
+
+def components(adj, indices):
+    """Connected components of a vertex-index subset over `adj`."""
     remaining = set(indices)
     out = []
     while remaining:
-        start = next(iter(remaining))
+        start = remaining.pop()
         seen = {start}
-        remaining.discard(start)
         stack = [start]
         while stack:
             i = stack.pop()
-            for e in bm.verts[i].link_edges:
-                j = e.other_vert(bm.verts[i]).index
+            for j in adj.get(i, ()):
                 if j in remaining:
                     remaining.discard(j)
                     seen.add(j)
@@ -3644,17 +3696,39 @@ else:
             if name in bones and g.weight >= threshold:
                 by_bone.setdefault(name, []).append(v.index)
 
+    # THE MESH'S OWN SHELLS ARE THE BASELINE, NOT ONE.
+    #
+    # "One bone drives one contiguous patch" is only true of a mesh that is
+    # itself one piece. This pipeline assembles characters from joined
+    # primitives, so a body is routinely 9 disconnected shells and a hip bone
+    # legitimately spans three of them; shells() elsewhere in this file records
+    # a real user character at 940. Counting islands against a hardcoded 1 makes
+    # every such bone a false positive. Counting them against the number of
+    # shells the bone actually touches asks the question that was meant: does
+    # the paint split WITHIN a piece of mesh, where nothing but a stray brush
+    # stroke could have put it.
+    adj = adjacency(bm)
+    shell_of = {}
+    for si, shell in enumerate(components(adj, [v.index for v in bm.verts])):
+        for i in shell:
+            shell_of[i] = si
+
     report = {}
     for name, indices in by_bone.items():
-        comps = islands(bm, indices)
-        sizes = sorted((len(c) for c in comps), reverse=True)
-        report[name] = {"vertex_count": len(indices), "islands": len(comps),
+        sizes = sorted((len(c) for c in components(adj, indices)), reverse=True)
+        touched = len({shell_of.get(i, -1) for i in indices})
+        report[name] = {"vertex_count": len(indices), "islands": len(sizes),
+                        "shells": touched,
                         "sizes": sizes[:8],
-                        "largest_fraction": round(sizes[0] / len(indices), 4)
-                                            if indices else 1.0}
+                        # Summed here, off the FULL list, because `sizes` above
+                        # is truncated for the stdout budget and summing the
+                        # truncated copy under-reports every bone past 8 islands.
+                        "bleed_vertices": sum(sizes[touched:]),
+                        "largest_fraction": round(sizes[0] / len(indices), 4)}
     bm.free()
     out["bones"] = report
     out["deform_bones"] = len(bones)
+    out["mesh_shells"] = len(set(shell_of.values()))
     print("__MARK__" + json.dumps(out))
 '''.replace("__MARK__", _WEIGHTS_MARK)
 
@@ -3685,33 +3759,42 @@ def weight_islands(model: str | os.PathLike[str], *, threshold: float = 0.02,
     return report
 
 
-def weight_islands_verdict(report: dict, *, min_largest_fraction: float = 0.9,
-                           min_bleed_vertices: int = 3) -> dict:
+def weight_islands_verdict(report: dict, *, min_bleed_vertices: int = 3) -> dict:
     """The judgement, kept OUT of the Blender script — same split as flex_verdict.
+
+    A bone is flagged when its weights form MORE islands than the number of
+    mesh shells it touches — paint that split inside a single connected piece
+    of surface, which nothing but a stray stroke explains. Spanning several
+    shells is not itself a fault; see the script's own note.
 
     min_bleed_vertices filters noise: a single stray vertex one brush stroke
     missed is a cleanup nit, not the failure this exists to catch.
     """
-    issues: list[dict] = []
+    issues = _unmeasured(report, report.get("bones"),
+                         "no deform bone carried a single weight above the "
+                         "threshold — nothing here was measured, and a pass "
+                         "would mean 'clean' when it means 'empty'")
+    if issues:
+        return {"passed": False, "issues": issues, "checked": 0,
+                "thresholds": {"min_bleed_vertices": min_bleed_vertices}}
     for name, info in (report.get("bones") or {}).items():
-        sizes = info.get("sizes") or []
-        if len(sizes) < 2:
-            continue
-        bleed = sum(sizes[1:])
-        if (info.get("largest_fraction", 1.0) < min_largest_fraction
-                and bleed >= min_bleed_vertices):
+        islands = int(info.get("islands") or 0)
+        shells = int(info.get("shells") or 1)
+        bleed = int(info.get("bleed_vertices") or 0)
+        if islands > shells and bleed >= min_bleed_vertices:
             issues.append({"bone": name, "kind": "bleed",
-                           "islands": info.get("islands"),
+                           "islands": islands, "shells": shells,
                            "bleed_vertices": bleed,
                            "largest_fraction": info.get("largest_fraction"),
                            "note": f"{name}'s weight paint splits into "
-                                   f"{info.get('islands')} disconnected regions "
-                                   f"on the mesh surface — {bleed} vertices sit "
-                                   "off the bone's own patch"})
+                                   f"{islands} regions across {shells} piece"
+                                   f"{'s' if shells != 1 else ''} of mesh — "
+                                   f"{bleed} vertices sit off the bone's own "
+                                   "patch on a surface it could not have "
+                                   "reached by following the geometry"})
     return {"passed": not issues, "issues": issues,
             "checked": len(report.get("bones") or {}),
-            "thresholds": {"min_largest_fraction": min_largest_fraction,
-                           "min_bleed_vertices": min_bleed_vertices}}
+            "thresholds": {"min_bleed_vertices": min_bleed_vertices}}
 
 
 # ---------------------------------------------------------------------------
@@ -3826,12 +3909,26 @@ import bpy, json
 P = json.loads(r"""__PAYLOAD__""")
 
 
-def joints(path):
-    """Every bone's HEAD position, in that file's own body-height fraction.
+def proportions(path):
+    """Every bone's LENGTH as a fraction of body height, plus its parent.
 
-    Height-normalised, not world-space: a candidate rigged at a different
-    height than the reference template is not itself a deviation, and
-    comparing raw metres would report one on every character.
+    LENGTHS, NOT HEAD POSITIONS, AND THE DIFFERENCE IS THE ENTIRE CHECK.
+
+    A head position is stance-dependent, and the two sides of this comparison
+    are never in the same stance: rig() defaults to pose="a" (BG_A_POSE_DROP,
+    0.42 rad) while the shipped HUMANOID_SKELETON is a T-pose. The first run
+    of this check reported both hands 0.154 body-heights out against a 0.08
+    threshold, perfectly mirrored left to right, with every non-arm bone at
+    exactly 0.0 — it was measuring the arm swing, not a fit fault, and it
+    failed every correctly-rigged character in the pipeline.
+
+    Bone length is invariant under both stance and translation: rotating a
+    joint does not change the length of the bone below it, and neither does
+    moving the whole rig off the origin (which the positional version also
+    counted, on every bone at once). That makes it the thing this docstring
+    always claimed to compare — PROPORTIONS — measurable without requiring the
+    reference and the candidate to be posed alike. `parent` rides along so a
+    rig that kept the 23 names but rewired the chain is still caught.
     """
     for o in list(bpy.context.scene.objects):
         bpy.data.objects.remove(o, do_unlink=True)
@@ -3839,26 +3936,39 @@ def joints(path):
     arms = [o for o in bpy.context.scene.objects if o.type == "ARMATURE"]
     meshes = [o for o in bpy.context.scene.objects if o.type == "MESH"]
     if not arms:
-        return None, 0.0
+        return None, 0.0, "no armature in %s" % path
+    if not meshes:
+        # NOT a fallback to height 1.0. That silently left one side of the
+        # comparison in metres while the other was height-normalised, so every
+        # bone read as wildly displaced and the report still said ok.
+        return None, 0.0, ("no mesh in %s — body height is what every length "
+                           "here is a fraction of, and without one the two "
+                           "sides of this comparison are in different units"
+                           % path)
     arm = arms[0]
-    height = 1.0
-    if meshes:
-        mesh = max(meshes, key=lambda o: len(o.data.polygons))
-        height = max(mesh.dimensions[2], 1e-6)
+    mesh = max(meshes, key=lambda o: len(o.data.polygons))
+    height = max(mesh.dimensions[2], 1e-6)
     out = {}
     for b in arm.data.bones:
         head = arm.matrix_world @ b.head_local
-        out[b.name] = [head.x / height, head.y / height, head.z / height]
-    return out, height
+        tail = arm.matrix_world @ b.tail_local
+        out[b.name] = [round((tail - head).length / height, 5),
+                       b.parent.name if b.parent else ""]
+    return out, height, ""
 
 
-ref_joints, ref_height = joints(P["reference"])
-cand_joints, cand_height = joints(P["candidate"])
-out = {"ok": bool(ref_joints and cand_joints),
+# KEEP THIS REPORT SMALL. run_script hands back only the LAST 4000 characters
+# of stdout and _marked needs the mark still at the start of its line, so an
+# oversized report is indistinguishable from a crashed run. The two full joint
+# tables this used to print came to 3580 characters on a 23-bone rig — three
+# more bones and a working run would have reported "no report from Blender".
+ref, ref_height, ref_error = proportions(P["reference"])
+cand, cand_height, cand_error = proportions(P["candidate"])
+out = {"ok": bool(ref and cand),
        "reference_height": ref_height, "candidate_height": cand_height,
-       "reference_joints": ref_joints or {}, "candidate_joints": cand_joints or {}}
+       "reference_bones": ref or {}, "candidate_bones": cand or {}}
 if not out["ok"]:
-    out["error"] = "reference or candidate has no armature"
+    out["error"] = ref_error or cand_error or "reference or candidate has no armature"
 print("__MARK__" + json.dumps(out))
 '''.replace("__MARK__", _TDEV_MARK)
 
@@ -3866,26 +3976,32 @@ print("__MARK__" + json.dumps(out))
 def template_deviation(model: str | os.PathLike[str], *,
                        reference: Optional[str | os.PathLike[str]] = None,
                        timeout: int = 300) -> dict:
-    """How far a rigged character's joints sit from the shipped template's.
+    """How far a rigged character's proportions sit from the shipped template's.
 
     Every generated humanoid is meant to share ONE skeleton's proportions —
     that is the entire point of conditioning the plate on HUMANOID_SKELETON
     (see humanoid_template) rather than inventing a rig per character. This
-    is the check that claim actually holds: bone HEAD positions, matched by
-    NAME (both rigs use the same 23-name schema, so there is no
-    correspondence problem to solve — the harder Chamfer-distance matching
-    the rigging literature needs for unlabeled skeletons does not apply
-    here), compared in body-height-normalised space so two characters of
-    different heights are not penalised for that alone.
+    is the check that claim actually holds: bone LENGTHS, matched by NAME
+    (both rigs use the same 23-name schema, so there is no correspondence
+    problem to solve — the harder Chamfer-distance matching the rigging
+    literature needs for unlabeled skeletons does not apply here), each as a
+    fraction of its own file's body height so two characters of different
+    heights are not penalised for that alone.
+
+    LENGTHS RATHER THAN JOINT POSITIONS because the two skeletons are never
+    posed alike — see the script's own note. Positions reported the A-pose
+    this pipeline rigs in as a fault against the T-pose template, which
+    failed every correctly-rigged character it was shown.
 
     NOT a weight comparison. RigNet-style weight-L1 needs the reference and
     the candidate to share mesh topology — vertex 4000 on one is vertex 4000
     on the other — which is never true here: the template skeleton and a
-    generated character are different meshes entirely. Only joint position
-    is comparable across them.
+    generated character are different meshes entirely. Only the skeleton is
+    comparable across them.
 
-    Returns {ok, reference_height, candidate_height, reference_joints,
-    candidate_joints}. Judge with template_deviation_verdict.
+    Returns {ok, reference_height, candidate_height, reference_bones,
+    candidate_bones}, each bone mapping to [length_fraction, parent_name].
+    Judge with template_deviation_verdict.
     """
     src = Path(model)
     if not src.is_file():
@@ -3893,7 +4009,11 @@ def template_deviation(model: str | os.PathLike[str], *,
     ref = Path(reference) if reference else HUMANOID_SKELETON
     if not ref.is_file():
         return {"ok": False, "error": f"no reference skeleton at {ref}"}
-    payload = {"model": str(src), "reference": str(ref).replace("\\", "/"),
+    # No "model" key: the script reads only reference/candidate, and the dead
+    # third copy was also the one path that skipped the separator normalisation
+    # the other two get — a backslash in a Windows path is an escape once it is
+    # inside the script's JSON payload.
+    payload = {"reference": str(ref).replace("\\", "/"),
                "candidate": str(src).replace("\\", "/")}
     script = _TDEV_SCRIPT.replace("__PAYLOAD__", json.dumps(payload))
     result = run_script(script, timeout=timeout, kit=False, record=False)
@@ -3908,25 +4028,49 @@ def template_deviation(model: str | os.PathLike[str], *,
 def template_deviation_verdict(report: dict, *, max_deviation: float = 0.08) -> dict:
     """The judgement, kept OUT of the Blender script — same split as flex_verdict.
 
-    max_deviation is a fraction of body height. 0.08 mirrors the 6 cm-on-a-1.8m
-    -figure incident already documented against humanoid_template — roughly
-    the same tolerance band, reused rather than re-derived.
+    max_deviation is how far ONE bone's length may differ from the template's,
+    as a fraction of body height. 0.08 carries over the tolerance band of the
+    6 cm-on-a-1.8m-figure incident documented against humanoid_template, but
+    note it is applied to a different quantity than it was when this compared
+    joint positions — it is a gross-error line (a limb collapsed to nothing, or
+    stretched across the body), not a proportional-fidelity one, and it has not
+    been validated against a corpus of known-good characters. Fitting is MEANT
+    to adapt the template to each body; only a length that no fit would produce
+    should trip this.
     """
-    ref = report.get("reference_joints") or {}
-    cand = report.get("candidate_joints") or {}
+    ref = report.get("reference_bones") or {}
+    cand = report.get("candidate_bones") or {}
     shared = sorted(set(ref) & set(cand))
-    issues: list[dict] = []
+    issues = _unmeasured(report, shared,
+                         "the two skeletons share no bone name — a candidate "
+                         "on a different naming scheme (mixamorig:Hips and "
+                         "friends) is not one this can compare, and zero bones "
+                         "checked is not zero bones wrong")
+    if issues:
+        return {"passed": False, "issues": issues, "checked": 0,
+                "deviations": {}, "threshold": max_deviation}
     deviations = {}
     for name in shared:
-        rx, ry, rz = ref[name]
-        cx, cy, cz = cand[name]
-        dist = ((rx - cx) ** 2 + (ry - cy) ** 2 + (rz - cz) ** 2) ** 0.5
-        deviations[name] = round(dist, 4)
-        if dist > max_deviation:
-            issues.append({"bone": name, "kind": "displaced", "value": round(dist, 4),
-                           "note": f"{name} sits {dist:.3f} body-heights from "
-                                   "where the template puts it — a fit that "
-                                   "landed it off the character's own anatomy"})
+        ref_len, ref_parent = ref[name][0], ref[name][1]
+        cand_len, cand_parent = cand[name][0], cand[name][1]
+        diff = abs(ref_len - cand_len)
+        deviations[name] = round(diff, 4)
+        if diff > max_deviation:
+            issues.append({"bone": name, "kind": "proportion",
+                           "value": round(diff, 4),
+                           "reference": ref_len, "candidate": cand_len,
+                           "note": f"{name} is {cand_len:.3f} body-heights long "
+                                   f"where the template makes it {ref_len:.3f} "
+                                   "— a fit that mis-solved this limb rather "
+                                   "than scaling it to the character"})
+        if ref_parent != cand_parent:
+            issues.append({"bone": name, "kind": "hierarchy",
+                           "reference": ref_parent, "candidate": cand_parent,
+                           "note": f"{name} hangs off "
+                                   f"{cand_parent or '(root)'} here and off "
+                                   f"{ref_parent or '(root)'} in the template "
+                                   "— same names, different chain, so nothing "
+                                   "retargeted onto this rig will land right"})
     return {"passed": not issues, "issues": issues, "checked": len(shared),
             "deviations": deviations, "threshold": max_deviation}
 
@@ -4162,14 +4306,34 @@ def silhouette_verdict(report: dict, *, min_ratio: float = 0.15,
     nearly vanishing from this camera or geometry ballooning past anything a
     single joint's rotation should produce.
     """
-    issues: list[dict] = []
+    measured = [p for p in (report.get("poses") or [])
+                if not p.get("skipped") and p.get("area_ratio") is not None]
+    issues = _unmeasured(report, measured,
+                         "every pose in the sweep was skipped — the bones it "
+                         "rotates are not on this armature, so no silhouette "
+                         "was ever compared against rest")
+    if issues:
+        return {"passed": False, "issues": issues, "checked": 0,
+                "thresholds": {"min_ratio": min_ratio, "max_ratio": max_ratio}}
+
+    # INERTNESS, THE SAME CLAUSE flex_verdict NEEDED. A mesh no bone drives
+    # projects to the identical outline in every pose, so each ratio comes back
+    # at exactly 1.0 and the sanity bounds — which only fire far from 1.0 —
+    # report a perfect sweep. Measured on this file's own unbound.glb fixture:
+    # six poses, area_ratio 1.0 to the digit, passed.
+    if all(abs(p["area_ratio"] - 1.0) < 1e-6 for p in measured):
+        return {"passed": False, "checked": len(measured),
+                "issues": [{"pose": "*", "kind": "inert",
+                            "value": 1.0,
+                            "note": "every pose projects the identical outline "
+                                    "as rest — nothing in this sweep moved, so "
+                                    "the mesh is not bound to the skeleton "
+                                    "posing it and every ratio here is vacuous"}],
+                "thresholds": {"min_ratio": min_ratio, "max_ratio": max_ratio}}
+
     checked = 0
-    for pose in report.get("poses") or []:
-        if pose.get("skipped"):
-            continue
-        ratio = pose.get("area_ratio")
-        if ratio is None:
-            continue
+    for pose in measured:
+        ratio = pose["area_ratio"]
         checked += 1
         label = pose.get("label", "?")
         if ratio < min_ratio:

--- a/bgate_core/art_tournament.py
+++ b/bgate_core/art_tournament.py
@@ -68,6 +68,16 @@ def record_verdict(root: str | os.PathLike[str], match_id: int, *,
         raise ValueError(
             f"winner {winner} is not one of this match's candidates "
             f"({match['candidate_a_id']}, {match['candidate_b_id']})")
+    # A DECIDED MATCH IS DECIDED. The reviewer brief walks an agent through 28
+    # of these in a row, so a retry after a dropped response was overwriting a
+    # recorded pick in silence — two activity lines both claiming a win, and a
+    # ranking that changed under a caller who thought it was re-sending.
+    if match.get("winner_id") is not None:
+        raise ValueError(
+            f"match {match_id} was already decided for candidate "
+            f"{match['winner_id']} at {match.get('decided_at')} — re-deciding "
+            "it would rewrite a recorded judgement. Open a new tournament if "
+            "the comparison needs to be run again.")
     who = actor if actor is not None else activity.current_actor()
     with db.tx(root) as conn:
         conn.execute(
@@ -84,20 +94,51 @@ def record_verdict(root: str | os.PathLike[str], match_id: int, *,
 def list_matches(root: str | os.PathLike[str], *,
                  logical_name: Optional[str] = None,
                  tournament_ref: Optional[str] = None,
-                 decided_only: bool = False, limit: int = 500) -> list[dict]:
+                 decided_only: bool = False,
+                 limit: Optional[int] = 500) -> list[dict]:
+    """Matches for a target, oldest first. `limit=None` for all of them.
+
+    `tournament_ref=""` is a REAL filter, not an absent one — record_match
+    stores "" as its own default, so a caller asking for the unnamed
+    tournament's matches must not silently get every tournament's. Pass None
+    to mean "any". `logical_name` keeps the older falsy-means-any behaviour
+    because "" is not a name anything is stored under.
+    """
     clauses, params = [], []
     if logical_name:
         clauses.append("logical_name = ?")
         params.append(logical_name)
-    if tournament_ref:
+    if tournament_ref is not None:
         clauses.append("tournament_ref = ?")
         params.append(tournament_ref)
     if decided_only:
         clauses.append("winner_id IS NOT NULL")
     where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+    if limit is None:
+        return rows(db.connect(root).execute(
+            f"SELECT * FROM art_match {where} ORDER BY id ASC", params))
     params.append(int(limit))
     return rows(db.connect(root).execute(
         f"SELECT * FROM art_match {where} ORDER BY id ASC LIMIT ?", params))
+
+
+def discard_matches(root: str | os.PathLike[str], match_ids: list[int]) -> int:
+    """Delete UNDECIDED matches by id. Returns how many went.
+
+    Exists so a tournament that failed to dispatch can be rolled back instead
+    of leaving its whole round-robin sitting open forever, which nothing else
+    could then clear and which a retry would duplicate rather than replace.
+    Decided matches are left alone — a recorded judgement is not scratch.
+    """
+    ids = [int(i) for i in match_ids]
+    if not ids:
+        return 0
+    marks = ",".join("?" for _ in ids)
+    with db.tx(root) as conn:
+        cur = conn.execute(
+            f"DELETE FROM art_match WHERE winner_id IS NULL AND id IN ({marks})",
+            ids)
+        return cur.rowcount
 
 
 def elo_ratings(matches: list[dict], *, k: float = DEFAULT_K,
@@ -137,9 +178,16 @@ def elo_ratings(matches: list[dict], *, k: float = DEFAULT_K,
 
 def standings(root: str | os.PathLike[str], logical_name: str, *,
              tournament_ref: Optional[str] = None) -> dict:
-    """Every candidate that has played a match for this target, ranked."""
+    """Every candidate that has played a match for this target, ranked.
+
+    RATED OVER EVERY MATCH, NOT THE FIRST 500. list_matches defaults to a 500
+    row cap ordered oldest-first, and taking that default here meant a target
+    past 500 comparisons was ranked on its OLDEST verdicts while every newer
+    one — the reviewer's most recent judgement — was dropped without a word.
+    Elo is path-dependent by nature; silently truncating its input is not.
+    """
     matches = list_matches(root, logical_name=logical_name,
-                           tournament_ref=tournament_ref)
+                           tournament_ref=tournament_ref, limit=None)
     decided = [m for m in matches if m.get("winner_id") is not None]
     ratings = elo_ratings(decided)
     ranked = sorted(

--- a/bgate_core/cutout.py
+++ b/bgate_core/cutout.py
@@ -49,7 +49,7 @@ import math
 import os
 import re
 from pathlib import Path
-from typing import Any, Iterable, Optional
+from typing import Any, Optional
 
 SUFFIX = ".cutout.json"
 VERSION = 1

--- a/bgate_core/cutoutwire.py
+++ b/bgate_core/cutoutwire.py
@@ -46,7 +46,7 @@ import json
 import math
 import os
 from pathlib import Path
-from typing import Any, Optional
+from typing import Optional
 
 from . import cutout
 from .cutout import CutoutError
@@ -391,7 +391,6 @@ def scene_text(doc: dict, *, project_dir: str | os.PathLike[str],
 
 def _hierarchy_order(doc: dict) -> list[dict]:
     """Bones with every parent before its children."""
-    by_name = {b["name"]: b for b in doc["bones"]}
     out, placed = [], set()
     remaining = list(doc["bones"])
     while remaining:

--- a/bgate_mcp/server.py
+++ b/bgate_mcp/server.py
@@ -1395,7 +1395,6 @@ def blender_flex(model: str, out_dir: str = "", stem: str = "flex",
 
 @_tool
 def blender_weights(model: str, threshold: float = 0.02,
-                    min_largest_fraction: float = 0.9,
                     min_bleed_vertices: int = 3, timeout: int = 300) -> dict:
     """Per deform bone, does its weight paint cover one patch of the mesh or two.
 
@@ -1409,16 +1408,26 @@ def blender_weights(model: str, threshold: float = 0.02,
     seam-tearing glitch the moment the spine and the hand pose differently.
 
     Reports each deform bone's weighted vertices as connected components on
-    the mesh surface (edge adjacency, not proximity — a seam does not count
-    as touching). One component is healthy. `verdict.passed` False names
-    which bones split and how many vertices sit off their own patch.
+    the mesh surface, and flags a bone whose paint makes MORE components than
+    the number of separate mesh pieces it touches — a split inside one
+    connected piece of surface, which only a stray stroke explains. Spanning
+    several pieces is not itself a fault: this pipeline assembles bodies from
+    joined primitives, so a hip bone legitimately covers three of them.
+
+    `threshold` is the minimum weight at which a vertex counts as belonging to
+    a bone (0.02). `min_bleed_vertices` (3) is a noise floor — a single stray
+    vertex is a cleanup nit, not the seam-tearing failure this exists to catch.
+
+    `verdict.passed` False names which bones split and how many vertices sit
+    off their own patch. It is also False when nothing could be measured — a
+    bind with no weights above `threshold` reports `checked: 0` and refuses,
+    rather than passing an empty result as a clean one.
     """
     try:
         report = _blender.weight_islands(model, threshold=threshold, timeout=timeout)
         if report.get("ok"):
             verdict = _blender.weight_islands_verdict(
-                report, min_largest_fraction=min_largest_fraction,
-                min_bleed_vertices=min_bleed_vertices)
+                report, min_bleed_vertices=min_bleed_vertices)
             report["verdict"] = verdict
             _log("blender",
                  f"weight-islands {model} -> "
@@ -1444,15 +1453,27 @@ def blender_template_deviation(model: str, reference: str = "",
     can be fully weighted, pinch-free, and bleed-free while still sitting in
     the wrong place on the body if height/limb fitting mis-solved.
 
-    Compares bone HEAD positions against HUMANOID_SKELETON (or a supplied
-    `reference`), matched by name and normalised by body height so two
-    characters of different heights aren't penalised for that alone. This is
-    a POSITION check only — it does not compare skin weights, because the
-    reference skeleton and a generated character never share mesh topology,
-    so there is nothing to diff vertex-for-vertex.
+    Compares bone LENGTHS against HUMANOID_SKELETON (or a supplied
+    `reference`), matched by name and each expressed as a fraction of its own
+    file's body height, so two characters of different heights aren't
+    penalised for that alone. Lengths rather than joint positions because the
+    two skeletons are never posed alike — this pipeline rigs in an A-pose and
+    the template is a T-pose, and a positional check reports that difference
+    as a fault on every correctly-rigged character. Bone length does not move
+    when a joint rotates. Parent links are compared too, so a rig that kept
+    the 23 names but rewired the chain is caught.
 
-    `verdict.passed` False names which bones sit furthest from the template's
-    own proportions, in units of body height.
+    NOT a weight comparison — the reference skeleton and a generated character
+    never share mesh topology, so there is nothing to diff vertex-for-vertex.
+
+    `max_deviation` (0.08 body-heights) is a GROSS-ERROR line — a limb
+    collapsed to nothing or stretched across the body — not a proportional-
+    fidelity one. Fitting is meant to adapt the template to each body.
+
+    `verdict.passed` False names which bones are mis-proportioned or
+    misparented. It is also False when nothing could be compared: a candidate
+    whose bones are named on another scheme entirely reports `checked: 0` and
+    refuses, rather than passing an empty intersection as agreement.
     """
     try:
         report = _blender.template_deviation(
@@ -1496,6 +1517,12 @@ def blender_silhouette(model: str, min_ratio: float = 0.15,
     the silhouette nearly vanished (min_ratio) or ballooned far past what a
     single joint's rotation should produce (max_ratio), not that anything
     changed at all.
+
+    It is ALSO False on a sweep that proves nothing: every pose skipped for
+    want of the bones it rotates, or every pose projecting the identical
+    outline as rest. The second is the important one — an unbound mesh does
+    exactly that, and bounds that only fire far from 1.0 would otherwise call
+    a ratio of exactly 1.0 across the whole sweep a perfect result.
     """
     try:
         report = _blender.silhouette(model, timeout=timeout)
@@ -1614,8 +1641,22 @@ def animation_curves(model: str, foot_bones: Optional[list[str]] = None,
                      or not c.get("sparc", {}).get("verdict", {}).get("passed", True)
                      or not c.get("foot_skate", {}).get("verdict", {}).get("passed", True)
                      or not c.get("anticipation", {}).get("verdict", {}).get("passed", True)]
+            measured = [c for c in channels if "velocity" in c]
             clips.append({"name": anim["name"], "channels": channels,
-                         "passed": not failed, "flagged_bones": failed})
+                         "measured_channels": len(measured),
+                         "passed": bool(measured) and not failed,
+                         "flagged_bones": failed})
+        # A FILE WITH NO CLIPS IS NOT A FILE WITH CLEAN CLIPS. `failed` never
+        # evaluates on an empty channel list, so every aggregate here reported
+        # a pass for a model carrying no animation at all — which is exactly
+        # what blender_rig hands back, and exactly the file an agent reaches
+        # for this tool with.
+        if not clips:
+            return {"ok": False, "clips": [],
+                    "error": f"{model} contains no animations — nothing was "
+                             "measured. A rigged-but-unanimated export (what "
+                             "blender_rig produces) has no curves to judge; "
+                             "animate or bake a clip into it first."}
         _log("blender", f"animation-curves {model} -> "
              f"{sum(1 for c in clips if c['passed'])}/{len(clips)} clips clean",
              ref=str(model))
@@ -4921,10 +4962,11 @@ def art_tournament_verdict(match_id: int, winner_artifact_id: int,
 
     art_qa_verdict asks "is this on-model" against a reference. This asks a
     different question a reviewer only sees when dispatched against a
-    tournament brief: given two candidates shown in a RANDOMISED order (see
-    the match's own shown_first, already fixed when the match was opened —
-    the randomisation happened before you were asked, not something you
-    control here), which one is better.
+    tournament brief: given two candidates shown in a RANDOMISED order —
+    fixed when the match was opened, before you were asked, and not something
+    you control or need to look up — which one is better. The brief you were
+    dispatched with lists each match's two images in that settled order and is
+    the only place match ids come from.
 
     PICK A WINNER — do not skip a match because it feels close. The
     VLM-as-judge research behind this tool is consistent that comparative
@@ -4934,7 +4976,9 @@ def art_tournament_verdict(match_id: int, winner_artifact_id: int,
 
     winner_artifact_id must be one of the two candidates IN THIS match — an
     id from a different match or a different logical_name is refused, not
-    silently recorded.
+    silently recorded. So is a second verdict on a match already decided:
+    re-sending after a dropped response used to overwrite the first pick in
+    silence, so a retry is now an error rather than a rewrite.
 
     Returns {ok, match_id, logical_name, winner_id}. The rating itself is
     NOT computed here — see art_tournament_standings, which derives it fresh
@@ -4949,15 +4993,19 @@ def art_tournament_verdict(match_id: int, winner_artifact_id: int,
         return {"ok": True, "match_id": match["id"],
                 "logical_name": match["logical_name"],
                 "winner_id": match["winner_id"]}
-    except (LookupError, ValueError) as exc:
-        return _fail(exc)
     except Exception as exc:
         return _fail(exc)
 
 
 @_tool
-def art_tournament_standings(logical_name: str) -> dict:
+def art_tournament_standings(logical_name: str, tournament_ref: str = "") -> dict:
     """Elo standings for a target, derived fresh from its decided matches.
+
+    `tournament_ref` scopes the result to ONE tournament. Left empty, every
+    match ever recorded for `logical_name` is pooled — which is the right
+    answer for a target run once, and misleading for one re-tournamented after
+    new candidates landed, since the two runs' verdicts then rate each other's
+    candidates. Pass the ref the tournament was opened with to separate them.
 
     Returns {logical_name, standings: [{artifact_id, rating, matches, wins}]
     ranked highest first, decided_matches, pending_matches}. An artifact
@@ -4965,7 +5013,8 @@ def art_tournament_standings(logical_name: str) -> dict:
     """
     try:
         root = _root()
-        return {"ok": True, **_art_tournament.standings(root, logical_name)}
+        return {"ok": True, **_art_tournament.standings(
+            root, logical_name, tournament_ref=(tournament_ref or None))}
     except Exception as exc:
         return _fail(exc)
 

--- a/bgate_ui/app.py
+++ b/bgate_ui/app.py
@@ -1802,8 +1802,8 @@ def serve(port: int = 7788) -> None:
     other = _serving_elsewhere(port, root)
     if other:
         print(f"builders gate · REFUSING to start on {url}")
-        print(f"  another dashboard is already serving that port, for a "
-              f"DIFFERENT project:")
+        print("  another dashboard is already serving that port, for a "
+              "DIFFERENT project:")
         print(f"    it is serving : {other}")
         print(f"    you asked for : {root or '(no project here)'}")
         print("  Two dashboards on one port means a browser tab that looks "

--- a/bgate_ui/dispatch.py
+++ b/bgate_ui/dispatch.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 
 import json
 import os
-import shutil
 import subprocess
 import sys
 import threading

--- a/bgate_ui/routes/art_tournament.py
+++ b/bgate_ui/routes/art_tournament.py
@@ -34,8 +34,17 @@ MAX_CANDIDATES = 8
 
 
 def _gather_candidates(r, logical_name: str) -> list[dict]:
+    """Every candidate, NOT the first MAX_CANDIDATES of them.
+
+    Asking the query for MAX_CANDIDATES rows made the caller's "too many
+    candidates" check unreachable — `len(candidates) > MAX_CANDIDATES` can
+    never be true of a list the database already truncated. Twelve candidates
+    silently became a round-robin over an arbitrary eight of them, reported as
+    a complete tournament. Fetch past the cap so the refusal can see it.
+    """
     return _artifacts.list_revisions(
-        r, logical_name=logical_name, status="candidate", limit=MAX_CANDIDATES)
+        r, logical_name=logical_name, status="candidate",
+        limit=MAX_CANDIDATES + 1)
 
 
 def _reviewer_brief(logical_name: str, matches: list[dict],
@@ -93,14 +102,40 @@ def start_tournament(payload: Optional[dict] = None) -> dict:
 
     candidates = _gather_candidates(r, logical_name)
     if len(candidates) < 2:
+        # NAME THE REAL CAUSE. A project with art.auto_approve on never leaves
+        # a revision at status "candidate" — register() promotes it on the spot
+        # — so this endpoint 404s on every target, and "found 0 candidates"
+        # sends the reader looking for missing renders that are all present and
+        # approved.
+        why = ""
+        if _artifacts._auto_approve(r):
+            why = (" — art.auto_approve is ON for this project, so generated "
+                   "revisions are approved at registration and never sit as "
+                   "candidates. A tournament ranks candidates; turn the "
+                   "setting off for targets you want reviewed this way.")
         raise HTTPException(
             404, f"need at least 2 candidates to run a tournament for "
-                 f"{logical_name!r}, found {len(candidates)}")
+                 f"{logical_name!r}, found {len(candidates)}{why}")
     if len(candidates) > MAX_CANDIDATES:
         raise HTTPException(
             400, f"{len(candidates)} candidates exceeds the "
                  f"{MAX_CANDIDATES}-candidate round-robin cap for one "
                  "tournament — approve or reject some first")
+
+    # ONE OPEN TOURNAMENT AT A TIME PER TARGET. Nothing deduplicated these, so
+    # a second POST — a retry after a timeout, a double-click — opened the whole
+    # round-robin again over the same pairs. standings() pools every match for a
+    # logical_name, so the duplicate did not sit harmlessly beside the first: it
+    # weighted the same comparison twice in the Elo.
+    open_already = [m for m in _art_tournament.list_matches(
+        r, logical_name=logical_name, tournament_ref=tournament_ref, limit=None)
+        if m.get("winner_id") is None]
+    if open_already:
+        raise HTTPException(
+            409, f"{len(open_already)} match(es) for {logical_name!r} are still "
+                 "open — judge or discard those before opening another "
+                 "tournament over the same candidates, or pass a distinct "
+                 "tournament_ref")
 
     candidates_by_id = {c["id"]: c for c in candidates}
     matches = []
@@ -118,6 +153,9 @@ def start_tournament(payload: Optional[dict] = None) -> dict:
             brief=_reviewer_brief(logical_name, matches, candidates_by_id),
             source="art-tournament", source_ref=logical_name)
     except (ValueError, LookupError) as exc:
+        # The matches are already committed at this point. Roll them back rather
+        # than orphaning a round-robin that no path could reach or clear.
+        _art_tournament.discard_matches(r, [m["id"] for m in matches])
         raise HTTPException(400, str(exc))
 
     dispatched = _dispatch.dispatch(str(r), item["id"])

--- a/bgate_ui/runners.py
+++ b/bgate_ui/runners.py
@@ -54,7 +54,7 @@ import shutil
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Callable, Optional, Sequence
+from typing import Callable, Optional
 
 # The MCP server every seat needs whichever CLI it runs on. An art agent that
 # cannot call ref_list, asset_lock, consistency_check or artifact register is

--- a/tests/test_animcurves.py
+++ b/tests/test_animcurves.py
@@ -197,12 +197,20 @@ def test_anticipation_verdict_passes_an_eased_transition():
     assert verdict["passed"] is True
 
 
-def test_anticipation_verdict_ignores_a_flat_signal():
+def test_anticipation_verdict_refuses_a_flat_signal():
+    """A constant track has no transition, so it cannot have a well-shaped one.
+
+    This asserted `passed is True` when it was written, which is the whole
+    fail-open in miniature: the loop that appends issues never runs on a signal
+    with no peaks, and `not issues` reads that as a clean bill of health. A
+    dead channel and a beautifully eased one returned the identical verdict.
+    """
     times = [i * 0.05 for i in range(60)]
     values = [1.0] * 60
     verdict = ac.anticipation_verdict(times, values)
-    assert verdict["passed"] is True
+    assert verdict["passed"] is False
     assert verdict["events"] == 0
+    assert verdict["issues"][0]["kind"] == "unmeasured"
 
 
 def test_log_response_is_zero_mean_on_a_constant_signal():
@@ -213,3 +221,69 @@ def test_log_response_is_zero_mean_on_a_constant_signal():
     values = [5.0] * 40
     result = ac.log_response(times, values)
     assert max(abs(r) for r in result["response"]) < 1e-6
+
+
+# ---------------------------------------------------------------------------
+# Fail-open guards
+#
+# Every verdict in this module is a loop that appends an issue per fault and
+# returns `passed = not issues`, so any input the loop cannot run over — a dead
+# channel, a NaN, a clip too short to transform — used to come back green. The
+# four metrics scored a 60-sample motionless track as clean, eased, jitter-free
+# and skate-free at once. These pin the refusals.
+# ---------------------------------------------------------------------------
+
+def _still(n=60, dt=0.05):
+    """A bone that does not move: n identical samples."""
+    return [i * dt for i in range(n)], [(1.0, 2.0, 3.0)] * n
+
+
+def test_zero_motion_is_unmeasured_not_smooth():
+    times, values = _still()
+    for measure, verdict in (
+            (ac.velocity_profile(times, values),
+             ac.velocity_profile_verdict),
+            (ac.sparc(times, values), ac.sparc_verdict),
+            (ac.foot_skate(times, values), ac.foot_skate_verdict)):
+        assert measure["measured"] is False, measure
+        assert verdict(measure)["passed"] is False
+
+
+def test_nan_does_not_pass_every_threshold():
+    """Every gate here is a `>` or `<`, and NaN compares False against both."""
+    times = [i * 0.05 for i in range(20)]
+    values = [(float("nan"), 0.0, 0.0)] * 20
+    assert ac.velocity_profile(times, values)["measured"] is False
+    assert ac.sparc(times, values)["measured"] is False
+    assert ac.foot_skate(times, values)["measured"] is False
+    assert ac.anticipation_verdict(times, [float("nan")] * 20)["passed"] is False
+
+
+def test_a_clip_too_short_to_transform_is_not_the_smoothest_possible():
+    """sparc 0.0 is its best score, and it was what a sub-0.1s clip of pure
+    noise received — the arc loop never ran, so nothing was integrated."""
+    times = [i * 0.01 for i in range(5)]
+    values = [(v, 0.0, 0.0) for v in (0.0, 9.0, -7.0, 8.0, -9.0)]
+    result = ac.sparc(times, values)
+    assert result["measured"] is False
+    assert ac.sparc_verdict(result)["passed"] is False
+
+
+def test_a_foot_that_never_plants_is_not_a_foot_that_never_slides():
+    """Zero contact frames yields zero skating frames — the same output a
+    perfectly planted foot gives. A wrong ground_axis looks exactly like this."""
+    times = [i * 0.05 for i in range(30)]
+    rising = [(float(i), float(i) * 2.0, 0.0) for i in range(30)]
+    result = ac.foot_skate(times, rising)
+    assert result["measured"] is False
+    assert ac.foot_skate_verdict(result)["passed"] is False
+
+
+def test_a_real_clip_is_still_measured():
+    """The guards must not swallow the ordinary case."""
+    times = [i * 0.05 for i in range(60)]
+    values = [(math.sin(t), 0.0, 0.0) for t in times]
+    profile = ac.velocity_profile(times, values)
+    assert profile.get("measured", True) is True
+    assert profile["peak_speed"] > 0
+    assert ac.sparc(times, values).get("measured", True) is True

--- a/tests/test_art_tournament.py
+++ b/tests/test_art_tournament.py
@@ -178,3 +178,110 @@ def test_verdicts_close_matches_and_standings_update(client, root):
         "/api/art-tournament/standings", params={"logical_name": "hero"}).json()
     assert standings["decided_matches"] == 1
     assert standings["standings"][0]["artifact_id"] == a["id"]
+
+
+# ---------------------------------------------------------------------------
+# Silent-loss guards
+#
+# Every one of these was a path where the tournament reported success while
+# quietly discarding or duplicating a reviewer's judgement.
+# ---------------------------------------------------------------------------
+
+def test_record_verdict_refuses_to_overwrite_a_decided_match(root):
+    """The brief walks an agent through 28 of these in a row, so a retry after
+    a dropped response was rewriting a recorded pick in silence — two activity
+    lines both claiming a win, and a ranking that moved under a caller who
+    thought they were re-sending the same thing."""
+    a, b = _candidate(root, "a", b"one"), _candidate(root, "b", b"two")
+    match = art_tournament.record_match(
+        root, logical_name="hero", candidate_a_id=a["id"],
+        candidate_b_id=b["id"], shown_first="a")
+    art_tournament.record_verdict(root, match["id"], winner_artifact_id=a["id"])
+    with pytest.raises(ValueError, match="already decided"):
+        art_tournament.record_verdict(root, match["id"],
+                                      winner_artifact_id=b["id"])
+    assert art_tournament.get_match(root, match["id"])["winner_id"] == a["id"]
+
+
+def test_standings_rates_every_match_not_the_oldest_five_hundred(root):
+    """list_matches caps at 500 rows ordered oldest-first, and standings took
+    that default — so past 500 comparisons a target was ranked on its OLDEST
+    verdicts while every newer one was dropped without a word."""
+    a, b = _candidate(root, "a", b"one"), _candidate(root, "b", b"two")
+    for _ in range(505):
+        match = art_tournament.record_match(
+            root, logical_name="hero", candidate_a_id=a["id"],
+            candidate_b_id=b["id"], shown_first="a")
+        art_tournament.record_verdict(root, match["id"],
+                                      winner_artifact_id=a["id"])
+    assert art_tournament.standings(root, "hero")["decided_matches"] == 505
+
+
+def test_list_matches_treats_an_empty_tournament_ref_as_a_filter(root):
+    """record_match stores "" as its own default, so it is a real value a
+    caller can ask for — `if tournament_ref:` silently widened that request
+    to every tournament ever run for the name."""
+    a, b = _candidate(root, "a", b"one"), _candidate(root, "b", b"two")
+    art_tournament.record_match(root, logical_name="hero",
+                                candidate_a_id=a["id"], candidate_b_id=b["id"],
+                                shown_first="a", tournament_ref="")
+    art_tournament.record_match(root, logical_name="hero",
+                                candidate_a_id=a["id"], candidate_b_id=b["id"],
+                                shown_first="a", tournament_ref="round-2")
+    assert len(art_tournament.list_matches(root, logical_name="hero")) == 2
+    assert len(art_tournament.list_matches(
+        root, logical_name="hero", tournament_ref="")) == 1
+    assert len(art_tournament.list_matches(
+        root, logical_name="hero", tournament_ref="round-2")) == 1
+
+
+def test_discard_matches_leaves_decided_ones_alone(root):
+    a, b = _candidate(root, "a", b"one"), _candidate(root, "b", b"two")
+    open_match = art_tournament.record_match(
+        root, logical_name="hero", candidate_a_id=a["id"],
+        candidate_b_id=b["id"], shown_first="a")
+    closed = art_tournament.record_match(
+        root, logical_name="hero", candidate_a_id=a["id"],
+        candidate_b_id=b["id"], shown_first="a")
+    art_tournament.record_verdict(root, closed["id"], winner_artifact_id=a["id"])
+    assert art_tournament.discard_matches(
+        root, [open_match["id"], closed["id"]]) == 1
+    assert art_tournament.get_match(root, closed["id"])["winner_id"] == a["id"]
+
+
+def test_start_refuses_more_candidates_than_the_round_robin_cap(client, root):
+    """The cap check was unreachable: the query already truncated to 8, so
+    `len(candidates) > 8` could never be true and twelve candidates silently
+    became a round-robin over an arbitrary eight of them."""
+    for i in range(12):
+        _candidate(root, f"c{i}", b"x" * (i + 1))
+    got = client.post("/api/art-tournament/start", json={"logical_name": "hero"})
+    assert got.status_code == 400
+    assert "cap" in got.text
+    assert art_tournament.list_matches(root, logical_name="hero") == []
+
+
+def test_start_refuses_a_second_open_tournament_for_the_same_target(client, root):
+    """standings() pools every match for a logical_name, so a duplicate
+    round-robin did not sit harmlessly beside the first — it weighted the
+    same comparison twice in the Elo."""
+    _candidate(root, "a", b"one")
+    _candidate(root, "b", b"two")
+    first = client.post("/api/art-tournament/start", json={"logical_name": "hero"})
+    assert first.status_code == 200
+    again = client.post("/api/art-tournament/start", json={"logical_name": "hero"})
+    assert again.status_code == 409
+    assert art_tournament.standings(root, "hero")["pending_matches"] == 1
+
+
+def test_start_explains_the_auto_approve_interaction(client, root):
+    """With art.auto_approve on, register() promotes on the spot and nothing
+    ever reaches status "candidate" — so this endpoint 404s on every target,
+    and a bare "found 0 candidates" points at the wrong thing entirely."""
+    from bgate_core import settings
+    settings.set(root, "art.auto_approve", True)
+    _candidate(root, "a", b"one")
+    _candidate(root, "b", b"two")
+    got = client.post("/api/art-tournament/start", json={"logical_name": "hero"})
+    assert got.status_code == 404
+    assert "auto_approve" in got.text

--- a/tests/test_harness_findings.py
+++ b/tests/test_harness_findings.py
@@ -5,7 +5,6 @@ project, not a thing that could happen. The comments name what it cost.
 """
 from __future__ import annotations
 
-import json
 from pathlib import Path
 
 import pytest

--- a/tests/test_rig_quality.py
+++ b/tests/test_rig_quality.py
@@ -109,35 +109,81 @@ def test_verdict_catches_weights_that_move_nothing():
 
 
 # ---------------------------------------------------------------------------
-# Template deviation: do a rig's joints sit where the shipped skeleton puts them
+# Template deviation: does a rig share the shipped skeleton's proportions
+#
+# Bone LENGTHS, not joint positions. Positions are stance-dependent and the two
+# skeletons are never in the same stance — rig() defaults to an A-pose and the
+# template is a T-pose — so the positional version reported both hands 0.154
+# body-heights out against a 0.08 threshold on a correctly-rigged character,
+# perfectly mirrored left to right, with every non-arm bone at exactly 0.0.
+# Each bone maps to [length_as_body_height_fraction, parent_name].
 # ---------------------------------------------------------------------------
 
+def _tdev(ref, cand):
+    return {"ok": True, "reference_bones": ref, "candidate_bones": cand}
+
+
 def test_template_deviation_passes_an_identical_skeleton():
-    joints = {"Hips": [0.0, 0.0, 0.5], "Head": [0.0, 0.0, 0.95]}
-    report = {"reference_joints": joints, "candidate_joints": dict(joints)}
-    verdict = blender.template_deviation_verdict(report)
+    bones = {"Hips": [0.06, "Root"], "Head": [0.13, "Neck"]}
+    verdict = blender.template_deviation_verdict(_tdev(bones, dict(bones)))
     assert verdict["passed"] is True
     assert verdict["checked"] == 2
 
 
-def test_template_deviation_names_a_displaced_bone():
-    ref = {"Hips": [0.0, 0.0, 0.5], "LeftHand": [0.6, 0.0, 0.8]}
-    # LeftHand fourteen centimetres out on a 1.8 m figure — the real incident
-    # humanoid_template's own docstring cites, expressed as a height fraction.
-    cand = {"Hips": [0.0, 0.0, 0.5], "LeftHand": [0.68, 0.0, 0.8]}
-    verdict = blender.template_deviation_verdict({"reference_joints": ref,
-                                                   "candidate_joints": cand})
+def test_template_deviation_survives_a_stance_difference():
+    """THE BUG THIS CHECK WAS BORN WITH. An A-posed candidate against the
+    T-posed template failed every bone in the arm chain, on a rig that was
+    correct. Rotating a joint cannot change the length of the bone below it,
+    so identical proportions read as identical whatever the pose."""
+    bones = {"LeftUpperArm": [0.155, "LeftShoulder"],
+             "LeftLowerArm": [0.146, "LeftUpperArm"],
+             "LeftHand": [0.04, "LeftLowerArm"]}
+    verdict = blender.template_deviation_verdict(_tdev(bones, dict(bones)))
+    assert verdict["passed"] is True
+
+
+def test_template_deviation_names_a_misproportioned_bone():
+    ref = {"Hips": [0.06, "Root"], "LeftHand": [0.04, "LeftLowerArm"]}
+    # A hand bone stretched to a quarter of body height — no fit produces this.
+    cand = {"Hips": [0.06, "Root"], "LeftHand": [0.25, "LeftLowerArm"]}
+    verdict = blender.template_deviation_verdict(_tdev(ref, cand))
     assert verdict["passed"] is False
     assert verdict["issues"][0]["bone"] == "LeftHand"
+    assert verdict["issues"][0]["kind"] == "proportion"
+
+
+def test_template_deviation_catches_a_rewired_chain():
+    """Same 23 names, different hierarchy — nothing retargets onto that."""
+    ref = {"LeftHand": [0.04, "LeftLowerArm"]}
+    cand = {"LeftHand": [0.04, "Hips"]}
+    verdict = blender.template_deviation_verdict(_tdev(ref, cand))
+    assert verdict["passed"] is False
+    assert verdict["issues"][0]["kind"] == "hierarchy"
 
 
 def test_template_deviation_only_compares_shared_bones():
-    ref = {"Hips": [0.0, 0.0, 0.5], "Tail": [0.0, -0.2, 0.3]}
-    cand = {"Hips": [0.0, 0.0, 0.5]}
-    verdict = blender.template_deviation_verdict({"reference_joints": ref,
-                                                   "candidate_joints": cand})
+    ref = {"Hips": [0.06, "Root"], "Tail": [0.2, "Hips"]}
+    cand = {"Hips": [0.06, "Root"]}
+    verdict = blender.template_deviation_verdict(_tdev(ref, cand))
     assert verdict["checked"] == 1
     assert verdict["passed"] is True
+
+
+def test_template_deviation_refuses_a_skeleton_it_shares_no_names_with():
+    """An empty intersection is not agreement. A candidate on the mixamorig
+    scheme used to report checked 0 and pass."""
+    verdict = blender.template_deviation_verdict(
+        _tdev({"Hips": [0.06, "Root"]}, {"mixamorig:Hips": [0.06, "Root"]}))
+    assert verdict["passed"] is False
+    assert verdict["checked"] == 0
+    assert verdict["issues"][0]["kind"] == "unmeasured"
+
+
+def test_template_deviation_refuses_a_failed_run():
+    verdict = blender.template_deviation_verdict(
+        {"ok": False, "error": "no report from Blender"})
+    assert verdict["passed"] is False
+    assert verdict["issues"][0]["kind"] == "unmeasured"
 
 
 # ---------------------------------------------------------------------------
@@ -168,7 +214,8 @@ def test_hull_area_is_zero_on_fewer_than_three_points():
 
 
 def test_silhouette_verdict_passes_an_ordinary_pose_change():
-    report = {"poses": [{"label": "arm_raise", "area_ratio": 1.4},
+    report = {"ok": True,
+              "poses": [{"label": "arm_raise", "area_ratio": 1.4},
                         {"label": "elbow_bend", "area_ratio": 0.85}]}
     verdict = blender.silhouette_verdict(report)
     assert verdict["passed"] is True
@@ -176,25 +223,41 @@ def test_silhouette_verdict_passes_an_ordinary_pose_change():
 
 
 def test_silhouette_verdict_catches_a_collapse():
-    report = {"poses": [{"label": "knee_bend", "area_ratio": 0.05}]}
+    report = {"ok": True, "poses": [{"label": "knee_bend", "area_ratio": 0.05}]}
     verdict = blender.silhouette_verdict(report)
     assert verdict["passed"] is False
     assert verdict["issues"][0]["kind"] == "collapsed"
 
 
 def test_silhouette_verdict_catches_an_explosion():
-    report = {"poses": [{"label": "spine_twist", "area_ratio": 12.0}]}
+    report = {"ok": True, "poses": [{"label": "spine_twist", "area_ratio": 12.0}]}
     verdict = blender.silhouette_verdict(report)
     assert verdict["passed"] is False
     assert verdict["issues"][0]["kind"] == "exploded"
 
 
-def test_silhouette_verdict_skips_unmeasured_poses():
-    report = {"poses": [{"label": "head_turn", "skipped": "no bone"},
+def test_silhouette_verdict_refuses_a_sweep_that_measured_nothing():
+    """Every pose skipped is not every pose clean. This returned checked 0
+    and passed — a sweep of a rig missing the bones it rotates."""
+    report = {"ok": True,
+              "poses": [{"label": "head_turn", "skipped": "no bone"},
                         {"label": "knee_bend", "area_ratio": None}]}
     verdict = blender.silhouette_verdict(report)
-    assert verdict["passed"] is True
+    assert verdict["passed"] is False
     assert verdict["checked"] == 0
+    assert verdict["issues"][0]["kind"] == "unmeasured"
+
+
+def test_silhouette_verdict_refuses_an_inert_model():
+    """flex_verdict's own bug, reintroduced here. A mesh no bone drives
+    projects the identical outline in every pose, so every ratio is exactly
+    1.0 — and bounds that only fire far from 1.0 called that a perfect sweep."""
+    report = {"ok": True,
+              "poses": [{"label": p, "area_ratio": 1.0}
+                        for p in ("arm_raise", "elbow_bend", "knee_bend")]}
+    verdict = blender.silhouette_verdict(report)
+    assert verdict["passed"] is False
+    assert verdict["issues"][0]["kind"] == "inert"
 
 
 @needs_blender
@@ -239,29 +302,63 @@ def test_coverage_is_exact_name_not_fuzzy():
 # Weight-island bleed: does a bone's paint cover one patch or two
 # ---------------------------------------------------------------------------
 
+def _bone(islands, shells, bleed, count=240):
+    return {"vertex_count": count, "islands": islands, "shells": shells,
+            "bleed_vertices": bleed, "sizes": [count - bleed, bleed],
+            "largest_fraction": round((count - bleed) / count, 4)}
+
+
 def test_weight_islands_verdict_passes_one_contiguous_patch():
-    report = {"bones": {"Hand.L": {"vertex_count": 240, "islands": 1,
-                                   "sizes": [240], "largest_fraction": 1.0}}}
+    report = {"ok": True, "bones": {"Hand.L": _bone(1, 1, 0)}}
     assert blender.weight_islands_verdict(report)["passed"] is True
 
 
 def test_weight_islands_verdict_catches_a_bleeding_bone():
-    report = {"bones": {"Hand.L": {"vertex_count": 240, "islands": 2,
-                                   "sizes": [232, 8], "largest_fraction": 0.967},
-                        "Spine": {"vertex_count": 900, "islands": 1,
-                                  "sizes": [900], "largest_fraction": 1.0}}}
-    verdict = blender.weight_islands_verdict(report, min_largest_fraction=0.99)
+    report = {"ok": True, "bones": {"Hand.L": _bone(2, 1, 8),
+                                    "Spine": _bone(1, 1, 0, count=900)}}
+    verdict = blender.weight_islands_verdict(report)
     assert verdict["passed"] is False
     assert [i["bone"] for i in verdict["issues"]] == ["Hand.L"]
     assert verdict["issues"][0]["bleed_vertices"] == 8
 
 
+def test_weight_islands_verdict_allows_a_bone_spanning_separate_mesh_pieces():
+    """THE BUG THIS GATE WAS BORN WITH, second layer. This pipeline joins
+    characters out of primitives, so a hip bone legitimately covers three
+    disconnected shells. Counting its islands against a hardcoded 1 made
+    every such bone a false positive on a bind that was correct."""
+    report = {"ok": True, "bones": {"Hips": _bone(3, 3, 90)}}
+    assert blender.weight_islands_verdict(report)["passed"] is True
+
+
+def test_weight_islands_verdict_still_catches_a_split_inside_one_piece():
+    """Spanning pieces is fine; splitting within one is what nothing but a
+    stray stroke explains."""
+    report = {"ok": True, "bones": {"Hips": _bone(4, 3, 90)}}
+    verdict = blender.weight_islands_verdict(report)
+    assert verdict["passed"] is False
+    assert verdict["issues"][0]["shells"] == 3
+
+
 def test_weight_islands_verdict_ignores_a_single_stray_vertex():
     """One vertex a brush missed is a cleanup nit, not a failure this gate names."""
-    report = {"bones": {"Hand.L": {"vertex_count": 240, "islands": 2,
-                                   "sizes": [239, 1], "largest_fraction": 0.996}}}
-    verdict = blender.weight_islands_verdict(report)
-    assert verdict["passed"] is True
+    report = {"ok": True, "bones": {"Hand.L": _bone(2, 1, 1)}}
+    assert blender.weight_islands_verdict(report)["passed"] is True
+
+
+def test_weight_islands_verdict_refuses_a_bind_with_no_weights():
+    """An empty table is not a clean one. A bind where no vertex cleared the
+    threshold reported checked 0 and passed."""
+    verdict = blender.weight_islands_verdict({"ok": True, "bones": {}})
+    assert verdict["passed"] is False
+    assert verdict["checked"] == 0
+    assert verdict["issues"][0]["kind"] == "unmeasured"
+
+
+def test_weight_islands_verdict_refuses_a_failed_run():
+    verdict = blender.weight_islands_verdict({"ok": False, "error": "boom"})
+    assert verdict["passed"] is False
+    assert verdict["issues"][0]["kind"] == "unmeasured"
 
 
 # ---------------------------------------------------------------------------
@@ -319,10 +416,12 @@ def test_template_deviation_of_a_real_bind(bound_glb):
     out, _ = bound_glb
     got = blender.template_deviation(str(out), timeout=900)
     assert got["ok"] is True, got.get("error")
-    assert got["candidate_joints"]
+    assert got["candidate_bones"]
     verdict = blender.template_deviation_verdict(got)
-    # bg_human IS the template, adopted and rebound — its own joints should
-    # sit close to where the shipped skeleton puts them.
+    # bg_human IS the template, adopted and rebound — its own bones should
+    # keep the shipped skeleton's proportions. It is rigged in an A-pose and
+    # the template is a T-pose, which is exactly the difference lengths are
+    # immune to and joint positions were not.
     assert verdict["checked"] >= 10
     assert verdict["passed"] is True, verdict["issues"]
 
@@ -337,15 +436,50 @@ def test_rig_reports_bone_coverage(bound_glb):
 
 
 @needs_blender
-def test_weight_islands_measures_a_real_bind(bound_glb):
+def test_weight_islands_does_not_flag_every_bone_of_a_clean_bind(bound_glb):
+    """THE FALSE-POSITIVE STORM. Before the adjacency graph welded coincident
+    vertices, this reported 14 to 30 islands on EVERY deform bone of a bind
+    the rest of the suite calls good — it was counting the vertex splits the
+    glTF exporter makes at UV and normal seams, not weight bleed. A gate that
+    is red on 100% of valid input is worse than no gate: it teaches the agent
+    reading it to ignore the result.
+
+    Asserted as a ceiling on flagged bones rather than zero, because zero is
+    not true of this fixture and pinning it would have been the same mistake
+    in the other direction — see the test below.
+    """
     out, _ = bound_glb
     got = blender.weight_islands(str(out), timeout=900)
     assert got["ok"] is True, got.get("error")
     assert got["deform_bones"] >= 10
     assert len(got["bones"]) >= 10
-    # A clean bind from a fresh bind() call should read as fully contiguous.
     verdict = blender.weight_islands_verdict(got)
-    assert verdict["passed"] is True, verdict["issues"]
+    flagged = {i["bone"] for i in verdict["issues"]}
+    assert len(flagged) <= 3, sorted(flagged)
+    # The limbs were the loudest false positives and must now be clean.
+    for bone in ("LeftUpperArm", "RightUpperArm", "LeftUpperLeg",
+                 "RightUpperLeg", "LeftShoulder", "RightShoulder"):
+        assert bone not in flagged, verdict["issues"]
+
+
+@needs_blender
+def test_weight_islands_finds_the_chest_split_in_the_shipped_template(bound_glb):
+    """A REAL PROPERTY OF bg_human's BIND, not a measurement artifact, and
+    recorded here so a future change to bind() shows up as a diff rather than
+    as a silent improvement or regression.
+
+    Chest's weights fall into two separate regions of ONE connected piece of
+    mesh — 22 vertices and 15 — and they stay separate as the membership
+    threshold is raised from 0.02 all the way to 0.2, so this is not the
+    near-zero fringe a low threshold invents. Whether it is worth fixing in
+    the template is a rigging question this test does not answer; that it is
+    genuinely there is what it pins.
+    """
+    out, _ = bound_glb
+    got = blender.weight_islands(str(out), threshold=0.1, timeout=900)
+    chest = got["bones"]["Chest"]
+    assert chest["shells"] == 1
+    assert chest["islands"] == 2, chest
 
 
 # ---------------------------------------------------------------------------
@@ -458,3 +592,35 @@ def test_retarget_says_so_when_the_model_is_not_rigged(probe_project):
     got = godot.retarget_check(str(root), "res://assets/does_not_exist.glb")
     assert got["ok"] is False
     assert "no resource" in json.dumps(got)
+
+
+# ---------------------------------------------------------------------------
+# The two hull_area copies
+# ---------------------------------------------------------------------------
+
+def test_the_embedded_hull_area_matches_the_module_one():
+    """_hull_area and the copy inside _SILHOUETTE_SCRIPT are maintained by
+    hand, in two places, and only one of them is reachable from a test — the
+    other runs inside Blender. Nothing stopped them drifting apart, which
+    would have made the module's unit tests above prove nothing about the
+    number the gate actually judges.
+    """
+    ns: dict = {}
+    body = blender._SILHOUETTE_SCRIPT.split("def hull_area(points):", 1)[1]
+    lines = body.splitlines()
+    end = next(i for i, ln in enumerate(lines)
+               if ln and not ln.startswith((" ", "\t")))
+    exec("def hull_area(points):" + "\n".join(lines[:end]), ns)
+    embedded = ns["hull_area"]
+
+    cases = [
+        [(0, 0), (1, 0), (1, 1), (0, 1)],
+        [(0, 0), (2, 0), (0, 2)],
+        [(0, 0), (1, 0), (1, 1), (0, 1), (0.5, 0.5)],
+        [(0, 0), (1, 0), (2, 0)],
+        [(1, 1)],
+        [],
+        [(0.0, 0.0), (3.5, 0.25), (2.0, 4.0), (-1.0, 2.5), (1.0, 1.0)],
+    ]
+    for pts in cases:
+        assert embedded(pts) == blender._hull_area(pts), pts

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -13,7 +13,6 @@ is the whole reason it is done this way.
 """
 from __future__ import annotations
 
-import pytest
 
 from bgate_core import queue, settings
 from bgate_ui import dispatch, runners


### PR DESCRIPTION
Two detectors were red on 100% of valid input and five verdicts were green on input they had not looked at. Both directions teach a reading agent to ignore the result.

WELD BEFORE COUNTING ISLANDS. weight_islands built its adjacency on the raw glTF edge graph, so it was measuring the vertex splits the exporter makes at UV and normal seams rather than weight bleed — 940 authored vertices come back as 1559, and every bone's weight set duly fell apart along the seams. RightUpperLeg read 14 islands where the welded graph shows 2. Fusing only exactly-coincident vertices keeps the promise the edge-only version was written for: a genuine seam a millimetre wide still counts as separate. Islands are now judged against the number of mesh shells the bone touches rather than against 1, because this pipeline joins characters out of primitives and a hip bone legitimately spans three of them.

COMPARE LENGTHS, NOT JOINT POSITIONS. template_deviation measured bone head positions, which are stance-dependent, against a T-posed template — while rig() defaults to an A-pose. It reported both hands 0.154 body-heights out against a 0.08 threshold, perfectly mirrored, every non-arm bone at exactly 0.0: the arm swing, not a fit fault, failing every correct character. Lengths are invariant under both stance and translation, and proportions are what the docstring always claimed to check. Parent links ride along so a rewired chain is still caught. The report also drops from 3580 characters to well under run_script's 4000-character stdout window, where three more bones would have made a working run parse as "no report from Blender".

AN UNKNOWN IS NOT A PASS. Each verdict is a loop appending one issue per fault returning `passed = not issues`, so an empty collection sailed through: a failed run, no armature, a bind with no weights, zero shared bone names, a sweep with every pose skipped, an unbound mesh projecting area_ratio 1.0 six times, a 60-sample motionless track scoring eased and jitter-free and skate-free at once, a NaN that compares False against every threshold, and a file with no animations reporting "0/0 clips clean". flex_verdict shipped this exact bug and had an inertness clause added after a real run passed a mesh nothing was bound to; these five reintroduced it.

Also, in the same family of silent loss:
- standings() rated the OLDEST 500 matches and dropped every newer verdict
- the MAX_CANDIDATES guard was unreachable, so 12 candidates silently became a round-robin over an arbitrary 8, reported as complete
- a second verdict on a decided match overwrote the first without a word
- a repeat /start duplicated the round-robin, double-weighting the same comparison in the Elo; a failed dispatch orphaned it with no way to clear
- tournament_ref="" widened the query to every tournament instead of filtering
- bleed_vertices summed a list truncated to 8 for display
- art.auto_approve makes a tournament unreachable; the 404 now says so

Tests: +30, covering every guard above, plus a drift test pinning the two hand-maintained hull_area copies together. One existing test asserted the fail-open (anticipation_verdict on a flat signal -> passed True) and is inverted. test_weight_islands_measures_a_real_bind asserted a fresh bind is fully contiguous, which is not true of the shipped template: Chest splits into two regions of one connected mesh piece and stays split as the threshold rises from 0.02 to 0.2. That is recorded as a property rather than hidden by widening the gate.

