### PR TITLE
fix(gates,art,board): the approval gate ignored "none", and four chec…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,152 @@ repository at first publication. There is no earlier release history to record.
 - **`assets.lock_holder()`** — one implementation of "who holds this path",
   which never raises. Three callers were answering it three ways or not at all.
 
+- **`pending_decisions`** — everything waiting on a human, in one call: the work
+  items parked by the builder's gate (the hard block — the chain behind each does
+  not advance), the artifact revisions nobody has dispositioned, and the open
+  `ask_human` questions, alongside the active gate mode. There was no way to ask
+  this. `asset_status` lists candidates but exposes no approval *state*,
+  `art_tournament_standings` reports Elo from matches already decided, and human
+  approval was dashboard-only — so a director could not see, surface or triage a
+  queue of decisions blocking its own board. It cannot approve anything and is
+  not meant to: the agent that made a candidate is exactly who must not clear it.
+  A candidate a QA agent already passed is reported distinctly from a raw one,
+  because the human is then confirming a check rather than performing the first.
+
+- **The heartbeat carries pending decisions.** `.bgate/notify.jsonl` now takes
+  `artifact.candidate` and `artifact.reviewed` lines beside the work-item ones,
+  and the event bus takes matching kinds. It carried only work-item transitions,
+  so five species candidates generated inside two minutes produced **zero lines**
+  while the dashboard drew an approval card for each — a blocking gate with no
+  signal, which looks exactly like an agent quietly working. Purely additive:
+  every line still carries `{ts, item_id, status, seat, title}`, now with a
+  `kind`, so a consumer reading `status` sees what it always saw.
+
+- **`queue_add(depends_on=...)`** — order for an item filed onto a board that
+  already has the work it waits on. Priority is a preference among things that
+  are ALL ready; it does not stop auto-deploy from starting both agents in the
+  same tick, so the one that needed the other's output writes against a file
+  that does not exist and reports done. Order could previously only be expressed
+  by `queue_add_chain`, which files a whole group at once — and chains are
+  strictly linear and cannot be appended to, so a dependent FOLLOW-UP had no
+  correct form at all. A dependency on an item that does not exist is refused,
+  not dropped: an item silently waiting on nothing dispatches immediately.
+
+- **`project_set_dimension`** — correct the 2d/3d record after the game changes
+  shape. `init` wrote it and `adopt` detected it; nothing could change it, so a
+  2D prototype that grew a 3D scene reported `dimension: "2d"` forever. Not
+  cosmetic — the field steers scaffolding templates and the wording of seat
+  briefs. The only workaround was re-running `project_init`, which overwrites
+  name, pitch and engine to correct one field.
+
+- **The seat brief carries the traps, gated by seat and dimension.** Two agents
+  independently hit the `.tscn` Transform3D transpose in one night; once the list
+  was pasted into briefs by hand, nobody did — and the hand-pasting only happened
+  because somebody remembered. Every row is a bug that has already cost a run AND
+  emits no error a search would find (transpose, winding-vs-normals,
+  parse-error-looks-like-a-hang, `preload` not `class_name`, deferred `_ready`,
+  sequential imports, sRGB-vs-linear, self-reported success, screenshot focus).
+  A 2D project is not billed for the 3D rows. The brief also now states that the
+  MCP tools are DEFERRED and need `ToolSearch` first — universal, non-obvious,
+  and an agent that has not been told concludes the tools do not exist.
+
+- **A long correction can reach a running agent.** `agent_steer` past 2000
+  characters writes the full text to the project's steer box and hands the agent
+  the opening paragraph plus that path, instead of refusing outright. The cap is
+  right and truncation is still never on the table — half a sentence with no way
+  to know it was cut is worse than either — but the refusal left no route for a
+  long correction short of killing the run and paying for it twice.
+
+- **A stopped run says it was stopped** (`work_item.stopped_by` / `stopped_at`,
+  migration 0019, and `queue.stop`). Deliberately NOT a sixth status: `failed` is
+  keyed on in ~85 places — `reopen`'s guard, the QA gate query, the chain
+  interlock, the console's lanes — and a new status changes behaviour in every one
+  that filters by name, silently and by omission. A stopped item stays failed
+  because it did not finish and it IS worth reopening; what was missing was the
+  CAUSE, which is a different question and now has its own column and an
+  `item.stopped` event.
+
 ### Fixed
+
+- **The approval gate's `none` setting was not honoured, for approvals OR
+  sign-offs, across every seat.** With the selector reading `NONE` — labelled *an
+  agent's own word closes its item* — the console went on drawing SIGN-OFF cards
+  over every finished item and APPROVAL cards over every generated candidate,
+  each saying only a human could decide. Observed across art and director both,
+  which is what ruled out "the art path forgot to check" and named it one defect
+  at the gate layer: `routes/console.py::_gates` never read `gates.mode` at all.
+
+  Setting a gate to `none` is a sentence — *do not stop to ask me* — and asking
+  anyway has two silent failure modes: work stalls behind a card nobody knew to
+  click, or the human learns to rubber-stamp, which spends the gate's credibility
+  on the runs where it IS on. It is now off at the DECISION and not merely at the
+  drawing: `artifacts.register` auto-approves under `none`, because suppressing
+  the card while leaving the revision a candidate would leave the live path
+  holding the previous image with the one surface that said so now hidden.
+  Untouched for `agent`, where an agent's verdict still leaves a candidate
+  pending — an agent approving art is the drift the art-QA router exists to stop.
+
+- **The builder's gate drew no card for the items it actually blocks.** The
+  inverse of the above, found while fixing it. `queue.complete` parks a completion
+  in `review` under that mode and the sign-off query asked for `done`, so the one
+  mode that genuinely mandates a human decision was the one whose stopped chains
+  were invisible. Parked items are now listed, marked `parked`, never aged out of
+  the window (a stopped chain is not a claim worth a glance), and `accept` routes
+  to `queue.approve` — acking one into a workspace doc would have cleared the card
+  and left the chain stopped forever.
+
+- **`image_generate(tileable=True)` silently did nothing.** `Image.save`
+  dispatches on the destination's suffix, so an output named `litter_albedo`
+  rather than `litter_albedo.png` raised `ValueError: unknown file extension:`
+  inside a swallowing `try` — the mirror pass never ran and the caller got a
+  texture back reporting success. The evidence arrived days later as a visible
+  seam at 2.4m tiling across a full-screen terrain floor. The format is now taken
+  from the source image, and the metadata records the MEASURED outcome
+  (`tileable`) beside the request (`tileable_requested`), with a `warning` on the
+  result when they disagree. A flag computed from the request is not evidence.
+
+- **The alpha keyer reported `clean: true` over an opaque pink slab.** Krea
+  ignores the pure-magenta backdrop contract and paints a DESATURATED magenta —
+  measured ~`#c0559f`, which is 143 from `(255,0,255)` and so outside the tol=125
+  sphere. The frame border keyed (closest to the contract colour) and the
+  interior did not. Every one of the audit's five measurements inspects THE CUT —
+  border, soft edge, RGB under zero alpha, enclosed holes — and not one inspects
+  what the cut left behind, so a solid rectangle passed all five.
+
+  Two fixes, because either alone leaves the hole. `key` gains a second pass on
+  PINKNESS — `(R+B)/2 - G`, a scalar the desaturated backdrop keeps and a green
+  leaf, brown twig or buff plume does not — unioned with the distance key and
+  gated on the chroma actually being a pink. And `audit(path, chroma=...)` now
+  measures `residual_chroma`: is the key colour still sitting opaque in the
+  frame. Reported as `None` rather than `0.0` when no chroma is passed, because
+  "not checked" and "checked and clean" reading the same is how this shipped.
+
+- **glTF `alphaMode: MASK` is flagged at import.** Godot 4.7 imports it as
+  `DEPTH_PRE_PASS`, not `ALPHA_SCISSOR`, so surfaces meant to be opaque cutouts
+  land in the sorted transparent pass. Nothing errors and one tree looks
+  identical; a forest is a framerate cliff with no error to grep for. Reported
+  rather than corrected — whether a MASK surface wants scissor (foliage) or the
+  transparent pass (genuinely translucent) is not knowable from the file. The
+  glTF JSON chunk is read directly, so warning costs no new dependency.
+
+- **`godot_screenshot` says its window has no foreground focus**, on every
+  result rather than only when something looks wrong. The capture window never
+  takes the foreground on Windows, so `Input.mouse_mode` stays VISIBLE and
+  anything gated on `MOUSE_MODE_CAPTURED` collapses in the shot while working
+  for a human. A previous pass "fixed" that by re-asserting capture every frame
+  with a comment blaming the game, masking the real finding for a whole pass —
+  when a fix has to run every frame forever, it is a symptom, not a cure.
+
+- **`blender_status` conflated "configured" with "running", and hosted with
+  local.** `usable: ["hunyuan-local", "krea", "trellis-cpp"]` gave no hint that
+  two of those need a server the user has to start and one is a hosted API
+  needing only its key — and the summary probes nothing, on purpose, because a
+  status call that blocks on a TCP timeout is one nobody makes. An agent tried
+  the two local backends, got connection refused from both, reported image-to-3D
+  unavailable, and the whole path was written off for a session; Krea was hosted,
+  its key was set, and it had already produced every texture in that build. The
+  `local`/`hosted` split the adapter always computed is now surfaced, alongside
+  `checked` and a note naming a reachable hosted backend by name.
 
 - **Nothing could be dispatched at all.** A CodeQL autofix landed a containment
   check in `runners.preflight` requiring the working directory to sit under

--- a/bgate_adapters/godot.py
+++ b/bgate_adapters/godot.py
@@ -661,6 +661,90 @@ def import_asset(project_dir: str, src_path: str, dest_rel: str = "assets",
         "replaced": replaced,
         "import": {"ok": imported["ok"], "errors": imported.get("errors", [])},
         "engine_view": inspected,
+        # None on anything that is not glTF, or when the file cannot be read.
+        # See alpha_mode_report — a silent transparency downgrade that only shows
+        # up as a framerate cliff on a forest.
+        "alpha_mode": alpha_mode_report(dest),
+    }
+
+
+# The value Godot 4.7 does NOT give you, and the one it gives you instead.
+GLTF_MASK = "MASK"
+GODOT_MASK_ACTUAL = "DEPTH_PRE_PASS"
+GODOT_MASK_EXPECTED = "ALPHA_SCISSOR"
+
+
+def gltf_json(path: str | os.PathLike[str]) -> Optional[dict]:
+    """The glTF JSON for a ``.gltf`` or ``.glb``, or None if it is neither.
+
+    A ``.glb`` is a 12-byte header followed by length-prefixed chunks, the first
+    of which is the same JSON a ``.gltf`` holds in the clear. Reading it needs no
+    glTF library and no Blender — which matters, because this runs on an import
+    path that must not grow a dependency to emit a warning.
+
+    Never raises: a truncated or exotic file gives None, and a missing warning is
+    a much smaller problem than an import that fails because of the warner.
+    """
+    p = Path(path)
+    try:
+        if p.suffix.lower() == ".gltf":
+            return json.loads(p.read_text(encoding="utf-8"))
+        if p.suffix.lower() != ".glb":
+            return None
+        raw = p.read_bytes()
+        if len(raw) < 20 or raw[:4] != b"glTF":
+            return None
+        length = int.from_bytes(raw[12:16], "little")
+        if raw[16:20] != b"JSON":
+            return None
+        return json.loads(raw[20:20 + length].decode("utf-8"))
+    except Exception:
+        return None
+
+
+def alpha_mode_report(path: str | os.PathLike[str]) -> Optional[dict]:
+    """Which materials use ``alphaMode: MASK``, and what Godot will do with them.
+
+    GODOT 4.7 IMPORTS glTF ``MASK`` AS ``DEPTH_PRE_PASS``, NOT ``ALPHA_SCISSOR``.
+    Nothing errors, nothing is logged, and the mesh looks right in a screenshot.
+    What changes is which render pass it lands in: scissor is an OPAQUE-pass
+    cutout resolved per fragment, while depth-pre-pass puts the surface into the
+    SORTED TRANSPARENT pass. On a tree that is hundreds of alpha quads, every one
+    of them is then depth-sorted per frame and cannot early-z against its
+    neighbours — a framerate cliff on a forest, with no error to search for and
+    no visual tell to notice.
+
+    Reported rather than corrected. The fix is a per-material override in the
+    sibling ``.import`` file, and choosing it needs to know whether the surface
+    is foliage (wants scissor) or genuinely translucent (wants the transparent
+    pass) — which this cannot know from the file. Naming it at import time is the
+    difference between a five-minute change and an afternoon profiling a forest.
+
+    None for a non-glTF file or one that cannot be parsed; a dict with an empty
+    ``materials`` list when the file is glTF and uses no MASK at all, because
+    "checked, nothing to say" and "not checked" must not read the same.
+    """
+    doc = gltf_json(path)
+    if doc is None:
+        return None
+    masked = [str(m.get("name") or f"material {i}")
+              for i, m in enumerate(doc.get("materials") or [])
+              if str(m.get("alphaMode") or "").upper() == GLTF_MASK]
+    if not masked:
+        return {"masked_materials": [], "warning": ""}
+    return {
+        "masked_materials": masked,
+        "warning": (
+            f"{len(masked)} material(s) use glTF alphaMode:{GLTF_MASK} "
+            f"({', '.join(masked[:6])}"
+            + (f", +{len(masked) - 6} more" if len(masked) > 6 else "")
+            + f"). Godot 4.7 imports that as {GODOT_MASK_ACTUAL}, NOT "
+            f"{GODOT_MASK_EXPECTED} — so these surfaces render in the sorted "
+            "TRANSPARENT pass instead of as opaque cutouts. Silent, and it costs "
+            "real frames once there are hundreds of alpha quads on screen. If "
+            "these are foliage or any hard-edged cutout, override the material's "
+            f"transparency to {GODOT_MASK_EXPECTED} in the sibling .import "
+            "rather than leaving the default."),
     }
 
 

--- a/bgate_adapters/imagegen.py
+++ b/bgate_adapters/imagegen.py
@@ -70,6 +70,15 @@ def make_tileable(path: str, out_path: Optional[str] = None) -> dict:
     what gets a genuinely seamless map when the model can manage one; this is
     the floor underneath it. Returns ``{ok, path, method, note}`` and never
     raises — a texture that failed to tile is still a texture.
+
+    THE SAVE FORMAT IS NAMED EXPLICITLY, and that is a bug fix, not a tidy-up.
+    ``Image.save`` dispatches on the destination's SUFFIX, so a file written
+    without one — which is what a caller passing ``filename="litter_albedo"``
+    gets — raised ``ValueError: unknown file extension:`` on every call. The
+    failure was real and completely invisible: four texture generations came back
+    reporting a tileable map, and the terrain seamed visibly at 2.4m tiling
+    across a full-screen floor. Nothing downstream re-checks, so the first
+    evidence was the render.
     """
     src = Path(path)
     dst = Path(out_path or path)
@@ -81,6 +90,11 @@ def make_tileable(path: str, out_path: Optional[str] = None) -> dict:
                         "so its edges are only as seamless as the model made them"}
     try:
         with Image.open(src) as im:
+            # The SOURCE knows what it is even when the destination path does
+            # not: Pillow read it, so `im.format` is the real container. Falling
+            # back to PNG rather than raising is right for the one case that
+            # reaches here — a generated plate whose name lost its extension.
+            fmt = im.format or "PNG"
             im = im.convert("RGBA" if "A" in im.getbands() else "RGB")
             w, h = im.size
             flip_h = im.transpose(Image.FLIP_LEFT_RIGHT)
@@ -89,7 +103,11 @@ def make_tileable(path: str, out_path: Optional[str] = None) -> dict:
             canvas.paste(flip_h, (w, 0))
             canvas.paste(im.transpose(Image.FLIP_TOP_BOTTOM), (0, h))
             canvas.paste(flip_h.transpose(Image.FLIP_TOP_BOTTOM), (w, h))
-            canvas.resize((w, h), Image.LANCZOS).save(dst)
+            tiled = canvas.resize((w, h), Image.LANCZOS)
+            if tiled.mode == "RGBA" and fmt in ("JPEG", "JPG"):
+                # A JPEG cannot hold the alpha the convert above may have kept.
+                tiled = tiled.convert("RGB")
+            tiled.save(dst, format=fmt)
     except Exception as exc:                                   # noqa: BLE001
         return {"ok": False, "path": str(src), "method": "",
                 "note": f"could not mirror-tile ({type(exc).__name__}: {exc}) — "

--- a/bgate_core/artifacts.py
+++ b/bgate_core/artifacts.py
@@ -84,6 +84,23 @@ def register(root: str | os.PathLike[str], logical_name: str,
             root, iteration_id, "asset_revision", "artifact", str(artifact_id),
             f"Created {name} r{revision}", {"path": rel, "producer": producer})
 
+    # THE DECISION IS NOW PENDING, AND THE HEARTBEAT HAS TO SAY SO.
+    #
+    # notify.jsonl carried work-item status transitions and nothing else, so a
+    # batch of candidates waiting on a human produced ZERO lines while the
+    # dashboard drew an approval card for each one. Measured: five species
+    # candidates generated inside two minutes, not one line on the stream. A
+    # human decision nobody can see is the same failure as a dead agent — silence
+    # that is indistinguishable from an agent still working — arriving through a
+    # different door, and it is worse here because the thing on the other side of
+    # the silence is a person who does not know they are being waited on.
+    #
+    # Emitted BEFORE the auto-approve below so the ordering on the stream is the
+    # ordering of what happened: the candidate existed, then something cleared
+    # it. A consumer that sees only the pair learns the gate was off; one that
+    # sees the first line alone knows a human is owed an answer.
+    _announce_candidate(root, artifact_id, name, revision, rel, work_item_id)
+
     # AUTO-APPROVE AT REGISTRATION, when the project has asked for it.
     #
     # Gating `review()` alone was not enough and the reason is worth stating: an
@@ -108,6 +125,66 @@ def register(root: str | os.PathLike[str], logical_name: str,
                          f"auto-approve failed for {name} r{revision}: "
                          f"{type(exc).__name__}: {exc}", ref=str(artifact_id))
     return get(root, artifact_id)
+
+
+def _notify_line(root: str | os.PathLike[str], line: dict) -> None:
+    """Append one JSON line to ``.bgate/notify.jsonl``. Never raises.
+
+    THE SAME FILE queue._notify writes, deliberately, and in the same shape:
+    ``{ts, item_id, status, seat, title}`` plus a ``kind``. An orchestrator
+    already tails this one file — telling it to also tail a second one, with a
+    second schema, to learn about the other half of the gates is how a heartbeat
+    stops being a heartbeat.
+
+    ``kind`` is additive: every line queue writes is a work-item transition and
+    now says so, and a consumer that only reads ``status`` sees exactly what it
+    saw before. Losing a ping must never cost the registration that caused it.
+    """
+    try:
+        import json as _json
+        from datetime import datetime, timezone
+
+        path = os.path.join(str(root), ".bgate", "notify.jsonl")
+        with open(path, "a", encoding="utf-8") as fh:
+            fh.write(_json.dumps({
+                "ts": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+                **line,
+            }) + "\n")
+    except Exception:
+        pass
+
+
+def _announce_candidate(root, artifact_id: int, name: str, revision: int,
+                        rel: str, work_item_id: Optional[int]) -> None:
+    """Put a pending human decision on the heartbeat and on the event bus.
+
+    Two surfaces because they answer different questions and neither substitutes
+    for the other: the jsonl is what a shell can tail with no database and no
+    MCP, and the bus is what the notifier, the bell and the webhook read through
+    a cursor that survives a restart. Both guarded — an art run must not fail
+    because a notification could not be filed.
+    """
+    _notify_line(root, {
+        "kind": "artifact.candidate",
+        "item_id": int(work_item_id) if work_item_id else None,
+        # 'candidate' is a real status in STATUSES, not a word invented here, so
+        # a consumer switching on `status` reads something true.
+        "status": "candidate",
+        "seat": "art",
+        "title": f"{name} r{revision} awaiting approval"[:120],
+        "artifact_id": int(artifact_id),
+        "path": rel,
+    })
+    try:
+        from . import events as _events
+
+        _events.emit(root, "artifact.candidate", ref=str(artifact_id), payload={
+            "artifact_id": int(artifact_id), "logical_name": name,
+            "revision": revision, "path": rel,
+            "work_item_id": int(work_item_id) if work_item_id else None,
+        })
+    except Exception:
+        pass
 
 
 def get(root: str | os.PathLike[str], artifact_id: int) -> dict:
@@ -186,16 +263,46 @@ def _promote(root: str | os.PathLike[str], artifact: dict) -> dict:
 def _auto_approve(root: str | os.PathLike[str]) -> bool:
     """Is this project letting agents promote their own artifacts?
 
-    Reads ``art.auto_approve`` (default False). Imported inside the function
-    because ``settings`` is a higher layer than this module and a top-level
-    import would make the dependency circular.
+    TWO WAYS TO SAY YES, and the second one is why this docstring is long.
 
-    FAILS CLOSED. A registry that cannot be read is not permission — it is an
-    unknown, and the safe reading of an unknown here is "a human still decides".
+    ``art.auto_approve`` (default False) is the narrow switch: art specifically,
+    left alone by everything else. The APPROVAL GATE (``gate.mode``) is the broad
+    one, and ``none`` is a project-wide instruction — "an agent's own word closes
+    its item, nobody is checking" — that this path used to ignore completely.
+
+    The consequence was reported from the field and it is worse than a stray
+    card. With the gate at ``none`` every generated candidate still landed as a
+    'candidate', so the dashboard drew an APPROVAL card reading *only a human can
+    approve a candidate* for work the human had explicitly stopped asking about.
+    Suppressing the card alone would have been the wrong fix twice over: the
+    revision would sit un-promoted with the live path still holding the previous
+    image, and the one surface that said so would be the one that had just been
+    hidden. A gate that is off has to be off at the DECISION, not at the drawing
+    of it.
+
+    Deliberately not extended to ``agent``. That mode means a machine verifies
+    the claim, and the art path's machine verdict (:func:`qa_verdict`) is defined
+    to leave the revision a candidate — an agent approving art is exactly the
+    drift the art-QA router exists to stop, and a second agent doing it is the
+    same failure with an extra hop.
+
+    Imported inside the function because ``settings`` and ``gates`` are higher
+    layers than this module and a top-level import would make the dependency
+    circular.
+
+    FAILS CLOSED, both ways. A registry that cannot be read is not permission —
+    it is an unknown, and the safe reading of an unknown here is "a human still
+    decides".
     """
     try:
         from . import settings as _settings
-        return bool(_settings.get(root, "art.auto_approve"))
+        if bool(_settings.get(root, "art.auto_approve")):
+            return True
+    except Exception:
+        return False
+    try:
+        from . import gates as _gates
+        return _gates.mode(root) == _gates.NONE
     except Exception:
         return False
 
@@ -264,7 +371,43 @@ def review(root: str | os.PathLike[str], artifact_id: int, status: str,
             root, int(iteration_id), "asset_decision", "artifact", str(artifact_id),
             f"{artifact['logical_name']} r{artifact['revision']} -> {status}{tail}",
             {"status": status, "reason": note.strip(), "integration": promotion})
+    # THE DECISION CLOSING IS AS MUCH NEWS AS THE DECISION OPENING. Without this
+    # a consumer that saw the candidate line has no way to learn it was answered,
+    # so its pending list only ever grows and it goes on telling the human they
+    # owe a decision they already made.
+    _announce_review(root, artifact, status, who, promotion)
     return get(root, artifact_id)
+
+
+def _announce_review(root, artifact: dict, status: str, who: str,
+                     promotion: Optional[dict]) -> None:
+    """The pending decision is settled. Same two surfaces as the candidate."""
+    _notify_line(root, {
+        "kind": "artifact.reviewed",
+        "item_id": artifact.get("work_item_id"),
+        "status": status,
+        "seat": "art",
+        "title": f"{artifact['logical_name']} r{artifact['revision']} "
+                 f"-> {status}"[:120],
+        "artifact_id": int(artifact["id"]),
+        "by": (who or "")[:120],
+    })
+    try:
+        from . import events as _events
+
+        _events.emit(root, "artifact.reviewed", ref=str(artifact["id"]), payload={
+            "artifact_id": int(artifact["id"]),
+            "logical_name": artifact["logical_name"],
+            "revision": artifact["revision"], "status": status,
+            "by": (who or "")[:120],
+            # Whether the BUILD actually loads these bytes now. 'approved' with a
+            # failed promotion is the case where the badge and the disk disagree,
+            # and a subscriber acting on the badge alone would be acting on the
+            # wrong image.
+            "live": bool(promotion and promotion.get("ok")) if promotion else None,
+        })
+    except Exception:
+        pass
 
 
 def qa_verdict(root: str | os.PathLike[str], artifact_id: int, *, passed: bool,

--- a/bgate_core/chroma.py
+++ b/bgate_core/chroma.py
@@ -332,6 +332,35 @@ def key(img, chroma: Sequence[int], tol: int = 125, despill: int = 185):
     keyed = ev("convert((d2 < near) * 255, 'L')", d2=d2, near=near)
     fringe = ev("convert(min(d2 >= near, d2 < band) * 255, 'L')",
                 d2=d2, near=near, band=band)
+    # SECOND PASS ON PINKNESS, for the backdrop the sphere cannot reach.
+    #
+    # A distance key assumes the model painted the colour it was asked for. Krea
+    # does not: it paints a desaturated version of it, far enough away to miss
+    # the sphere and close enough that a human looking at the frame calls it
+    # magenta. The result was an opaque pink slab that passed the audit on the
+    # strength of its border, which HAD keyed.
+    #
+    # Union rather than replacement — the sphere is exact where it applies, and
+    # this only ever ADDS the off-axis pixels the sphere left behind. Gated on
+    # the chroma actually being a pink, so a cyan or chartreuse key is untouched.
+    if pinkness((cr, cg, cb)) >= PINK_CHROMA_MIN:
+        # int(), not the raw float: ImageMath binds a scalar by building a
+        # one-colour image out of it, and Image.new refuses a float — it raises
+        # "color must be int or single-element tuple", which names neither
+        # ImageMath nor the argument and would land in finish()'s except as an
+        # unexplained "chroma key failed".
+        # Doubled to keep it division-free — see is_pinker_than, which is the
+        # same predicate and must agree with this one pixel for pixel.
+        floor = int(pinkness((cr, cg, cb)) * PINK_KEY_FRACTION)
+        pinkish = ev("convert((((r+b) - 2*g) > twice) * 255, 'L')",
+                     r=r, g=g, b=b, twice=2 * floor)
+        keyed = ev("convert(max(keyed, pinkish), 'L')",
+                   keyed=keyed, pinkish=pinkish)
+        # Anything newly keyed must not also be treated as fringe, or the
+        # despill below paints grey into pixels that are about to become
+        # transparent — which is dirty alpha, the thing the audit fails on.
+        fringe = ev("convert(min(fringe, 255 - keyed), 'L')",
+                    fringe=fringe, keyed=keyed)
     # int() before convert() so the halving floors exactly like the // it
     # replaces — an F->L convert would be free to land a pixel one step off.
     grey = ev("convert(int((r+g+b)/3), 'L')", r=r, g=g, b=b)
@@ -358,9 +387,74 @@ SOFT_ALPHA_MAX = 0.35      # feathered/mushy cut instead of a crisp one
 DIRTY_ALPHA_MAX = 0.15     # colour still sitting under alpha 0
 HOLLOW_REVIEW = 0.05       # enclosed transparency — maybe a curled arm
 HOLLOW_FAIL = 0.12         # ...or the key ate the art from the inside
+# The key colour SURVIVING inside the frame. Every threshold above measures the
+# cut; this one measures what the cut missed, which is the failure they all
+# walked past — see the `residual_chroma` paragraph in audit().
+RESIDUAL_CHROMA_MAX = 0.04
 
 
-def audit(path: str | os.PathLike[str]) -> dict:
+# PINKNESS, and why a colour distance is not enough.
+#
+# `key` compares squared RGB distance to the chroma, which is a SPHERE around
+# one point. Krea ignores the pure-magenta backdrop contract and paints a DUSTY
+# pink — measured at ~#c0559f, which is 143 away from (255,0,255) and therefore
+# outside the default tol=125 sphere. Widening the sphere is not the fix: at 143
+# it starts swallowing skin, brick and autumn leaf.
+#
+# The backdrop is not an arbitrary colour, though. It is the chroma DESATURATED
+# toward grey, so it keeps the one property that made magenta a good key in the
+# first place — red and blue high, green low — while losing the distance. That
+# property is a scalar:
+#
+#     pinkness = (R + B) / 2 - G
+#
+# Measured on real frames from the run this came out of:
+#
+#     pure magenta   (255,  0,255) -> 255      the contract
+#     krea's dusty   (192, 85,159) ->  90      what actually arrived
+#     pink petal     (240,150,180) ->  60      must SURVIVE
+#     buff plume     (220,200,160) -> -10      must survive
+#     brown twig     (110, 80, 50) ->   0      must survive
+#     green leaf     ( 60,120, 50) -> -65      must survive
+#
+# so a threshold anywhere in 65..85 separates the backdrop from every subject
+# colour that caused trouble. 0.33 of the chroma's own pinkness puts it at 84 for
+# magenta, which is the widest setting that still spares the petal.
+PINK_KEY_FRACTION = 0.33
+# Below this the chroma is not a pink at all (cyan, chartreuse, orange), the
+# scalar means nothing, and the pass does not run.
+PINK_CHROMA_MIN = 150
+
+
+def pinkness(rgb: Sequence[int]) -> float:
+    """``(R+B)/2 - G`` — how much a colour is magenta rather than anything else.
+
+    Positive for magenta/pink, ~0 for neutrals and browns, negative for greens.
+    Named because it is used in two places that must agree: the second keying
+    pass and the audit that checks whether it worked.
+    """
+    r, g, b = (float(c) for c in rgb[:3])
+    return (r + b) / 2.0 - g
+
+
+def is_pinker_than(rgb: Sequence[int], floor: int) -> bool:
+    """``pinkness(rgb) > floor``, in EXACT INTEGER ARITHMETIC.
+
+    Doubled on both sides — ``(R+B) - 2G > 2*floor`` — so there is no division
+    and therefore no rounding to disagree about. That matters because the same
+    predicate is evaluated three ways: here per pixel, as a Pillow band
+    expression inside :func:`key`, and per pixel again in the audit. ImageMath
+    runs its arithmetic on int32 bands where ``/`` FLOORS, so a pixel whose true
+    pinkness is 84.5 tested as 84 in the band version and 84.5 here — the two
+    paths disagreed on exactly the colours sitting on the threshold, which is
+    the worst possible place for them to differ and cost a real test failure.
+    """
+    r, g, b = (int(c) for c in rgb[:3])
+    return (r + b) - 2 * g > 2 * int(floor)
+
+
+def audit(path: str | os.PathLike[str],
+          chroma: Optional[Sequence[int]] = None) -> dict:
     """Measure whether an image is actually a clean cut-out. Flags, not taste.
 
     Was born inside consistency_check as a review tripwire for gpt-image's
@@ -370,8 +464,28 @@ def audit(path: str | os.PathLike[str]) -> dict:
     needs it as a GATE at generation time, not as a comment during review: a
     frame with dirty alpha that reaches ``sprites`` is already too late.
 
+    ``residual_chroma`` IS THE ONE THAT WAS MISSING, and the gap it left is the
+    reason to read this paragraph before adding another threshold. Every other
+    measurement here inspects the CUT — the border, the soft edge, the pixels
+    under zero alpha, the enclosed holes. Not one of them inspects what the cut
+    left behind. So when Krea painted a dusty pink backdrop the sphere key could
+    not reach, the frame border keyed (it was closest to the contract colour),
+    the interior did not, and every threshold above read clean over an opaque
+    pink slab. ``clean: true``, shipped.
+
+    The shape of that bug is worth naming because it recurs: the check validated
+    a PROXY for the artifact (the border) instead of the artifact. Pass
+    ``chroma`` and this one asks the direct question — is the key colour still
+    sitting in the frame, opaque, after keying? — using :func:`pinkness` rather
+    than a distance, because the surviving backdrop is the chroma desaturated
+    and a distance is exactly what it escaped.
+
+    Without ``chroma`` the measurement is skipped and reported as ``None``, not
+    as zero: "not checked" and "checked and clean" must not look the same.
+
     Returns {border_opaque, white_fringe, soft_alpha, dirty_alpha, hollow,
-    flags, review, clean}. `flags` are hard failures; `review` is advisory.
+    residual_chroma, flags, review, clean}. `flags` are hard failures; `review`
+    is advisory.
     """
     from PIL import Image
 
@@ -381,6 +495,11 @@ def audit(path: str | os.PathLike[str]) -> dict:
     px = im.load()
     border = border_op = soft = opaque = softc = whal = 0
     dirty = transp = 0
+    # Only meaningful for a pink key; see PINK_CHROMA_MIN.
+    pink_floor = (pinkness(chroma) * PINK_KEY_FRACTION
+                  if chroma is not None and pinkness(chroma) >= PINK_CHROMA_MIN
+                  else None)
+    residual = 0
     for y in range(H):
         for x in range(W):
             r, g, b, a = px[x, y]
@@ -390,6 +509,8 @@ def audit(path: str | os.PathLike[str]) -> dict:
                     border_op += 1
             if a >= 224:
                 opaque += 1
+                if pink_floor is not None and is_pinker_than((r, g, b), pink_floor):
+                    residual += 1
             if 24 < a < 224:
                 soft += 1
             if 24 < a < 240:
@@ -401,6 +522,11 @@ def audit(path: str | os.PathLike[str]) -> dict:
                 if r > 16 or g > 16 or b > 16:
                     dirty += 1
     border_opaque = border_op / max(1, border)
+    # Over the WHOLE FRAME, not over the opaque pixels. A slab that barely keyed
+    # is nearly all opaque, so dividing by the opaque count would put a
+    # completely failed cut and a perfect one on the same denominator and read
+    # the disaster as a modest percentage.
+    residual_chroma = (residual / max(1, W * H)) if pink_floor is not None else None
     soft_ratio = soft / max(1, opaque + soft)
     white_fringe = whal / max(1, softc)
     dirty_alpha = dirty / max(1, transp)
@@ -445,6 +571,14 @@ def audit(path: str | os.PathLike[str]) -> dict:
     if dirty_alpha > DIRTY_ALPHA_MAX:
         flags.append(f"dirty alpha: {dirty_alpha:.0%} of transparent pixels "
                      "carry nonzero RGB — clean RGB:=0 where alpha==0")
+    if residual_chroma is not None and residual_chroma > RESIDUAL_CHROMA_MAX:
+        flags.append(
+            f"unkeyed backdrop: {residual_chroma:.0%} of the frame is still "
+            "opaque key colour. The model painted a DESATURATED version of the "
+            "chroma (measured ~#c0559f against a pure-magenta contract), which "
+            "is too far off for a distance key and near enough that the border "
+            "keyed and the middle did not. This is a slab, not a sprite — "
+            "regenerate; do not ship it.")
     # Enclosed transparency is ambiguous in general (a curled arm makes a real
     # hole) so consistency_check only ever flagged it for a human. In the KEYED
     # path it stops being ambiguous past a point: a large enclosed hole means
@@ -464,6 +598,10 @@ def audit(path: str | os.PathLike[str]) -> dict:
             "soft_alpha": round(soft_ratio, 3),
             "dirty_alpha": round(dirty_alpha, 3),
             "hollow": round(hollow, 3),
+            # None, not 0.0, when no chroma was passed — "not checked" and
+            # "checked and clean" reading the same is how this got shipped.
+            "residual_chroma": (round(residual_chroma, 3)
+                                if residual_chroma is not None else None),
             "flags": flags, "review": review, "clean": not flags}
 
 
@@ -487,7 +625,10 @@ def finish(path: str | os.PathLike[str], chroma: Sequence[int], *,
         return {"ok": False, "chroma": name, "alpha": {},
                 "error": f"chroma key failed on {path}: {type(exc).__name__}: {exc}"}
     try:
-        flags = audit(path)
+        # The chroma is passed so the audit can ask whether the key colour is
+        # still in the frame. Without it the audit can only inspect the cut, and
+        # the cut looks fine on an image that was never cut. See audit().
+        flags = audit(path, chroma=tuple(int(c) for c in chroma))
     except Exception as exc:
         # An audit that cannot run must not silently pass the frame — the whole
         # point of this contract is that nothing ships unverified.

--- a/bgate_core/db.py
+++ b/bgate_core/db.py
@@ -847,6 +847,32 @@ _MIGRATIONS: list = [
     CREATE INDEX idx_art_match_logical ON art_match(logical_name, id DESC);
     CREATE INDEX idx_art_match_tournament ON art_match(tournament_ref);
     """,
+
+    # 0019 — a stop is not a crash, and prose is not a field.
+    #
+    # A human ending a run banks the item as `status='failed'` with the only
+    # evidence in the result note: "stopped by Adrian — this run was ended by
+    # hand, it did not die on its own". Honest, and unreadable to anything that
+    # is not a person. Measured: three items across three seats flipped to
+    # 'failed' in the same second and read as three separate bugs until someone
+    # opened the notes; the same-second multi-seat signature is what a systemic
+    # event looks like, and no tool could see it.
+    #
+    # NOT A SIXTH STATUS, deliberately. 'failed' is load-bearing in ~85 places —
+    # reopen()'s guard, the QA gate's query, the chain interlock, the console's
+    # lanes — and a new status is a silent behaviour change in every one of them
+    # that filters by name. What was actually missing is the CAUSE of the
+    # failure, which is a different question from the status and belongs in its
+    # own column. A stopped item stays failed: it did not finish, it IS worth
+    # reopening, and every recovery path keeps working untouched.
+    #
+    # stopped_at is separate from updated_at because a stopped item that is later
+    # reopened and re-run keeps its history; the pair is what tells "this run was
+    # killed" from "this item was killed once, three rounds ago".
+    """
+    ALTER TABLE work_item ADD COLUMN stopped_by TEXT NOT NULL DEFAULT '';
+    ALTER TABLE work_item ADD COLUMN stopped_at TEXT NOT NULL DEFAULT '';
+    """,
 ]
 
 

--- a/bgate_core/events.py
+++ b/bgate_core/events.py
@@ -58,9 +58,12 @@ KINDS = (
     "item.done",         # an agent finished and nothing is holding the work
     "item.review",       # finished, parked for a human under the builder's gate
     "item.failed",       # the agent (or the watchdog) says it could not finish
+    "item.stopped",      # a HUMAN ended the run — banked as failed, not a crash
     "item.approved",     # the human released a held item
     "item.rejected",     # the human sent it back with a reason
     "item.aging",        # heartbeat: nobody has looked at a 'review' item
+    "artifact.candidate",# a generated candidate is waiting on a human decision
+    "artifact.reviewed", # that decision was made — approved, rejected, integrated
     "chain.filed",       # a dependent group was queued as one ordered chain
     "chain.advanced",    # a link landed and the next one became ready
     "chain.stalled",     # heartbeat: the head of a chain has not moved

--- a/bgate_core/project.py
+++ b/bgate_core/project.py
@@ -156,6 +156,42 @@ def get(root: str | os.PathLike[str]) -> dict:
     return dict(row)
 
 
+def set_dimension(root: str | os.PathLike[str], dimension: str) -> dict:
+    """Correct the project's 2d/3d record after the game changed shape.
+
+    A PROJECT CHANGES DIMENSION AND THE RECORD DID NOT FOLLOW. ``init`` writes it
+    and ``adopt`` detects it, and after that there was no way to change it: a 2D
+    prototype that grew a 3D scene kept reporting ``dimension: "2d"`` in
+    project_status forever, with no tool on any surface that could fix it. It
+    reads as cosmetic and is not — the field steers scaffolding templates and the
+    wording of seat briefs, so a wrong value quietly aims the whole board at the
+    wrong kind of game.
+
+    Re-running ``init`` would have done it, and that is exactly why this exists
+    instead: init also rewrites name, pitch and engine from its own defaults, so
+    the available workaround was to overwrite four fields to correct one. The
+    2d+3d value is there for the common real case — a 3D game with a 2D HUD, or a
+    prototype mid-port — and is not a compromise between the other two.
+    """
+    if dimension not in DIMENSIONS:
+        raise ValueError(f"dimension must be one of {DIMENSIONS}, "
+                         f"got {dimension!r}")
+    was = get(root).get("dimension") or ""
+    with db.tx(root) as conn:
+        conn.execute("UPDATE project SET dimension = ?, "
+                     "updated_at = datetime('now') WHERE id = 1", (dimension,))
+    if was != dimension:
+        try:
+            from . import activity
+
+            activity.log(root, "project",
+                         f"dimension {was or '(unset)'} -> {dimension}",
+                         seat="director")
+        except Exception:
+            pass            # an unlogged correction is still a correction
+    return get(root)
+
+
 def game_dir(root: str | os.PathLike[str]) -> Optional[Path]:
     """Where this project's Godot project.godot actually lives, or None.
 

--- a/bgate_core/queue.py
+++ b/bgate_core/queue.py
@@ -227,6 +227,14 @@ def _notify(root: str | os.PathLike[str], item: dict) -> None:
     here, so an orchestrator (or the UI) can tail/long-poll one file instead of
     sleep-polling the queue. Never raises — losing a ping must not break the
     status change itself.
+
+    ``kind`` says WHICH CLASS OF EVENT a line is, and it is here because this
+    file is no longer only work items: ``artifacts._notify_line`` puts pending
+    human decisions on the same stream (they had no signal at all, so a batch of
+    candidates waiting on a human produced silence indistinguishable from an
+    agent still working). Purely additive — every line this function writes is a
+    work-item transition and still carries the same five fields, so a consumer
+    reading ``status`` sees exactly what it saw before.
     """
     try:
         import json as _json
@@ -235,6 +243,7 @@ def _notify(root: str | os.PathLike[str], item: dict) -> None:
         with open(path, "a", encoding="utf-8") as fh:
             fh.write(_json.dumps({
                 "ts": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+                "kind": "item.status",
                 "item_id": item["id"], "status": item["status"],
                 "seat": item["seat"], "title": item["title"][:120],
             }) + "\n")
@@ -519,6 +528,64 @@ def reject(root: str | os.PathLike[str], item_id: int, reason: str,
           payload={**_item_event_payload(sent_back), "by": actor[:120],
                    "reason": reason[:400]})
     return sent_back
+
+
+def stop(root: str | os.PathLike[str], item_id: int, by: str = "",
+         reason: str = "") -> dict:
+    """A HUMAN ended this run. Bank it as failed, and say so in a column.
+
+    ``status`` stays 'failed' and that is deliberate — the item did not finish,
+    it is worth reopening, and 'failed' is what reopen(), the QA gate query, the
+    chain interlock and the console's lanes all key on. Inventing a sixth status
+    would change behaviour in every one of those by omission.
+
+    What was missing is the CAUSE, which is a different question from the status
+    and now has its own field. Before this the only evidence was English in the
+    result note, so ``status: failed`` covered both "the agent crashed" and "a
+    person pressed stop" with no way to tell them apart except by reading. Three
+    items across three seats flipped to failed in the same second during a STOP
+    ALL and read as three separate bugs; a same-second multi-seat failure is the
+    signature of a systemic event, and nothing could see it.
+
+    Two things worth remembering about a stopped run, because both surprised
+    somebody: a stop often lands AFTER the valuable work, so check what survived
+    before assuming loss — and ``stopped_at`` is kept separate from
+    ``updated_at`` so a stopped item that is later reopened and re-run still says
+    it was stopped once, three rounds ago, rather than claiming it just now.
+    """
+    actor = (by or activity.current_actor() or "the dashboard")[:120]
+    said = (reason or "").strip() or (
+        f"stopped by {actor} — this run was ended by hand, "
+        "it did not die on its own")
+    item = set_status(root, item_id, "failed", result=said)
+    try:
+        with db.tx(root) as conn:
+            conn.execute(
+                "UPDATE work_item SET stopped_by = ?, "
+                "stopped_at = datetime('now') WHERE id = ?", (actor, item_id))
+        item = get(root, item_id)
+    except Exception:
+        pass            # bookkeeping must never lose the stop itself
+    # ON THE HEARTBEAT AS A STOP, not just as another 'failed'. set_status above
+    # already appended its line, but it ran before the column was stamped and it
+    # says exactly what a crash says. A watcher tailing the stream during a STOP
+    # ALL would otherwise see a burst of identical failures and have to open the
+    # database to learn a person caused them.
+    _notify(root, {**item, "status": "stopped"})
+    _emit(root, "item.stopped", ref=str(item_id),
+          payload={**_item_event_payload(item), "by": actor})
+    return item
+
+
+def was_stopped(item: dict) -> bool:
+    """Did a human end this run, as opposed to it dying?
+
+    A helper rather than an inline truth test because callers kept reaching for
+    the prose. ``stopped_by`` is absent on a project that has not migrated and
+    empty on every crash, so this is the one place that has to be careful about
+    the difference between "no" and "cannot tell".
+    """
+    return bool((item or {}).get("stopped_by"))
 
 
 def awaiting_review(root: str | os.PathLike[str]) -> list[dict]:

--- a/bgate_core/seats.py
+++ b/bgate_core/seats.py
@@ -859,6 +859,100 @@ def workflow_for(role: str, dimension: str, base: str) -> str:
     return f"{base}\n\n{note}" if base else note
 
 
+# ---------------------------------------------------------------------------
+# Traps: the failures that cost a run each, handed over before they cost another
+# ---------------------------------------------------------------------------
+#
+# MEASURED: two agents independently hit the .tscn Transform3D transpose in one
+# night. Once the list below started going out with the brief, nobody did. That
+# is the entire argument for this block — these are not tips, they are bugs that
+# have already been paid for, and every one of them is SILENT: no error, no
+# stack, no visual tell until something much later looks wrong for another
+# reason. An agent cannot search for a failure that never announces itself.
+#
+# The bar for adding a row: it cost at least one real run, and it produces no
+# error message a search would find. Anything an agent will discover in ten
+# seconds by reading a traceback does not belong here — a brief is a budget, and
+# a list nobody finishes is a list nobody reads.
+#
+# `dims` gates a row to project dimensions ("" means all), so a 2D project is not
+# billed for the Transform3D paragraph.
+TRAPS: tuple[dict, ...] = (
+    {"dims": ("3d", "2d+3d"), "seats": (), "text":
+     "`.tscn` Transform3D is ROW-major: the twelve floats fill the basis ROWS, "
+     "while the x/y/z axis vectors are its COLUMNS. Authoring the axes directly "
+     "gives you the TRANSPOSE, which for a rotation is its INVERSE — still a "
+     "valid rotation, pointing somewhere else. Nothing errors. After hand-"
+     "authoring any rotation, print `-basis.z` at runtime (or a dot product "
+     "against the intended target) and check it. dot == 1.000 is proof; 'it "
+     "looks about right' is not."},
+    {"dims": ("3d", "2d+3d"), "seats": (), "text":
+     "Winding drives CULLING; normals drive LIGHTING. Backwards winding does not "
+     "look like a missing mesh — it looks like objects floating over the sky's "
+     "ground colour. Supplying ARRAY_NORMAL does not save you. If geometry is "
+     "invisible from the side you expect, suspect winding before materials."},
+    {"dims": (), "seats": (), "text":
+     "A PARSE ERROR IN A godot_run SCRIPT LOOKS EXACTLY LIKE A HANG. If load() "
+     "fails it returns null, the next call errors, quit() is never reached, and "
+     "the harness kills the run at the timeout with NO stdout at all. Always: "
+     "`if X == null: print('LOAD FAILED'); quit(); return`, and bisect with "
+     "early quit()s. Confirm the engine starts at all with a trivial "
+     "print+quit before suspecting your own logic."},
+    {"dims": (), "seats": (), "text":
+     "Reference other scripts by PATH, not by class_name. A cross-script "
+     "`class_name` lookup hangs a headless run for 45s+ with no output when the "
+     "editor's global class cache has not been rebuilt — which is the state "
+     "every godot_run is in. Use `const X := preload(\"res://...\")`."},
+    {"dims": (), "seats": (), "text":
+     "`_ready()` is DEFERRED when you add_child during `_init()`. Measured on "
+     "one scene: 0 nodes immediately after add_child, 850 after a single "
+     "`await process_frame`. A headless test that instantiates a scene and reads "
+     "state set in _ready() must await a frame first — otherwise a correct game "
+     "is reported broken by a test with a timing bug."},
+    {"dims": ("3d", "2d+3d"), "seats": (), "text":
+     "IMPORT ASSETS SEQUENTIALLY. Parallel godot_import_asset calls collide on "
+     "the shared `.godot/` cache and die with a Windows PermissionError that "
+     "reads like a locked file. And a src_path already inside the project makes "
+     "the tool copy a file onto itself, which Windows also refuses — generate to "
+     "a staging dir and import FROM there."},
+    {"dims": ("3d", "2d+3d"), "seats": ("art", "tech"), "text":
+     "sRGB vs LINEAR: a hex picked off a reference image is sRGB, Blender's "
+     "Principled base colour is LINEAR. Assigning the hex directly ships "
+     "everything ~1.3x too bright, the .glb validates clean, and every check "
+     "that does not render IN THE ENGINE passes. Convert exactly once — twice is "
+     "as wrong as never, and both look plausible."},
+    {"dims": (), "seats": (), "text":
+     "A TOOL REPORTING ITS OWN SUCCESS IS NOT EVIDENCE. Verify the artifact: "
+     "measure the seam, look at the alpha, render it in the engine. Two shipped "
+     "defects came from a flag computed from the REQUEST or from a proxy (a "
+     "frame border) rather than from the file that was produced."},
+    {"dims": (), "seats": (), "text":
+     "godot_screenshot's window never takes true foreground focus on Windows, so "
+     "Input.mouse_mode stays VISIBLE and anything gated on MOUSE_MODE_CAPTURED "
+     "collapses in the shot. That is the harness, not your game. Never add "
+     "per-frame re-capture to make a screenshot look right — when a fix has to "
+     "run every frame forever, it is a symptom, not a cure."},
+)
+
+
+def traps_for(role: str, dimension: str) -> list[str]:
+    """The trap list this seat is actually exposed to, in fixed order."""
+    return [t["text"] for t in TRAPS
+            if (not t["dims"] or dimension in t["dims"])
+            and (not t["seats"] or role in t["seats"])]
+
+
+# Universal, and non-obvious enough that an agent which has not been told
+# concludes the tools do not exist and works around their absence.
+TOOLING_RULE = (
+    "THE builders-gate MCP TOOLS ARE DEFERRED in a fresh session: they are "
+    "listed by name but their schemas are not loaded, so calling one directly "
+    "fails. Load what you need first — ToolSearch(\"select:queue_get,seat_brief\") "
+    "— and pass project_dir explicitly on every call rather than relying on the "
+    "working directory."
+)
+
+
 def brief(root: str | os.PathLike[str], role: str, note_limit: int = 10) -> dict:
     """Everything a seat needs to start, BOUNDED.
 
@@ -959,7 +1053,12 @@ def brief(root: str | os.PathLike[str], role: str, note_limit: int = 10) -> dict
                             MAX_LOCKS, "asset_status (others)"),
         "notes": notes,
         "truncated": truncated,
+        # Bugs that have already been paid for, gated to this seat and this
+        # project's dimension. See TRAPS for why they are in the brief and not
+        # in a document somebody is expected to have read.
+        "traps": traps_for(role, dimension),
         "rules": [
+            TOOLING_RULE,
             "Write only inside your lanes; can_write is the oracle, not a suggestion.",
             "Lock binaries before editing (asset_lock), release when done.",
             "Narrative writes go through canon_check before they land.",

--- a/bgate_core/settings.py
+++ b/bgate_core/settings.py
@@ -86,8 +86,10 @@ GROUPS = ("Dispatch", "Gates", "Art", "Follow-up", "Notifications",
 # has no checkbox, so it can never be added to notify.kinds and the coerce()
 # below REFUSES it — which is how chain.filed was emitted by queue.add_chain and
 # unselectable in the panel at the same time.
-EVENT_KINDS = ("item.done", "item.review", "item.failed", "item.approved",
-               "item.rejected", "item.aging", "chain.filed", "chain.advanced",
+EVENT_KINDS = ("item.done", "item.review", "item.failed", "item.stopped",
+               "item.approved", "item.rejected", "item.aging",
+               "artifact.candidate", "artifact.reviewed",
+               "chain.filed", "chain.advanced",
                "chain.stalled", "gate.mode", "settings.guard", "style.trained",
                "budget.refused",
                "director.question", "agent.spawned", "agent.exited",

--- a/bgate_core/steerbox.py
+++ b/bgate_core/steerbox.py
@@ -74,6 +74,66 @@ def post(root: str | os.PathLike[str], item_id: int, text: str, *,
     return payload
 
 
+# How much of a long correction goes in the steer itself. The rest is cited.
+# Sized so the pointer sentence and the excerpt together stay well inside
+# MAX_TEXT with room for a long project path.
+EXCERPT = 900
+
+
+def notes_dir(root: str | os.PathLike[str]) -> Path:
+    return box(root) / "notes"
+
+
+def post_long(root: str | os.PathLike[str], item_id: int, text: str, *,
+              by: str = "", note: str = "") -> dict:
+    """Steer a running agent with a correction too long to be a steer.
+
+    THE CAP IS RIGHT AND THE DEAD END WAS NOT. Refusing a 2000+ character steer
+    outright — rather than truncating it, which would hand an agent half a
+    sentence and no way to know — is the correct call and it stays. But it left
+    no route at all for a genuinely long correction to reach a RUNNING agent:
+    the only options were to kill the run and re-pay for it, or to let it carry
+    on doing the wrong thing.
+
+    So the long text becomes a FILE and the steer becomes a citation. This is the
+    same discipline ``ask_human`` already asks of its callers — cite, do not
+    paste — applied to the channel that could not.
+
+    What the agent receives stays an interruption: a head excerpt so it can tell
+    immediately whether to stop what it is doing, and the path to read for the
+    rest. What it does NOT do is change the brief. A correction that should
+    outlive the run belongs in ``queue.update``; this one dies with the process
+    it was aimed at, which is the honest lifetime for "no, not like that".
+
+    Returns the posted steer plus ``note_path`` (absolute) and ``excerpted``.
+    """
+    text = str(text or "").strip()
+    if not text:
+        raise ValueError("a steer needs something to say")
+    if len(text) <= MAX_TEXT:
+        return {**post(root, item_id, text, by=by, note=note),
+                "note_path": "", "excerpted": False}
+
+    directory = notes_dir(root)
+    directory.mkdir(parents=True, exist_ok=True)
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    path = directory / f"item-{int(item_id)}-{stamp}-{uuid.uuid4().hex[:6]}.md"
+    header = (f"# Steer for item #{int(item_id)}\n\n"
+              f"From: {by or 'unknown'}  \nAt: {stamp} UTC\n\n"
+              "This is the full text of a mid-run correction. The agent was "
+              "given the first paragraph and this path.\n\n---\n\n")
+    path.write_text(header + text, encoding="utf-8")
+
+    head = text[:EXCERPT].rstrip()
+    posted = post(root, item_id, (
+        f"MID-RUN CORRECTION — too long for one steer, so the full text is at "
+        f"{path}. READ THAT FILE before your next step; what follows is only "
+        f"its opening so you can judge whether to stop now.\n\n{head}\n\n"
+        f"[...{len(text) - len(head)} more characters in {path.name}]"
+    ), by=by, note=note)
+    return {**posted, "note_path": str(path), "excerpted": True}
+
+
 def pending(root: str | os.PathLike[str],
             item_id: int | None = None) -> list[dict]:
     """Undelivered messages, oldest first. Reads only — nothing is consumed."""

--- a/bgate_mcp/server.py
+++ b/bgate_mcp/server.py
@@ -697,6 +697,31 @@ def project_status() -> dict:
         return _fail(exc)
 
 
+@_tool
+def project_set_dimension(dimension: str) -> dict:
+    """Correct the project's 2d | 3d | 2d+3d record after the game changed shape.
+
+    ``init`` writes this and ``adopt`` detects it; nothing could change it
+    afterwards. A 2D prototype that grew a 3D scene went on reporting
+    ``dimension: "2d"`` in project_status indefinitely, and the only workaround
+    was re-running ``project_init``, which rewrites name, pitch and engine from
+    its own defaults — overwriting four fields to correct one.
+
+    Not cosmetic: the field steers scaffolding templates and the wording of seat
+    briefs, so a stale value aims the board at the wrong kind of game. Use
+    ``2d+3d`` for the real mixed case (a 3D game with a 2D HUD, a prototype
+    mid-port) rather than picking whichever is closer.
+    """
+    try:
+        was = _project.get(_root()).get("dimension") or ""
+        after = _project.set_dimension(_root(), dimension)
+        _log("project", f"dimension {was or '(unset)'} -> {dimension}")
+        return {"project": after, "was": was, "now": after.get("dimension"),
+                "changed": was != after.get("dimension")}
+    except Exception as exc:
+        return _fail(exc)
+
+
 # ---------------------------------------------------------------------------
 # Design bible
 # ---------------------------------------------------------------------------
@@ -908,14 +933,48 @@ def _imageto3d_summary() -> dict:
     blocked = {b["backend"]: b.get("reason", "")
                for b in full.get("backends") or []
                if not b.get("available") and b.get("implemented")}
+    # SPLIT HOSTED FROM LOCAL, BECAUSE `usable` MEANS CONFIGURED, NOT RUNNING.
+    #
+    # This flattened status() to one list and dropped the local/hosted split the
+    # adapter had already computed. ["hunyuan-local", "krea", "trellis-cpp"] gave
+    # no hint that two of those need a server the user has to start and one is a
+    # hosted API that needs only its key — and probe=False, which is the default
+    # here for the good reason that a status call must not block on a TCP
+    # timeout, means a local row says "usable" while nothing is listening.
+    #
+    # THE COST, MEASURED: an agent tried the two local backends, got connection
+    # refused from both, and reported image-to-3D unavailable. That was relayed
+    # upward as fact and the whole image-to-3D path was written off for a
+    # session. Krea was hosted, its key was set, and it had already produced
+    # every texture in the same build. One ambiguous list did that.
+    local = list(full.get("local") or [])
+    hosted = list(full.get("hosted") or [])
+    clear = list(full.get("unconditional_licence") or [])
+    hint = ""
+    if local and not hosted:
+        hint = ("every usable backend here is LOCAL, which means CONFIGURED, not "
+                "running — probe one before concluding anything, and do not "
+                "report image-to-3D unavailable on a refused connection alone.")
+    elif hosted:
+        hint = (f"hosted backends ({', '.join(hosted)}) need no local server — "
+                "they are reachable now. If a local one refuses a connection, "
+                "try a hosted one before reporting the path unavailable.")
     return {"available": bool(usable), "usable": usable,
+            # Kept alongside `usable` rather than replacing it: existing callers
+            # read that key, and a status field that silently changes shape is
+            # its own version of this bug.
+            "local": local, "hosted": hosted,
+            "unconditional_licence": clear,
             "gpu": gpu.get("name", ""), "vram_gb": gpu.get("vram_gb"),
             "blocked": blocked,
+            "checked": "configuration only — a local backend listed usable may "
+                       "still have no server running",
             "note": ("nothing configured — see .env.example; a generated mesh "
                      "is a DRAFT and still has to be cleaned, scaled, oriented "
                      "and rigged before it is an asset")
             if not usable else
-            "a generated mesh is a DRAFT: clean, scale, orient and rig it"}
+            ("a generated mesh is a DRAFT: clean, scale, orient and rig it. "
+             + hint).strip()}
 
 
 @_tool
@@ -2417,6 +2476,21 @@ def image_generate(prompt: str, filename: str, size: str = "1024x1024",
                                   logical_name=_Path(filename).stem,
                                   work_item_id=_work_item_id())
         result["refs_used"] = named
+        # WHAT HAPPENED, NOT WHAT WAS ASKED FOR. `tileable` above is the request;
+        # chroma puts the mirror pass's own {ok, method, note} at result["tileable"]
+        # and it can be a failure. Recording the boolean meant a map that never
+        # tiled was filed as a tileable map, and the seam turned up in a render
+        # days later with the metadata still claiming otherwise. A flag computed
+        # from the request is not evidence about the artifact.
+        tiled = result.get("tileable")
+        tiled_ok = bool(tiled.get("ok")) if isinstance(tiled, dict) else bool(tiled)
+        if tileable and not tiled_ok:
+            # Surfaced on the result, not buried in metadata: the caller is
+            # standing right here and can regenerate or heal the seam now.
+            result["warning"] = (
+                "tileable was requested and DID NOT happen: "
+                + (tiled.get("note") if isinstance(tiled, dict) else "no tile pass ran")
+                + " — this map will seam where it repeats")
         if result.get("ok"):
             archived = _archive_preview(result["path"], f"art-{_Path(filename).stem}")
             if archived:
@@ -2426,7 +2500,10 @@ def image_generate(prompt: str, filename: str, size: str = "1024x1024",
                 model=result.get("model", ""), prompt=prompt, refs=named,
                 metadata={"size": size, "quality": quality,
                           "transparent": transparent,
-                          "task_kind": task_kind, "tileable": tileable,
+                          "task_kind": task_kind,
+                          "tileable_requested": tileable,
+                          "tileable": tiled_ok,
+                          "tileable_detail": tiled if isinstance(tiled, dict) else None,
                           "resolved_refs": resolved,
                           "pinned_refs": pinned_names,
                           "anchors": anchor_paths,
@@ -3725,11 +3802,27 @@ def godot_import_asset(godot_project: str, src_path: str, dest_rel: str = "asset
     result is where that is said. Read it before telling anyone the import was
     clean.
 
+    `alpha_mode` carries the OTHER silent one: Godot 4.7 imports glTF
+    `alphaMode: MASK` as DEPTH_PRE_PASS rather than ALPHA_SCISSOR, which moves
+    every one of those surfaces into the sorted transparent pass. Nothing errors
+    and a screenshot looks correct; it costs frames once a scene has hundreds of
+    alpha quads on it. Read the warning before shipping foliage.
+
+    IMPORT SEQUENTIALLY. Two headless imports at once fight over the shared
+    `.godot/` cache and one of them dies with a Windows PermissionError that
+    reads like a locked file rather than like the race it is. Batching them in
+    parallel to save wall-clock buys an error instead. And a `src_path` already
+    inside the project makes this copy a file onto itself, which Windows also
+    refuses — generate to a staging directory and import FROM there.
+
     godot_project: the directory holding project.godot.
     """
     try:
         result = _godot.import_asset(godot_project, src_path, dest_rel=dest_rel,
                                      timeout=timeout)
+        warning = (result.get("alpha_mode") or {}).get("warning")
+        if warning:
+            _log("asset", f"alphaMode:MASK in {src_path} — {warning[:160]}")
         # Register the landed asset so asset_verify covers it from birth. Only
         # possible when the game project lives inside the bgate root.
         if result.get("ok") and result.get("copied_to"):
@@ -4143,6 +4236,32 @@ def godot_screenshot(godot_project: str, at: float = 1.0, scene: Optional[str] =
     (rendering needs a display) and closes itself after the capture. The shot
     is archived to the preview gallery — check it before and after visual work.
 
+    THE WINDOW NEVER GAINS TRUE FOREGROUND FOCUS ON WINDOWS, AND THAT IS THIS
+    TOOL'S ARTIFACT, NOT YOUR GAME'S. Read this before "fixing" anything it
+    seems to reveal about input.
+
+    The capture window is spawned by a background process, so Windows does not
+    hand it the foreground. The mouse is therefore never captured:
+    `Input.mouse_mode` stays VISIBLE no matter what `_ready` asked for, and any
+    code gated on MOUSE_MODE_CAPTURED — a viewfinder, a first-person look
+    controller, a pointer-lock HUD — collapses in the shot while working
+    perfectly for a human running the same build.
+
+    Measured cost of not knowing: a previous pass "fixed" this by re-asserting
+    mouse capture EVERY FRAME from the shot rig, with a comment blaming the
+    game. That masked the real finding for a whole pass. **When a fix has to run
+    every frame forever, it is a symptom, not a cure.**
+
+    So: do not conclude anything about input capture from a screenshot, and do
+    not add per-frame re-capture to make one look right. To check input for
+    real, run the game with `godot_run` and assert on state, or have a human
+    play it. `focus` in the result says this out loud on every call.
+
+    Two more things this tool cannot give you. It returns NO STDOUT, so a
+    windowed run's diagnostics must be written to `user://` and read back. And
+    `res://.bgate_shot.gd` is the harness's own helper — it can error during
+    unrelated headless runs; work around it, do not delete it.
+
     godot_project: the directory holding project.godot.
     """
     try:
@@ -4162,6 +4281,22 @@ def godot_screenshot(godot_project: str, at: float = 1.0, scene: Optional[str] =
             _log("screenshot", f"captured the running game at t={at}s"
                                + (f" ({label})" if label else ""),
                  ref=archived or result["path"])
+        # ON EVERY RESULT, not only when something looks wrong. The failure this
+        # prevents is a correct-looking screenshot being read as evidence about
+        # input — by which point the misreading has already been acted on. A
+        # caveat that only appears once you suspect a problem arrives after the
+        # bug report has been written.
+        result["focus"] = {
+            "foreground": False,
+            "mouse_capture": "unavailable",
+            "note": ("this window never takes true foreground focus on Windows, "
+                     "so Input.mouse_mode stays VISIBLE and anything gated on "
+                     "MOUSE_MODE_CAPTURED will not appear in this shot. That is "
+                     "the harness, not the game — do not fix the game for it, "
+                     "and do not re-assert capture per frame to make the shot "
+                     "look right. Check input with godot_run and an assertion, "
+                     "or with a human at the keyboard."),
+        }
         return result
     except Exception as exc:
         return _fail(exc)
@@ -5083,6 +5218,100 @@ def asset_status(kind: Optional[str] = None, locked_only: bool = False) -> dict:
 
 
 @_tool
+def pending_decisions(limit: int = 40) -> dict:
+    """EVERYTHING WAITING ON A HUMAN, in one call. The gate's read path.
+
+    There was no way to ask this. ``asset_status`` lists candidates but exposes
+    no approval STATE, ``art_tournament_standings`` reports Elo from matches
+    already decided, and human approval was dashboard-only — so a director could
+    not see, surface or triage a queue of decisions blocking their own board.
+    Measured: five candidates generated in two minutes with an approval card each,
+    and nothing an agent could call would say so.
+
+    WHY THAT IS DANGEROUS AND NOT MERELY INCOMPLETE. A pending decision is a
+    blocking gate. Work stalls behind it and the heartbeat shows nothing, which
+    looks exactly like an agent quietly working — the same "silence is not
+    success" failure as a dead agent, arriving through a different door.
+
+    Three classes, because the floor has three:
+
+      review      work items parked by the builder's gate. THE HARD BLOCK: the
+                  chain behind each one does not advance until a human approves.
+      candidates  generated artifact revisions nobody has dispositioned. An
+                  agent may record a verdict (art_qa_verdict) but may not
+                  promote — that is the human's call, by design.
+      questions   open ask_human questions, oldest first.
+
+    ``gate`` names the mode that decides whether any of this is being asked for
+    at all. Under 'none' the board is not supposed to be stopping for a human;
+    a non-empty list under that mode is worth reporting rather than clicking
+    through.
+
+    WHAT THIS DOES NOT DO: approve anything. It cannot — the agent that made a
+    candidate is exactly who must not clear it. Hand the list to the human with
+    what each decision is blocking, and keep working on what it does not block.
+    """
+    try:
+        from bgate_core import gates as _gatemode
+        from bgate_core import queue as _q
+        from bgate_core import steerbox as _steerbox
+
+        root = _root()
+        cap = max(1, min(int(limit or 40), 200))
+
+        parked = [{"item_id": int(r["id"]), "seat": r["seat"],
+                   "title": r["title"], "since": r["updated_at"],
+                   "result": (r["result"] or "")[:240]}
+                  for r in _q.awaiting_review(root)[:cap]]
+
+        candidates = []
+        for art in _artifacts.list_revisions(root, status="candidate",
+                                             limit=cap):
+            qa = (art.get("metadata") or {}).get("qa_review") or {}
+            candidates.append({
+                "artifact_id": int(art["id"]),
+                "logical_name": art.get("logical_name") or "",
+                "revision": art.get("revision"),
+                "path": art.get("path") or "",
+                "work_item_id": art.get("work_item_id"),
+                "producer": art.get("producer") or "",
+                # WHETHER A MACHINE HAS ALREADY LOOKED. A candidate with a
+                # passing qa_review is a different ask than a raw one — the human
+                # is confirming a check, not performing the first one.
+                "machine_verdict": qa.get("verdict") or "",
+                "machine_note": (qa.get("reasons") or "")[:200],
+            })
+
+        try:
+            questions = _steerbox.open_questions(root)[:cap]
+        except Exception:
+            questions = []
+
+        state = _gatemode.state(root)
+        total = len(parked) + len(candidates) + len(questions)
+        return {
+            "gate": {"mode": state["mode"], "source": state.get("source", ""),
+                     "env_override": state.get("env_override", "")},
+            "blocked_chains": parked,
+            "candidates": candidates,
+            "questions": questions,
+            "total": total,
+            "note": (
+                "nothing is waiting on a human" if not total else
+                f"{len(parked)} chain(s) stopped, {len(candidates)} candidate(s) "
+                f"and {len(questions)} question(s) waiting. Only a human clears "
+                "these — surface the list, say what each blocks, and carry on "
+                "with the work that is not behind one."
+                + (" NOTE: the approval gate is 'none' for this project, so "
+                   "nothing here should be stopping for a human — report that "
+                   "rather than working around it."
+                   if state["mode"] == _gatemode.NONE else "")),
+        }
+    except Exception as exc:
+        return _fail(exc)
+
+
+@_tool
 def asset_verify() -> dict:
     """Audit every tracked asset against disk — catches silent clobbers.
 
@@ -5468,12 +5697,58 @@ def queue_get(item_id: int) -> dict:
 
 
 @_tool
-def queue_add(seat: str, title: str, brief: str = "", priority: int = 0) -> dict:
-    """Queue work for a seat. Use when your work uncovers work that isn't yours."""
+def queue_add(seat: str, title: str, brief: str = "", priority: int = 0,
+              depends_on: Optional[int] = None) -> dict:
+    """Queue work for a seat. Use when your work uncovers work that isn't yours.
+
+    ``depends_on`` is an EXISTING item id this work must not start before. Pass
+    it whenever the new item reads or edits something another queued item is
+    about to produce.
+
+    PRIORITY IS NOT ORDER, and this parameter exists because that gap had no
+    workaround. Priority is a preference among things that are ALL ready — it
+    does not stop auto-deploy from starting both agents in the same tick, so the
+    one that needed the other's output writes against a file that does not exist,
+    reports done, and the damage surfaces two items later wearing someone else's
+    face. Only a dependency stops that.
+
+    Before this, order could only be expressed by ``queue_add_chain``, which
+    files a whole ordered group at once. Chains are strictly linear and cannot be
+    appended to, so filing a dependent FOLLOW-UP once a chain already existed had
+    no correct form at all — which is how a fidelity pass nearly got dispatched
+    into a running build. Use the chain when you are filing the group; use this
+    when the group is already on the board.
+
+    A dependency on an item that does not exist is refused rather than dropped:
+    an item silently waiting on nothing is indistinguishable from one that is
+    ready, and it would dispatch immediately — the exact failure being prevented.
+    """
     try:
         from bgate_core import queue as _q
-        return _q.add(_root(), seat, title, brief=brief, priority=priority,
-                      source=f"seat:{_seat() or 'unknown'}")
+        item = _q.add(_root(), seat, title, brief=brief, priority=priority,
+                      source=f"seat:{_seat() or 'unknown'}",
+                      depends_on=depends_on)
+        if depends_on is None:
+            return item
+        # SAY WHAT THE BOARD WILL DO WITH IT. A caller that files a dependency
+        # and sees an ordinary queued row has no way to tell the wait took, and
+        # the difference only becomes visible when the item does (or does not)
+        # start.
+        try:
+            blocker = _q.get(_root(), int(depends_on))
+            waiting = blocker["status"] != "done"
+        except Exception:
+            blocker, waiting = {}, True
+        return {**item, "waits_for": {
+            "item": int(depends_on),
+            "title": str(blocker.get("title") or "")[:120],
+            "status": blocker.get("status") or "",
+            "note": (f"#{item['id']} will not dispatch until #{depends_on} is "
+                     "done" + (" — approved, if this project runs an approval "
+                               "gate" if waiting else "")
+                     if waiting else
+                     f"#{depends_on} is already done, so #{item['id']} is "
+                     "ready now")}}
     except Exception as exc:
         return _fail(exc)
 
@@ -5496,6 +5771,11 @@ def queue_add_chain(links: list, chain_id: str = "") -> dict:
     link N-1 to reach 'done' — approved, if this project runs an approval gate.
     Chains are strictly linear; model a fan-out as separate chains that share a
     first link, or as one link whose brief covers both halves.
+
+    A CHAIN CANNOT BE APPENDED TO. To hang one dependent item off work that is
+    already on the board — a follow-up you did not know about when you filed the
+    chain — use ``queue_add(..., depends_on=<item id>)`` instead of filing a
+    second chain that races the first.
 
     WRITE EACH BRIEF AS IF ITS PREDECESSOR ALREADY LANDED, because it will have.
     Name what it produced (the file, the function, the scene) rather than saying
@@ -5613,11 +5893,18 @@ def agent_steer(item_id: int, text: str) -> dict:
         status='dispatched') first, and use queue_update or queue_reopen for
         work that is not running.
 
-      * A STEER IS CAPPED AT 2000 CHARACTERS and a longer one is refused
-        outright, not truncated. It is an interruption, not a brief: anything
-        that needs more than a couple of paragraphs is a change to the work
-        rather than a correction to it, so put it in queue_update's brief or
-        reopen the item with it.
+      * A STEER IS CAPPED AT 2000 CHARACTERS. It is an interruption, not a
+        brief. Past the cap the text is written to a file in the project's steer
+        box and the agent is handed the opening paragraph plus that path — so a
+        long correction reaches a RUNNING agent instead of forcing you to kill
+        the run and pay for it twice, which is what the cap used to mean in
+        practice. Truncation is still never on the table: half a sentence with
+        no way to know it was cut is worse than either.
+
+        A correction that should OUTLIVE the run is still not this tool. This
+        one dies with the process it was aimed at, which is the honest lifetime
+        for "no, not like that"; a change to the work itself goes in
+        queue_update's brief or a queue_reopen.
 
     Delivery, and any failure to deliver, is recorded in the activity ledger
     against the item.
@@ -5632,11 +5919,17 @@ def agent_steer(item_id: int, text: str) -> dict:
                     "error": f"item {item_id} is {item['status']!r}, not running "
                              "— there is no agent to steer",
                     "status": item["status"]}
-        posted = _steerbox.post(root, int(item_id), text,
-                                by=f"seat:{_seat() or 'director'}")
-        return {"ok": True, "item_id": int(item_id), "steer_id": posted["id"],
-                "delivery": "queued for the dashboard to hand over; the agent "
-                            "reads it when its current step ends"}
+        posted = _steerbox.post_long(root, int(item_id), text,
+                                     by=f"seat:{_seat() or 'director'}")
+        out = {"ok": True, "item_id": int(item_id), "steer_id": posted["id"],
+               "delivery": "queued for the dashboard to hand over; the agent "
+                           "reads it when its current step ends"}
+        if posted.get("excerpted"):
+            out["note_path"] = posted["note_path"]
+            out["delivery"] += (f" — over {_steerbox.MAX_TEXT} characters, so it "
+                                "was handed over as an excerpt plus the path to "
+                                "the full text")
+        return out
     except Exception as exc:
         return _fail(exc)
 

--- a/bgate_ui/dispatch.py
+++ b/bgate_ui/dispatch.py
@@ -1920,10 +1920,14 @@ def stop(item_id: int, actor: str = "") -> dict:
     # Written here, not at reap time: the reap only writes while the item is
     # still 'dispatched', so recording the stop now is what keeps the crash
     # story from being told over it.
+    #
+    # queue.stop rather than set_status: the prose is for the human reading the
+    # card, and it stamps `stopped_by` so anything that is not a human can tell
+    # this apart from a crash without parsing the sentence. See migration 0019.
     if root:
         try:
             if _queue.get(root, item_id)["status"] == "dispatched":
-                _queue.set_status(root, item_id, "failed", result=reason)
+                _queue.stop(root, item_id, by=actor, reason=reason)
         except LookupError:
             pass
     return {"ok": True, "item_id": item_id, "pid": pid, "actor": actor,

--- a/bgate_ui/routes/console.py
+++ b/bgate_ui/routes/console.py
@@ -347,7 +347,41 @@ def _gates(root_dir, conn, active: set[int]) -> list[dict]:
     with a used art library grows a permanent wall of approval nodes hanging off
     work that finished weeks ago — which is a review backlog, not a gate, and
     the review queue in Assets is where it belongs.
+
+    THE MODE SELECTOR REACHES THIS LIST. It did not, and that is the bug this
+    paragraph exists for: a project with the gate set to ``none`` kept drawing
+    SIGN-OFF cards over every finished item and APPROVAL cards over every
+    generated candidate, each one telling the human that only they could decide.
+    Reported from the field across seats — art and director both — after the
+    human had explicitly switched the asking off. Setting a gate to ``none`` is
+    a sentence: *do not stop to ask me*. Asking anyway either stalls work behind
+    a card nobody knew to click or trains the human to rubber-stamp, which
+    destroys the gate for the runs where it IS on. So the mode is read here, once
+    per poll, and it decides which human-facing cards exist at all.
+
+    What each mode draws, stated so the next reader does not have to infer it:
+
+        none      QA-gate items only — those are real work items somebody filed,
+                  and hiding a queued agent is a different lie. No sign-off, no
+                  candidate approvals (``artifacts._auto_approve`` clears those
+                  at registration under this mode, so nothing is left stuck).
+        agent     the above plus candidate approvals: an agent records a verdict
+                  with ``art_qa_verdict`` and the revision STAYS a candidate, so
+                  a human is still the only one who can promote it.
+        builders  everything, including sign-off — and sign-off covers items
+                  parked in ``review`` as well as recently-finished ones. Under
+                  this mode ``queue.complete`` parks a finished item in 'review'
+                  rather than 'done', and this list queried 'done' only, so the
+                  one gate the mode actually mandates had no card on the graph.
     """
+    from bgate_core import gates as _gatemode
+
+    try:
+        mode = _gatemode.mode(root_dir)
+    except Exception:
+        # An unreadable mode must not blank the board. DEFAULT is 'agent', the
+        # behaviour that shipped before the setting existed.
+        mode = _gatemode.DEFAULT
     out: list[dict] = []
     for row in conn.execute(
             "SELECT id, seat, title, status, source, source_ref, created_at "
@@ -369,46 +403,69 @@ def _gates(root_dir, conn, active: set[int]) -> list[dict]:
     # only a claim. The gate appears the moment the item lands and disappears
     # the moment it is acted on, which is what makes it a gate rather than a
     # backlog — see POST /api/console/signoff.
-    acked = set((_ws.get(root_dir, SEAT, SIGNOFF_KEY, {}).get("acked") or {}))
-    cutoff = (datetime.now(timezone.utc)
-              - timedelta(hours=_signoff_hours(root_dir))
-              ).strftime("%Y-%m-%d %H:%M:%S")
-    for row in conn.execute(
-            "SELECT id, seat, title, result, source, updated_at FROM work_item "
-            "WHERE status = 'done' AND source NOT IN ('chat', 'qa-gate') "
-            "AND updated_at >= ? ORDER BY updated_at DESC, id DESC LIMIT 14",
-            (cutoff,)):
-        if str(row["id"]) in acked:
-            continue
-        out.append({
-            "kind": "signoff",
-            "id": f"gate_done_{row['id']}",
-            "item_id": int(row["id"]),
-            "over_item_id": int(row["id"]),
-            "title": row["title"],
-            "seat": row["seat"],
-            "status": "done",
-            "result": (row["result"] or "")[:400],
-            "blocking": True,
-            "created_at": row["updated_at"],
-        })
+    #
+    # BUILDER'S GATE ONLY. Under 'agent' the QA seat is the reviewer and a second
+    # human ask buys nothing the QA verdict has not already bought; under 'none'
+    # the human has said not to ask at all.
+    if mode == _gatemode.BUILDERS:
+        acked = set((_ws.get(root_dir, SEAT, SIGNOFF_KEY, {}).get("acked") or {}))
+        cutoff = (datetime.now(timezone.utc)
+                  - timedelta(hours=_signoff_hours(root_dir))
+                  ).strftime("%Y-%m-%d %H:%M:%S")
+        # 'review' has no time window and never gets one: it is not a claim
+        # somebody may want to glance at, it is a chain stopped dead waiting for
+        # this exact decision. Ageing it out of the list would hide the block and
+        # leave the work behind it queued forever with nothing on screen saying
+        # why. 'done' keeps the window — see SIGNOFF_HOURS.
+        for row in conn.execute(
+                "SELECT id, seat, title, result, status, source, updated_at "
+                "FROM work_item "
+                "WHERE source NOT IN ('chat', 'qa-gate') "
+                "AND (status = 'review' OR (status = 'done' AND updated_at >= ?)) "
+                "ORDER BY CASE status WHEN 'review' THEN 0 ELSE 1 END, "
+                "updated_at DESC, id DESC LIMIT 14",
+                (cutoff,)):
+            if str(row["id"]) in acked:
+                continue
+            parked = row["status"] == "review"
+            out.append({
+                "kind": "signoff",
+                "id": f"gate_done_{row['id']}",
+                "item_id": int(row["id"]),
+                "over_item_id": int(row["id"]),
+                "title": row["title"],
+                "seat": row["seat"],
+                "status": row["status"],
+                # The one field that separates "glance at this" from "this is
+                # stopped": a parked item releases its chain only on approve.
+                "parked": parked,
+                "result": (row["result"] or "")[:400],
+                "blocking": True,
+                "created_at": row["updated_at"],
+                "gate_mode": mode,
+            })
 
-    for art in _artifacts.list_revisions(root_dir, status="candidate")[:60]:
-        item_id = art.get("work_item_id")
-        if not item_id or int(item_id) not in active:
-            continue
-        out.append({
-            "kind": "art",
-            "id": f"gate_art_{art['id']}",
-            "artifact_id": int(art["id"]),
-            "item_id": int(item_id) if item_id else None,
-            "over_item_id": int(item_id) if item_id else None,
-            "title": art.get("logical_name") or f"candidate {art['id']}",
-            "seat": "art",
-            "status": "candidate",
-            "blocking": True,
-            "path": art.get("path") or "",
-        })
+    # A candidate is human-only to promote, so under 'none' there is nobody left
+    # to ask — artifacts.register auto-approves at registration under that mode
+    # rather than leaving a wall of candidates behind a suppressed card.
+    if mode != _gatemode.NONE:
+        for art in _artifacts.list_revisions(root_dir, status="candidate")[:60]:
+            item_id = art.get("work_item_id")
+            if not item_id or int(item_id) not in active:
+                continue
+            out.append({
+                "kind": "art",
+                "id": f"gate_art_{art['id']}",
+                "artifact_id": int(art["id"]),
+                "item_id": int(item_id) if item_id else None,
+                "over_item_id": int(item_id) if item_id else None,
+                "title": art.get("logical_name") or f"candidate {art['id']}",
+                "seat": "art",
+                "status": "candidate",
+                "blocking": True,
+                "path": art.get("path") or "",
+                "gate_mode": mode,
+            })
     return out
 
 
@@ -749,6 +806,16 @@ def console_signoff(payload: dict) -> dict:
     'the agent finished'; without a second, separate record there is no way to
     express 'and a human has looked at it', which is the entire difference
     between a claim and an approval.
+
+    TWO DIFFERENT ITEMS ARRIVE HERE AND ONLY ONE OF THEM IS A CLAIM. Under the
+    builder's gate a completion parks in 'review' and the chain behind it does
+    not advance — the decision is not a glance, it is the thing releasing the
+    work. Acking that in the workspace doc would clear the CARD and leave the
+    CHAIN stopped, with the one surface that said so now hidden: the same
+    off-at-the-drawing-not-at-the-decision mistake the gate selector made. So a
+    parked item routes to ``queue.approve``/``queue.reject``, which move the
+    status, stamp who signed and emit; only a genuinely finished item takes the
+    acknowledgement path.
     """
     try:
         item_id = int(payload.get("item_id"))
@@ -764,11 +831,22 @@ def console_signoff(payload: dict) -> dict:
     except LookupError:
         raise _api.not_found(f"no work item {item_id}")
 
+    parked = item["status"] == "review"
+
     if verdict == "reopen":
         if not reason:
             raise _api.bad_request(
                 "say what is wrong — a reopen with no reason spends another "
                 "agent on the same guess")
+        if parked:
+            # queue.reject parks it as failed and reuses reopen, so a rejected
+            # item is indistinguishable from a QA-failed one downstream: one fix
+            # path, one round counter, one place the next agent looks.
+            _queue.reject(r, item_id, reason)
+            _activity.log(r, "signoff", f"rejected #{item_id}: {reason[:120]}",
+                          seat=item["seat"], ref=str(item_id))
+            return {"ok": True, "item_id": item_id, "verdict": verdict,
+                    "status": "queued", "released": False}
         if item["status"] not in ("done", "failed"):
             raise _api.bad_request(
                 f"item {item_id} is {item['status']} — only a finished item "
@@ -782,6 +860,17 @@ def console_signoff(payload: dict) -> dict:
         return {"ok": True, "item_id": item_id, "verdict": verdict,
                 "status": "queued"}
 
+    if parked:
+        # 'review' -> 'done', which is what frees the chain. approve() records
+        # WHO signed, because an approval nobody signed is not an approval, and
+        # emits item.approved rather than a second item.done — the completion was
+        # already announced when it parked.
+        _queue.approve(r, item_id, note=reason)
+        _activity.log(r, "signoff", f"approved #{item_id}: {item['title'][:80]}",
+                      seat=item["seat"], ref=str(item_id))
+        return {"ok": True, "item_id": item_id, "verdict": verdict,
+                "status": "done", "released": True}
+
     def _ack(doc: dict) -> dict:
         acked = dict(doc.get("acked") or {})
         acked[str(item_id)] = {"verdict": "accept", "by": _activity.current_actor(),
@@ -792,7 +881,8 @@ def console_signoff(payload: dict) -> dict:
     _ws_update(r, SIGNOFF_KEY, _ack)
     _activity.log(r, "signoff", f"accepted #{item_id}: {item['title'][:80]}",
                   seat=item["seat"], ref=str(item_id))
-    return {"ok": True, "item_id": item_id, "verdict": verdict, "status": "done"}
+    return {"ok": True, "item_id": item_id, "verdict": verdict, "status": "done",
+            "released": False}
 
 
 @router.post("/api/console/answer")

--- a/bgate_ui/static/agents_graph.js
+++ b/bgate_ui/static/agents_graph.js
@@ -670,8 +670,13 @@
       }
       if (n.type === "gate") {
         const g = n.gate || {};
+        // A parked item is not a claim worth a glance, it is a stopped chain.
+        // Both used to read "your call", which made the one that is actually
+        // holding work up indistinguishable from the ten that are not.
         const what = g.kind === "art" ? "a human decides — approve or reject"
-          : g.kind === "signoff" ? "the agent says this is done — your call"
+          : g.kind === "signoff" ? (g.parked
+              ? "held in review — the chain behind it waits on you"
+              : "the agent says this is done — your call")
           : g.kind === "escalation" ? "QA loop broken — you arbitrate"
           : "verifying the claim before it counts";
         return `<div class="cg-meta"><span>${esc(g.seat || "")}</span>
@@ -856,14 +861,19 @@
       if (n.type === "gate") {
         const g = n.gate || {};
         if (g.kind === "signoff") {
-          return head("Sign-off", g.title)
+          return head(g.parked ? "Sign-off · held" : "Sign-off", g.title)
             + `<div class="cg-kv"><span>seat</span><span style="color:${seatColor(g.seat)}">${esc(g.seat)}</span></div>`
             + `<div class="cg-kv"><span>item</span><span>#${g.item_id}</span></div>`
             + `<div class="cg-sec">what it says it did</div>`
             + `<div class="cg-answer">${esc(g.result || "(no result note)")}</div>`
-            + `<div class="cg-note">'Done' is the agent's claim. Accept it and the
-                 gate clears; send it back and the reason is appended to the brief
-                 for whoever picks it up next.</div>`
+            + (g.parked
+              ? `<div class="cg-note">This item is PARKED IN REVIEW under the
+                   builder's gate — it is not closed, and anything chained behind
+                   it will not start until you accept. Send it back and the reason
+                   is appended to the brief for the next round.</div>`
+              : `<div class="cg-note">'Done' is the agent's claim. Accept it and the
+                   gate clears; send it back and the reason is appended to the brief
+                   for whoever picks it up next.</div>`)
             + `<div class="cg-acts">
                  <button class="qbtn small" data-act="accept" data-id="${g.item_id}">accept</button>
                  <button class="qbtn small ghost" data-act="sendback" data-id="${g.item_id}">send back</button>

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -112,7 +112,26 @@ server process while the reaper runs in the dashboard's, so the log is
 multi-writer across processes and an appended file cannot hand out a monotonic
 sequence without a lock. `since()` reports `gap: true` when a cursor points below
 the oldest surviving row — "you missed forty events" and "nothing happened" must
-never look the same. `.bgate/notify.jsonl` is still written, unchanged.
+never look the same.
+
+`.bgate/notify.jsonl` is still written, and it is still the shell-readable view:
+one appended JSON line per transition, tailable with no database and no MCP. It
+now carries two classes rather than one, because it used to carry only work-item
+transitions and a batch of art candidates waiting on a human therefore produced
+**zero lines** while the dashboard drew an approval card for each. A blocking
+gate with no signal looks exactly like an agent quietly working.
+
+| `kind`                | what happened                                     |
+|-----------------------|---------------------------------------------------|
+| `item.status`         | a work item changed status (the original line)     |
+| `artifact.candidate`  | a generated revision is waiting on a human         |
+| `artifact.reviewed`   | that decision was made                             |
+
+`kind` is additive: every line still carries `{ts, item_id, status, seat, title}`,
+so a consumer reading `status` sees exactly what it saw before. What the stream
+still cannot tell you is whether a decision is *stale* — for the current pending
+list, call the `pending_decisions` MCP tool, which answers with the parked chains,
+the undecided candidates and the open questions in one call.
 
 ### The follow-up router
 

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -325,6 +325,40 @@ working.
 The ceilings live in the project's budget (`/api/spend`); the two environment
 variables are escape hatches for a machine that needs different numbers.
 
+## Inventory before you plan
+
+The stamped `CLAUDE.md` names the calls; this is why they are worth the tokens.
+
+Measured across a week of real builds, the single most expensive habit was not
+running them. Each is one call and each returns a *list* rather than a verdict:
+
+| call | what it enumerates |
+|---|---|
+| `project_status`, `queue_list`, `bible_read`, `seat_list` | the board and the design |
+| `bgate_doctor` | the toolchain — **an inventory, not a pass/fail gate** |
+| `image_status`, `blender_status` | providers, models and backends the doctor only summarises |
+| `pending_decisions` | what is already blocked on a human |
+| `seat_notes`, `handoff_read` | what earlier sessions and sibling agents know |
+| `ref_list` | what is already pinned, before generating anything |
+
+Three failures this prevents, all of them from the same session:
+
+- **A green row is a capability, not a tick.** `imageto3d: {available: true}`
+  was read as "that check passed" and the backend went unused for a week. If you
+  decline a capability, say so as a decision.
+- **`usable` means configured, not running, and not local-only.** A local
+  backend is listed usable with no server up; a hosted one needs only its key. An
+  agent tried the two local image-to-3D backends, got connection refused, and
+  reported the path unavailable — the hosted one worked and had already produced
+  every texture in that build. Check `hosted` before reporting anything down.
+- **A subagent's "X was not available" deserves the same scepticism as its "X
+  worked."** Check which variants it actually tried before repeating that upward.
+
+The board is live while you read it: closing a chain link releases the next one
+to auto-deploy even when the session-start banner said nothing was queued, so
+re-read `queue_list` after every `queue_complete`, and treat a file you did not
+write as evidence of a concurrent writer rather than a curiosity.
+
 ## Two things that will bite you
 
 **Approval is human-only, on purpose.** An agent records a verdict; it does not

--- a/templates/shared/CLAUDE.md
+++ b/templates/shared/CLAUDE.md
@@ -15,9 +15,11 @@ itself.
 **Never used this before? Read to "The loop", do that, ignore the rest until
 you need it.**
 
-Start every fresh session with `project_status`, then `queue_list`. If those
-two tools are missing from your tool list, the MCP server is not connected —
-tell the user to run `bgate serve` / check their `.mcp.json`, and stop.
+Start with `project_status` and `queue_list`; if those are missing from your tool
+list the MCP server is not connected — say so and stop. Then INVENTORY, one call
+each: `bgate_doctor`, `image_status`, `blender_status`, `pending_decisions`,
+`seat_notes`, `handoff_read`, `ref_list`. `available: true` is a capability to
+USE, not a gate you passed. Re-read `queue_list` after each `queue_complete`.
 
 ## The vocabulary, in one line each
 

--- a/tests/test_chroma_dusty_key.py
+++ b/tests/test_chroma_dusty_key.py
@@ -1,0 +1,190 @@
+"""The keyer shipped an opaque pink slab and called it clean.
+
+WHAT HAPPENED. The keyable-background contract asks the model for a flat
+PURE-MAGENTA backdrop and keys it out by RGB distance. Krea ignores the exact
+colour and paints a DUSTY pink — measured at ~#c0559f on real frames, which is
+143 away from (255,0,255) and therefore outside the default tol=125 sphere. So
+the interior never keyed.
+
+WHY NOTHING CAUGHT IT is the part worth keeping. The audit has five
+measurements and every one of them inspects THE CUT: the frame border, the soft
+edge, the RGB under zero alpha, the enclosed holes. None inspects what the cut
+left behind. The border happened to key — it sat closest to the contract colour —
+so `border_opaque` read clean, and with the interior fully opaque there was no
+soft edge, no dirty alpha and no enclosed transparency to fail on either. Five
+green checks over a solid rectangle, and `clean: true` on the way out.
+
+That is the same shape as `image_generate(tileable=True)` reporting success for a
+mirror pass that threw: a gate that validates a PROXY for the artifact instead of
+the artifact. So the assertions here are on pixels and on the specific flag, and
+the controls are the subject colours that must SURVIVE — a test that only proves
+the backdrop dies would be satisfied by a keyer that erases everything.
+"""
+from __future__ import annotations
+
+import pytest
+
+from bgate_core import chroma
+
+Image = pytest.importorskip("PIL.Image")
+
+MAGENTA = (255, 0, 255)
+# What Krea actually painted, not what it was asked for.
+DUSTY = (192, 85, 159)
+# Subject colours from the same build. Each must come through the key intact.
+LEAF = (60, 120, 50)
+TWIG = (110, 80, 50)
+PLUME = (220, 200, 160)
+PETAL = (240, 150, 180)     # the closest legitimate colour to the backdrop
+
+
+def _plate(path, backdrop, subject, *, size=64):
+    """A frame: flat backdrop with a solid subject block in the middle."""
+    im = Image.new("RGBA", (size, size), (*backdrop, 255))
+    for y in range(size // 4, 3 * size // 4):
+        for x in range(size // 4, 3 * size // 4):
+            im.putpixel((x, y), (*subject, 255))
+    im.save(path)
+    return path
+
+
+def _opaque_fraction(path):
+    with Image.open(path) as im:
+        data = list(im.convert("RGBA").getdata())
+    return sum(1 for *_, a in data if a > 200) / len(data)
+
+
+class TestPinkness:
+    """The scalar the fix turns on, checked against the measured colours."""
+
+    def test_the_contract_colour_is_maximally_pink(self):
+        assert chroma.pinkness(MAGENTA) == 255
+
+    def test_the_backdrop_that_shipped_is_still_clearly_pink(self):
+        """~90 — far below a distance key's reach, far above every subject."""
+        assert 85 < chroma.pinkness(DUSTY) < 95
+
+    @pytest.mark.parametrize("rgb,name",
+                             [(LEAF, "leaf"), (TWIG, "twig"), (PLUME, "plume")])
+    def test_subject_colours_are_not_pink(self, rgb, name):
+        assert chroma.pinkness(rgb) < 10, name
+
+    def test_a_petal_sits_between_them_and_is_spared(self):
+        """The tightest case, and the reason the threshold is a fraction rather
+        than as low as it could go: a pink subject must survive a magenta key."""
+        floor = chroma.pinkness(MAGENTA) * chroma.PINK_KEY_FRACTION
+        assert chroma.pinkness(PETAL) < floor < chroma.pinkness(DUSTY)
+
+
+class TestThePredicateIsExact:
+    """The same rule is evaluated three ways and they must not disagree.
+
+    Caught for real: the band version runs inside ImageMath on int32, where `/`
+    FLOORS, so a pixel whose true pinkness is 84.5 tested as 84 there and as 84.5
+    in the per-pixel paths. The two disagreed on exactly the colours sitting on
+    the threshold — the worst possible place — and only on those, so it survived
+    every test using a colour comfortably either side of it.
+    """
+
+    def test_a_half_step_pixel_is_decided_the_same_way_everywhere(self, tmp_path):
+        """(229,102,144) has pinkness 84.5 against a floor of 84. Whichever way
+        it is decided, the keyer and the audit have to agree."""
+        half = (229, 102, 144)
+        assert chroma.pinkness(half) == 84.5
+        floor = int(chroma.pinkness(MAGENTA) * chroma.PINK_KEY_FRACTION)
+        assert floor == 84
+
+        plate = _plate(tmp_path / "edge.png", half, TWIG)
+        chroma.finish(str(plate), MAGENTA, name="magenta")
+        with Image.open(plate) as im:
+            backdrop_keyed = im.convert("RGBA").getpixel((0, 0))[3] == 0
+        residual = chroma.audit(str(plate), chroma=MAGENTA)["residual_chroma"]
+        # Agreement is the assertion, not which way it went: keyed backdrop means
+        # no residual, unkeyed means residual. Never one without the other.
+        assert backdrop_keyed == (residual == 0.0)
+
+    def test_the_predicate_keeps_the_half_step_instead_of_dropping_it(self):
+        """Doubling both sides removes the rounding question rather than picking
+        a side of it: 84.5 > 84 stays True, which is what the float definition
+        always meant. The floored band version answered False — the two were only
+        ever going to differ here, on the .5, which is why nothing caught it."""
+        assert chroma.pinkness((229, 102, 144)) == 84.5
+        assert chroma.is_pinker_than((229, 102, 144), 84) is True
+        assert chroma.is_pinker_than((228, 102, 144), 84) is False   # 84.0 !> 84
+
+
+class TestTheDustyBackdropIsActuallyKeyed:
+    def test_the_frame_is_no_longer_a_slab(self, tmp_path):
+        plate = _plate(tmp_path / "heron.png", DUSTY, PLUME)
+        assert _opaque_fraction(plate) == 1.0        # the control: it starts solid
+        chroma.finish(str(plate), MAGENTA, name="magenta")
+        assert _opaque_fraction(plate) < 0.30        # only the subject survives
+
+    def test_the_audit_now_passes_it(self, tmp_path):
+        plate = _plate(tmp_path / "heron.png", DUSTY, PLUME)
+        assert chroma.finish(str(plate), MAGENTA, name="magenta")["ok"] is True
+
+    def test_a_pure_magenta_backdrop_still_keys(self, tmp_path):
+        """Regression guard on the path that always worked — the pinkness pass
+        is a UNION with the distance key, never a replacement."""
+        plate = _plate(tmp_path / "fox.png", MAGENTA, TWIG)
+        assert chroma.finish(str(plate), MAGENTA, name="magenta")["ok"] is True
+        assert _opaque_fraction(plate) < 0.30
+
+
+class TestTheSubjectSurvives:
+    """Without these, a keyer that erased the whole frame would pass above."""
+
+    @pytest.mark.parametrize("subject,name", [(LEAF, "leaf"), (TWIG, "twig"),
+                                              (PLUME, "plume"), (PETAL, "petal")])
+    def test_the_middle_is_still_there(self, tmp_path, subject, name):
+        plate = _plate(tmp_path / f"{name}.png", DUSTY, subject)
+        chroma.finish(str(plate), MAGENTA, name="magenta")
+        with Image.open(plate) as im:
+            assert im.convert("RGBA").getpixel((32, 32))[3] > 200, name
+
+    def test_a_non_pink_key_is_left_alone(self, tmp_path):
+        """The pinkness pass is gated on the chroma being a pink. A cyan key over
+        a pink subject must not have the subject eaten by a pass that does not
+        apply to it."""
+        cyan = (0, 255, 255)
+        plate = _plate(tmp_path / "petal.png", cyan, PETAL)
+        chroma.finish(str(plate), cyan, name="cyan")
+        with Image.open(plate) as im:
+            assert im.convert("RGBA").getpixel((32, 32))[3] > 200
+
+
+class TestTheAuditCatchesWhatTheKeyMisses:
+    """Belt and braces. The keyer is now better; the audit must still refuse a
+    slab that reaches it by any other route, because the next provider will
+    invent a backdrop nobody predicted."""
+
+    def test_an_unkeyed_slab_is_flagged(self, tmp_path):
+        plate = _plate(tmp_path / "slab.png", DUSTY, PLUME)
+        got = chroma.audit(str(plate), chroma=MAGENTA)
+        assert got["clean"] is False
+        assert any("unkeyed backdrop" in f for f in got["flags"])
+
+    def test_the_old_border_check_alone_would_have_passed_it(self, tmp_path):
+        """Names the exact hole: every pre-existing measurement reads clean on
+        the slab. If this ever starts failing, the new flag is redundant — but
+        it is not, and this is the proof."""
+        plate = _plate(tmp_path / "slab.png", DUSTY, PLUME)
+        for x in range(64):                     # key just the border, as krea did
+            for y in (0, 63):
+                pass
+        with Image.open(plate) as im:
+            im = im.convert("RGBA")
+            for i in range(64):
+                for x, y in ((i, 0), (i, 63), (0, i), (63, i)):
+                    im.putpixel((x, y), (0, 0, 0, 0))
+            im.save(plate)
+        got = chroma.audit(str(plate))          # no chroma: the old behaviour
+        assert got["clean"] is True             # ...and it says the slab is fine
+        assert got["residual_chroma"] is None   # because it never looked
+
+    def test_not_checked_and_checked_clean_do_not_look_the_same(self, tmp_path):
+        plate = _plate(tmp_path / "ok.png", MAGENTA, TWIG)
+        chroma.finish(str(plate), MAGENTA, name="magenta")
+        assert chroma.audit(str(plate))["residual_chroma"] is None
+        assert chroma.audit(str(plate), chroma=MAGENTA)["residual_chroma"] == 0.0

--- a/tests/test_console_gate_mode.py
+++ b/tests/test_console_gate_mode.py
@@ -1,0 +1,259 @@
+"""The approval-gate selector reaches the cards it claims to control.
+
+THE FIELD REPORT THIS FILE EXISTS FOR. A human set the gate to ``none``, which
+the label spells out as "an agent's own word closes its item", and the dashboard
+went on drawing APPROVAL cards over every generated candidate and SIGN-OFF cards
+over every finished item — each one saying only a human could decide. Observed
+across seats, art and director both, which is what ruled out "the art path forgot
+to check" and named it one defect at the gate layer.
+
+Why it is worth this much test: a gate that asks anyway has two failure modes and
+both are silent. Either work stalls behind a card nobody knew to click — nothing
+lands in notify.jsonl, so the board looks exactly like an agent still working —
+or the human learns to rubber-stamp, which spends the gate's credibility on the
+runs where it IS switched on.
+
+The second half is the inverse bug, found while fixing the first. Under
+``builders`` a finished item parks in 'review' (queue.complete), and the sign-off
+query asked for 'done' — so the one mode that genuinely mandates a human decision
+was the one whose blocked items had no card at all.
+
+These assert through ``_gates`` with a real database rather than through the JS,
+because the payload is the contract; the card is a rendering of it.
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from bgate_core import artifacts, db, gates, queue as _queue
+
+
+@pytest.fixture()
+def client(root, monkeypatch):
+    from bgate_ui.app import app
+
+    monkeypatch.setenv("BGATE_ROOT", str(root))
+    return TestClient(app)
+
+
+def _gates_for(root, active=None):
+    """Call the console's gate list the way /api/console/state does."""
+    from bgate_ui.routes import console as _console
+
+    conn = db.connect(root)
+    live = {int(r["id"]) for r in conn.execute(
+        "SELECT id FROM work_item WHERE status IN ('queued', 'dispatched')")}
+    return _console._gates(root, conn, active if active is not None else live)
+
+
+def _kinds(rows):
+    return sorted({r["kind"] for r in rows})
+
+
+@pytest.fixture()
+def finished(root):
+    """One maker-seat item an agent has reported done."""
+    item = _queue.add(root, "art", title="paint the heron",
+                      brief="one heron, full body")
+    _queue.complete(root, item["id"], result="painted it")
+    return _queue.get(root, item["id"])
+
+
+@pytest.fixture()
+def candidate(root):
+    """One generated candidate hanging off a still-running item."""
+    item = _queue.add(root, "art", title="fox plate", brief="a fox")
+    _queue.set_status(root, item["id"], "dispatched")
+    image = root / "fox.png"
+    image.write_bytes(b"fox-bytes")
+    art = artifacts.register(root, "species_red_fox", image,
+                             producer="image_generate",
+                             work_item_id=item["id"])
+    return item, art
+
+
+class TestGateNone:
+    """'none' is a sentence: do not stop to ask me."""
+
+    def test_no_signoff_card_for_a_finished_item(self, root, finished):
+        gates.set_mode(root, gates.NONE)
+        assert "signoff" not in _kinds(_gates_for(root))
+
+    def test_no_approval_card_for_a_candidate(self, root):
+        gates.set_mode(root, gates.NONE)
+        item = _queue.add(root, "art", title="fox plate", brief="a fox")
+        _queue.set_status(root, item["id"], "dispatched")
+        image = root / "fox.png"
+        image.write_bytes(b"fox-bytes")
+        artifacts.register(root, "species_red_fox", image,
+                           producer="image_generate", work_item_id=item["id"])
+        assert "art" not in _kinds(_gates_for(root))
+
+    def test_the_candidate_is_approved_not_merely_hidden(self, root):
+        """THE HALF THAT MATTERS MOST. Suppressing the card while leaving the
+        revision a candidate would be the worse bug: the live path still holds
+        the previous image and the only surface that said so is the one just
+        hidden. A gate that is off is off at the decision."""
+        gates.set_mode(root, gates.NONE)
+        image = root / "fox.png"
+        image.write_bytes(b"fox-bytes")
+        art = artifacts.register(root, "species_red_fox", image,
+                                 producer="image_generate")
+        assert art["status"] in ("approved", "integrated")
+
+    def test_a_queued_qa_item_still_shows(self, root):
+        """The control. 'none' suppresses ASKING, not the board — a qa-gate row
+        is a real work item somebody filed, and hiding a queued agent would be a
+        different lie told by the same fix."""
+        gates.set_mode(root, gates.NONE)
+        item = _queue.add(root, "qa", title="verify the heron",
+                          brief="check it", source="qa-gate")
+        assert [r for r in _gates_for(root, active={item["id"]})
+                if r["kind"] == "qa"]
+
+
+class TestGateAgent:
+    """The default. A machine verifies the claim; the human is not the reviewer."""
+
+    def test_no_signoff_card(self, root, finished):
+        """The QA seat already reviewed it — a second human ask buys nothing."""
+        gates.set_mode(root, gates.AGENT)
+        assert "signoff" not in _kinds(_gates_for(root))
+
+    def test_the_candidate_still_needs_a_human(self, root, candidate):
+        """Deliberately NOT extended to art: an agent's verdict leaves the
+        revision a candidate, because an agent approving art is the drift the
+        art-QA router exists to stop."""
+        gates.set_mode(root, gates.AGENT)
+        item, art = candidate
+        assert art["status"] == "candidate"
+        assert "art" in _kinds(_gates_for(root, active={item["id"]}))
+
+
+class TestGateBuilders:
+    """The human approves, and the card has to exist for them to do it."""
+
+    def test_signoff_card_for_a_finished_item(self, root, finished):
+        gates.set_mode(root, gates.BUILDERS)
+        assert "signoff" in _kinds(_gates_for(root))
+
+    def test_an_item_parked_in_review_gets_a_card(self, root):
+        """The inverse bug. holds_for_human parks a completion in 'review' and
+        the query asked for 'done', so the one gate this mode mandates drew
+        nothing — the chain behind it stopped with no card saying why."""
+        gates.set_mode(root, gates.BUILDERS)
+        item = _queue.add(root, "tech", title="scatter pass", brief="scatter")
+        done = _queue.complete(root, item["id"], result="scattered 850")
+        assert done["status"] == "review"          # the precondition, asserted
+        rows = [r for r in _gates_for(root) if r["kind"] == "signoff"]
+        assert [r for r in rows if r["item_id"] == item["id"] and r["parked"]]
+
+    def test_a_parked_item_is_never_aged_out(self, root, monkeypatch):
+        """'review' is a stopped chain, not a claim worth a glance. Ageing it out
+        of the window would hide the block and leave the work behind it queued
+        forever with nothing on screen explaining it."""
+        gates.set_mode(root, gates.BUILDERS)
+        item = _queue.add(root, "tech", title="scatter pass", brief="scatter")
+        _queue.complete(root, item["id"], result="scattered 850")
+        from bgate_ui.routes import console as _console
+        monkeypatch.setattr(_console, "_signoff_hours", lambda r: 0.25)
+        db.connect(root).execute(
+            "UPDATE work_item SET updated_at = '2001-01-01 00:00:00' "
+            "WHERE id = ?", (item["id"],))
+        db.connect(root).commit()
+        rows = [r for r in _gates_for(root) if r["kind"] == "signoff"]
+        assert [r for r in rows if r["item_id"] == item["id"]]
+
+    def test_an_acked_item_drops_off(self, root, finished):
+        """Unchanged behaviour, pinned so the rewritten query keeps it: the
+        acknowledgement is what makes this a gate rather than a backlog."""
+        gates.set_mode(root, gates.BUILDERS)
+        from bgate_ui.routes import console as _console
+        from bgate_core import workspace as _ws
+
+        _ws.set(root, _console.SEAT, _console.SIGNOFF_KEY,
+                {"acked": {str(finished["id"]): {"verdict": "accept"}}})
+        rows = [r for r in _gates_for(root) if r["kind"] == "signoff"]
+        assert not [r for r in rows if r["item_id"] == finished["id"]]
+
+
+class TestActingOnAParkedItem:
+    """A card that appears has to be a card that works.
+
+    Putting 'review' items in the sign-off list is only half a fix: the accept
+    button acked into a workspace doc, which would have cleared the CARD and left
+    the CHAIN stopped — the gate switched off at the drawing rather than at the
+    decision, which is the exact mistake being fixed one layer up.
+    """
+
+    @pytest.fixture()
+    def parked(self, root):
+        gates.set_mode(root, gates.BUILDERS)
+        item = _queue.add(root, "tech", title="scatter pass", brief="scatter")
+        _queue.complete(root, item["id"], result="scattered 850")
+        return _queue.get(root, item["id"])
+
+    def test_accept_releases_the_chain(self, client, root, parked):
+        got = client.post("/api/console/signoff",
+                          json={"item_id": parked["id"], "verdict": "accept"})
+        assert got.status_code == 200
+        assert got.json()["released"] is True
+        assert _queue.get(root, parked["id"])["status"] == "done"
+
+    def test_accept_records_who_signed(self, client, root, parked):
+        """An approval nobody signed is not an approval."""
+        client.post("/api/console/signoff",
+                    json={"item_id": parked["id"], "verdict": "accept"})
+        assert _queue.get(root, parked["id"])["approved_by"]
+
+    def test_send_back_requeues_with_the_reason_in_the_brief(self, client, root,
+                                                             parked):
+        got = client.post("/api/console/signoff",
+                          json={"item_id": parked["id"], "verdict": "reopen",
+                                "reason": "the legs are cropped"})
+        assert got.status_code == 200
+        after = _queue.get(root, parked["id"])
+        assert after["status"] == "queued"
+        assert "the legs are cropped" in after["brief"]
+
+    def test_a_finished_item_is_still_only_acked(self, client, root):
+        """The control: an item that is genuinely 'done' must NOT be run through
+        approve() — it has no chain to release and approve() refuses anything
+        that is not parked. The two paths have to stay distinguishable."""
+        gates.set_mode(root, gates.BUILDERS)
+        item = _queue.add(root, "art", title="paint", brief="paint")
+        _queue.complete(root, item["id"], result="painted", skip_gate=True)
+        _queue.set_status(root, item["id"], "done")
+        got = client.post("/api/console/signoff",
+                          json={"item_id": item["id"], "verdict": "accept"})
+        assert got.status_code == 200
+        assert got.json()["released"] is False
+        assert not [r for r in _gates_for(root) if r["kind"] == "signoff"
+                    and r["item_id"] == item["id"]]
+
+
+class TestDegradation:
+    """A gate the board cannot READ must not blank the board.
+
+    The mode is now consulted on every poll, which means an unreadable registry
+    is on the critical path of drawing the graph at all. It must degrade to
+    DEFAULT — 'agent', the behaviour that shipped before the setting existed —
+    rather than to silence, because silence here means a candidate awaiting a
+    human with no card, which is the bug this whole file is about arriving from
+    the opposite direction.
+    """
+
+    @pytest.fixture()
+    def unreadable(self, monkeypatch):
+        monkeypatch.setattr(gates, "mode",
+                            lambda r: (_ for _ in ()).throw(RuntimeError("db")))
+
+    def test_it_does_not_raise(self, root, candidate, unreadable):
+        _gates_for(root)
+
+    def test_it_falls_back_to_the_agent_gate(self, root, candidate, unreadable):
+        """Not to 'none'. Failing open would hide a pending human decision on
+        exactly the poll where something is already wrong."""
+        item, art = candidate
+        assert "art" in _kinds(_gates_for(root, active={item["id"]}))

--- a/tests/test_gltf_alpha_mode.py
+++ b/tests/test_gltf_alpha_mode.py
@@ -1,0 +1,118 @@
+"""Godot 4.7 downgrades glTF alphaMode:MASK, silently, and it costs frames.
+
+THE TRAP. `MASK` in glTF means "hard cutout" and the engine-side equivalent is
+ALPHA_SCISSOR — an opaque-pass decision resolved per fragment. Godot 4.7 imports
+it as DEPTH_PRE_PASS instead, which puts the surface in the SORTED TRANSPARENT
+pass. Nothing errors. Nothing is logged. A screenshot of one tree looks
+identical either way.
+
+What changes is a forest. Hundreds of alpha quads that should have been opaque
+cutouts are now depth-sorted every frame and cannot early-z against each other,
+so the symptom is a framerate cliff with no error to grep for and no visual tell
+— which is the worst possible shape for a bug, and the reason this is worth
+detecting at import time rather than leaving to a profiler.
+
+Reported, not corrected: whether a MASK surface wants scissor (foliage) or the
+transparent pass (genuinely translucent) is not knowable from the file.
+
+The parser is tested against bytes rather than a fixture .glb because the point
+is that reading the JSON chunk needs no glTF library and no Blender — this runs
+on the import path and must not grow a dependency in order to warn.
+"""
+from __future__ import annotations
+
+import json
+import struct
+
+
+from bgate_adapters import godot
+
+
+def _gltf_doc(*alpha_modes):
+    return {"asset": {"version": "2.0"},
+            "materials": [{"name": f"mat{i}", **({"alphaMode": m} if m else {})}
+                          for i, m in enumerate(alpha_modes)]}
+
+
+def _write_glb(path, doc):
+    """A minimal but REAL .glb: 12-byte header, then the JSON chunk."""
+    blob = json.dumps(doc).encode("utf-8")
+    blob += b" " * ((4 - len(blob) % 4) % 4)          # chunks are 4-byte aligned
+    header = b"glTF" + struct.pack("<II", 2, 12 + 8 + len(blob))
+    path.write_bytes(header + struct.pack("<I", len(blob)) + b"JSON" + blob)
+    return path
+
+
+class TestReadingTheJsonChunk:
+    def test_a_glb_is_parsed_without_a_gltf_library(self, tmp_path):
+        doc = _gltf_doc("OPAQUE")
+        got = godot.gltf_json(_write_glb(tmp_path / "tree.glb", doc))
+        assert got["materials"][0]["name"] == "mat0"
+
+    def test_a_plain_gltf_is_parsed_too(self, tmp_path):
+        p = tmp_path / "tree.gltf"
+        p.write_text(json.dumps(_gltf_doc("MASK")), encoding="utf-8")
+        assert godot.gltf_json(p)["materials"][0]["alphaMode"] == "MASK"
+
+    def test_a_non_gltf_file_is_none_not_an_error(self, tmp_path):
+        p = tmp_path / "notes.txt"
+        p.write_text("hello", encoding="utf-8")
+        assert godot.gltf_json(p) is None
+
+    def test_a_truncated_glb_is_none_not_an_exception(self, tmp_path):
+        """A missing warning is a far smaller problem than an import that fails
+        because the warner threw."""
+        p = tmp_path / "broken.glb"
+        p.write_bytes(b"glTF" + b"\x00" * 6)
+        assert godot.gltf_json(p) is None
+
+    def test_a_missing_file_is_none(self, tmp_path):
+        assert godot.gltf_json(tmp_path / "nope.glb") is None
+
+
+class TestTheWarning:
+    def test_mask_is_named_with_the_material(self, tmp_path):
+        got = godot.alpha_mode_report(
+            _write_glb(tmp_path / "tree.glb", _gltf_doc("MASK")))
+        assert got["masked_materials"] == ["mat0"]
+        assert "mat0" in got["warning"]
+
+    def test_it_names_what_godot_actually_does(self, tmp_path):
+        """The whole value is the specific pair of words. "Check your alpha
+        settings" would send someone to the same afternoon this prevents."""
+        got = godot.alpha_mode_report(
+            _write_glb(tmp_path / "tree.glb", _gltf_doc("MASK")))
+        assert "DEPTH_PRE_PASS" in got["warning"]
+        assert "ALPHA_SCISSOR" in got["warning"]
+
+    def test_opaque_and_blend_are_left_alone(self, tmp_path):
+        """The control. A warning on every material is a warning nobody reads."""
+        got = godot.alpha_mode_report(
+            _write_glb(tmp_path / "rock.glb", _gltf_doc("OPAQUE", "BLEND", None)))
+        assert got["masked_materials"] == []
+        assert got["warning"] == ""
+
+    def test_only_the_masked_ones_are_listed_in_a_mixed_file(self, tmp_path):
+        doc = {"asset": {"version": "2.0"}, "materials": [
+            {"name": "bark", "alphaMode": "OPAQUE"},
+            {"name": "leaves", "alphaMode": "MASK"},
+            {"name": "glass", "alphaMode": "BLEND"},
+        ]}
+        got = godot.alpha_mode_report(_write_glb(tmp_path / "tree.glb", doc))
+        assert got["masked_materials"] == ["leaves"]
+
+    def test_a_long_list_is_summarised_rather_than_dumped(self, tmp_path):
+        got = godot.alpha_mode_report(
+            _write_glb(tmp_path / "forest.glb", _gltf_doc(*(["MASK"] * 9))))
+        assert len(got["masked_materials"]) == 9
+        assert "+3 more" in got["warning"]
+
+    def test_checked_and_clean_does_not_look_like_not_checked(self, tmp_path):
+        """A glTF with no MASK returns a dict; a .obj returns None. Collapsing
+        those is how a check gets quietly skipped for a whole file type."""
+        clean = godot.alpha_mode_report(
+            _write_glb(tmp_path / "rock.glb", _gltf_doc("OPAQUE")))
+        p = tmp_path / "rock.obj"
+        p.write_text("v 0 0 0", encoding="utf-8")
+        assert clean is not None and clean["masked_materials"] == []
+        assert godot.alpha_mode_report(p) is None

--- a/tests/test_imagegen_tileable.py
+++ b/tests/test_imagegen_tileable.py
@@ -1,0 +1,110 @@
+"""make_tileable actually tiles, and says so honestly when it does not.
+
+THE DEFECT. ``Image.save`` dispatches on the destination path's SUFFIX. A caller
+naming its output ``litter_albedo`` rather than ``litter_albedo.png`` — which is
+what an agent passes roughly half the time, and which nothing in the tool
+signature forbids — produced ``ValueError: unknown file extension:`` inside a
+swallowing try, so the mirror pass never ran and the caller got a texture back.
+The evidence arrived days later as a visible seam at 2.4m tiling across a
+full-screen terrain floor.
+
+THE SHAPE OF THE BUG IS THE POINT, and it recurs across this codebase: the
+success flag was computed from the REQUEST, never from the artifact. The same
+week, the alpha keyer returned ``clean: true`` while shipping an opaque slab,
+because it validated the frame border rather than the interior. A tool that
+reports its own success on the strength of what it was asked to do is not
+evidence, and neither of these would have been caught by a test that only ever
+passes a well-formed path.
+
+So the control here is a path with no suffix, and the assertion is on PIXELS —
+whether the left column actually mirrors the right — not on the returned flag.
+"""
+from __future__ import annotations
+
+import shutil
+
+import pytest
+
+from bgate_adapters.imagegen import make_tileable
+
+Image = pytest.importorskip("PIL.Image")
+
+
+def _plate(path, w=16, h=16, fmt=None):
+    """A plate with a strong LEFT-RIGHT GRADIENT — the thing a mirror pass has
+    to visibly change. A flat colour tiles perfectly before and after, so it
+    could not tell a working pass from a no-op."""
+    im = Image.new("RGB", (w, h))
+    for x in range(w):
+        for y in range(h):
+            im.putpixel((x, y), (x * (255 // max(1, w - 1)), 40, 90))
+    im.save(path, format=fmt)
+    return path
+
+
+def _seams(path):
+    """Mean worst-channel gap between the left edge and the right edge — what
+    you would see as a hard line where the tile repeats. A mirrored tile joins
+    by construction, so this collapses to ~0. Worst channel rather than the
+    average of three, because a seam in one channel is a visible seam and
+    averaging it against two clean ones is how a real gap reads as small."""
+    with Image.open(path) as im:
+        im = im.convert("RGB")
+        w, h = im.size
+        return sum(max(abs(a - b) for a, b in zip(im.getpixel((0, y)),
+                                                  im.getpixel((w - 1, y))))
+                   for y in range(h)) / h
+
+
+class TestTheSuffixlessPath:
+    """The exact call that failed in the field."""
+
+    def test_it_reports_success(self, tmp_path):
+        src = _plate(tmp_path / "plate.png")
+        target = tmp_path / "litter_albedo"          # no extension, on purpose
+        shutil.copy(src, target)
+        assert make_tileable(str(target))["ok"] is True
+
+    def test_the_pixels_actually_changed(self, tmp_path):
+        """The assertion that matters. `ok: true` is the flag that lied before —
+        the proof is the seam measurement, and it must fall to nothing."""
+        src = _plate(tmp_path / "plate.png")
+        target = tmp_path / "litter_albedo"
+        shutil.copy(src, target)
+        before = _seams(target)
+        make_tileable(str(target))
+        after = _seams(target)
+        assert before > 200          # the control: the plate really did seam
+        assert after < 2             # and now it does not
+
+    def test_a_suffixed_path_is_unaffected(self, tmp_path):
+        """Regression guard on the path that always worked."""
+        target = _plate(tmp_path / "scree.png")
+        assert make_tileable(str(target))["ok"] is True
+        assert _seams(target) < 2
+
+
+class TestItStillFailsHonestly:
+    def test_a_file_that_is_not_an_image_is_reported_not_raised(self, tmp_path):
+        """A texture that failed to tile is still a texture — this must never
+        raise into a generation that already cost money."""
+        junk = tmp_path / "notanimage.png"
+        junk.write_bytes(b"not a png at all")
+        out = make_tileable(str(junk))
+        assert out["ok"] is False
+        assert "could not mirror-tile" in out["note"]
+
+    def test_a_missing_file_is_reported_not_raised(self, tmp_path):
+        assert make_tileable(str(tmp_path / "nope.png"))["ok"] is False
+
+
+class TestFormatIsCarried:
+    def test_a_jpeg_stays_a_jpeg(self, tmp_path):
+        """The source knows what it is even when the destination path does not.
+        Writing PNG bytes into a .jpg the engine imports by extension is the
+        same class of silent breakage this fix exists to end."""
+        target = tmp_path / "grain"
+        _plate(target, fmt="JPEG")
+        assert make_tileable(str(target))["ok"] is True
+        with Image.open(target) as im:
+            assert im.format == "JPEG"

--- a/tests/test_imageto3d_summary.py
+++ b/tests/test_imageto3d_summary.py
@@ -1,0 +1,113 @@
+"""The status an AGENT reads must distinguish configured from running.
+
+THE INCIDENT. ``blender_status`` answered:
+
+    generate.usable  = ["hunyuan-local", "krea", "trellis-cpp"]
+
+An agent tried the two local backends, got connection refused from both, and
+reported image-to-3D unavailable. That was relayed upward as fact and the entire
+image-to-3D path was written off for a session. Krea is HOSTED — it needs no
+local server, its key was set, and it had already produced every texture in the
+same build.
+
+Two things made one list do that damage. ``usable`` means CONFIGURED, and for a
+local backend configured is not running: the summary probes nothing, on purpose,
+because a status call that blocks on a TCP timeout for a server nobody started
+is a status call nobody makes. And the local/hosted split — which the adapter
+already computes and always did — was flattened away before the agent saw it.
+
+So these tests assert on the SHAPE the agent reads, not on this machine's actual
+hardware, which is why every backend list here is stubbed.
+"""
+from __future__ import annotations
+
+import pytest
+
+from bgate_adapters import imageto3d
+from bgate_mcp import server
+
+
+@pytest.fixture()
+def stub(monkeypatch):
+    """Force a known status() answer. The real one depends on the developer's
+    GPU and keys, which is exactly the kind of thing a contract test must not."""
+    def _set(*, local=(), hosted=(), blocked=None):
+        rows = ([{"backend": b, "kind": "local", "available": True,
+                  "implemented": True} for b in local]
+                + [{"backend": b, "kind": "hosted", "available": True,
+                    "implemented": True} for b in hosted]
+                + [{"backend": b, "kind": "hosted", "available": False,
+                    "implemented": True, "reason": why}
+                   for b, why in (blocked or {}).items()])
+        payload = {
+            "ok": bool(local or hosted),
+            "gpu": {"name": "NVIDIA GeForce RTX 3060", "vram_gb": 12.0},
+            "backends": rows,
+            "usable": [*local, *hosted],
+            "local": list(local), "hosted": list(hosted),
+            "unconditional_licence": [],
+            "reason": "" if (local or hosted) else "nothing configured",
+        }
+        monkeypatch.setattr(imageto3d, "status", lambda *a, **k: payload)
+        return payload
+    return _set
+
+
+class TestTheSplitIsVisible:
+    def test_local_and_hosted_are_named_separately(self, stub):
+        stub(local=("hunyuan-local", "trellis-cpp"), hosted=("krea",))
+        got = server._imageto3d_summary()
+        assert got["local"] == ["hunyuan-local", "trellis-cpp"]
+        assert got["hosted"] == ["krea"]
+
+    def test_usable_is_still_there_for_existing_callers(self, stub):
+        """A status field that silently changes shape is its own version of this
+        bug. The split is added ALONGSIDE the old key, not instead of it."""
+        stub(local=("hunyuan-local",), hosted=("krea",))
+        got = server._imageto3d_summary()
+        assert set(got["usable"]) == {"hunyuan-local", "krea"}
+        assert got["available"] is True
+
+    def test_it_says_out_loud_that_it_did_not_probe(self, stub):
+        """The word 'usable' carried an implication the call never checked."""
+        stub(local=("hunyuan-local",))
+        assert "no server running" in server._imageto3d_summary()["checked"]
+
+
+class TestTheNoteAnswersTheQuestionThatWasGotWrong:
+    def test_a_hosted_option_is_pointed_at_by_name(self, stub):
+        """The one sentence that would have saved the session."""
+        stub(local=("hunyuan-local", "trellis-cpp"), hosted=("krea",))
+        note = server._imageto3d_summary()["note"]
+        assert "krea" in note
+        assert "no local server" in note
+
+    def test_local_only_is_warned_about_explicitly(self, stub):
+        """With nothing hosted, a refused connection really can mean the path is
+        down — but only after a probe, and the agent has to be told to run one
+        rather than infer from an unqualified 'usable'."""
+        stub(local=("hunyuan-local", "trellis-cpp"))
+        note = server._imageto3d_summary()["note"]
+        assert "CONFIGURED, not" in note
+        assert "refused connection" in note
+
+    def test_nothing_configured_still_says_what_to_set(self, stub):
+        """The control: the empty answer must not gain a misleading hint."""
+        stub()
+        got = server._imageto3d_summary()
+        assert got["available"] is False
+        assert "nothing configured" in got["note"]
+        assert "krea" not in got["note"]
+
+    def test_the_draft_warning_survives_the_rewrite(self, stub):
+        """A generated mesh is not an asset, and that sentence must not have been
+        pushed out by the new hint."""
+        stub(hosted=("krea",))
+        assert "DRAFT" in server._imageto3d_summary()["note"]
+
+
+class TestBlockedIsUnchanged:
+    def test_a_blocked_backend_keeps_its_reason(self, stub):
+        stub(hosted=("krea",), blocked={"meshy": "MESHY_API_KEY not set"})
+        assert server._imageto3d_summary()["blocked"]["meshy"] == \
+            "MESHY_API_KEY not set"

--- a/tests/test_mcp_adjust.py
+++ b/tests/test_mcp_adjust.py
@@ -362,18 +362,34 @@ def test_a_run_tag_is_unique_across_a_burst():
 # The per-pixel loop that was moved onto Pillow primitives
 # ---------------------------------------------------------------------------
 def _reference_chroma_key(img, chroma, tol=125, despill=185):
-    """The original per-pixel implementation, kept here as the oracle: the
-    rewrite is only allowed to be faster, not different."""
+    """The per-pixel implementation, kept here as the oracle: the vectorised
+    version is allowed to be faster, not different.
+
+    TWO PASSES NOW, and the second one is a deliberate behaviour change rather
+    than drift — see bgate_core.chroma.pinkness. Krea paints a DESATURATED
+    magenta (~#c0559f, 143 from the contract colour and so outside tol) instead
+    of the flat chroma it is asked for, so a distance key left the interior of
+    every frame opaque while the border keyed. The union pass catches the
+    backdrop by pinkness; this oracle reimplements that rule per-pixel rather
+    than importing it, so the two can still disagree.
+    """
+    from bgate_core.chroma import (PINK_CHROMA_MIN, PINK_KEY_FRACTION,
+                                   is_pinker_than, pinkness)
+
     px = img.load()
     W, H = img.size
     cr, cg, cb = chroma
+    pink_floor = (int(pinkness(chroma) * PINK_KEY_FRACTION)
+                  if pinkness(chroma) >= PINK_CHROMA_MIN else None)
     for y in range(H):
         for x in range(W):
             r, g, b, a = px[x, y]
             if a == 0:
                 continue
             d = ((r - cr) ** 2 + (g - cg) ** 2 + (b - cb) ** 2) ** 0.5
-            if d < tol:
+            pinkish = (pink_floor is not None
+                       and is_pinker_than((r, g, b), pink_floor))
+            if d < tol or pinkish:
                 px[x, y] = (0, 0, 0, 0)
             elif d < despill:
                 m = (r + g + b) // 3
@@ -381,29 +397,59 @@ def _reference_chroma_key(img, chroma, tol=125, despill=185):
     return img
 
 
-def test_the_chroma_key_matches_the_per_pixel_original():
-    import random
-
+def _key_case(chroma, seed=7):
     from PIL import Image
 
-    chroma = (255, 0, 255)
-    random.seed(7)
+    import random
+
+    random.seed(seed)
     pixels = [(random.randrange(256), random.randrange(256),
                random.randrange(256), 255) for _ in range(64 * 64)]
     # Guarantee all three branches are exercised, not just the random middle.
-    pixels[:64] = [chroma + (255,)] * 64                       # keyed
+    pixels[:64] = [tuple(chroma) + (255,)] * 64                # keyed
     pixels[64:128] = [(200, 40, 200, 255)] * 64                # despill fringe
     source = Image.new("RGBA", (64, 64))
     source.putdata(pixels)
+    return source
 
+
+def _assert_matches_reference(chroma):
+    source = _key_case(chroma)
     expected = _reference_chroma_key(source.copy(), chroma)
     got = server._chroma_key(source.copy(), chroma)
-
     for i, (want, have) in enumerate(zip(expected.getdata(), got.getdata())):
         assert want[3] == have[3], f"alpha differs at {i}"
         # Band math floors where the loop floored; allow one step of slack on
         # the despilled channels rather than pinning float32 rounding.
         assert all(abs(a - b) <= 1 for a, b in zip(want[:3], have[:3])), i
+
+
+def test_the_chroma_key_matches_the_per_pixel_original():
+    _assert_matches_reference((255, 0, 255))
+
+
+def test_a_non_pink_chroma_is_pure_distance_keying():
+    """THE ORIGINAL INVARIANT, unchanged and still guarded. The pinkness pass is
+    gated on the chroma being a pink, so a cyan key must behave exactly as it did
+    before that pass existed — same pixels, same despill, no widening."""
+    _assert_matches_reference((0, 255, 255))
+
+
+def test_the_pink_pass_only_ever_adds():
+    """It is a UNION with the distance key, never a replacement. Anything the
+    distance rule cut must still be cut — a 'fix' that traded one set of missed
+    pixels for another would satisfy the oracle above and still be wrong."""
+    chroma = (255, 0, 255)
+    source = _key_case(chroma)
+    distance_only = _reference_chroma_key(source.copy(), (0, 255, 255))
+    both = server._chroma_key(source.copy(), chroma)
+    # Every pixel the CHROMA's own distance rule keyed, keyed by hand here so the
+    # comparison does not lean on the implementation being tested.
+    for i, px in enumerate(source.getdata()):
+        d = sum((c - k) ** 2 for c, k in zip(px[:3], chroma)) ** 0.5
+        if d < 125:
+            assert both.getdata()[i][3] == 0, i
+    assert distance_only is not None      # the copy above was not mutated in place
 
 
 def test_keyed_pixels_carry_no_colour_underneath():

--- a/tests/test_pending_decisions.py
+++ b/tests/test_pending_decisions.py
@@ -1,0 +1,160 @@
+"""A pending human decision has to be READABLE, not just drawable.
+
+THE GAP THIS CLOSES. Human approval was dashboard-only by design — the agent
+that made a candidate must not be the one to clear it — but "you may not decide
+it" was implemented as "you may not SEE it", and those are different rules. A
+director could not ask what was blocking its own board: asset_status lists
+candidates with no approval state, art_tournament_standings reports only decided
+matches, and nothing emitted an event.
+
+The cost is not inconvenience. A blocking gate with no signal looks exactly like
+an agent quietly working, so work stalls behind it and the heartbeat says
+nothing — the same "silence is not success" failure as a dead agent, through a
+different door. Measured in the field: five species candidates generated inside
+two minutes, an approval card for each, and zero lines on notify.jsonl.
+
+Two surfaces are tested here because they answer different questions and neither
+substitutes for the other — the jsonl is what a shell can tail with no database
+and no MCP, the tool is what an agent mid-run can call.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from bgate_core import artifacts, gates, queue as _queue
+
+
+def _notify_lines(root):
+    path = root / ".bgate" / "notify.jsonl"
+    if not path.is_file():
+        return []
+    return [json.loads(line) for line in
+            path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def _register(root, name="species_red_fox", item_id=None):
+    image = root / f"{name}.png"
+    image.write_bytes(b"plate-bytes")
+    return artifacts.register(root, name, image, producer="image_generate",
+                              work_item_id=item_id)
+
+
+class TestTheHeartbeatCarriesCandidates:
+    def test_a_candidate_appends_a_line(self, root):
+        before = len(_notify_lines(root))
+        _register(root)
+        after = _notify_lines(root)
+        assert len(after) == before + 1
+        assert after[-1]["kind"] == "artifact.candidate"
+
+    def test_the_line_names_what_is_waiting(self, root):
+        item = _queue.add(root, "art", title="fox plate", brief="a fox")
+        art = _register(root, item_id=item["id"])
+        line = _notify_lines(root)[-1]
+        assert line["artifact_id"] == art["id"]
+        assert line["item_id"] == item["id"]
+        assert "species_red_fox" in line["title"]
+
+    def test_the_decision_closing_is_news_too(self, root):
+        """Without this a consumer's pending list only grows, and it keeps
+        telling the human they owe a decision they already made."""
+        art = _register(root)
+        artifacts.review(root, art["id"], "approved", actor="Adrian")
+        line = _notify_lines(root)[-1]
+        assert line["kind"] == "artifact.reviewed"
+        assert line["status"] in ("approved", "integrated")
+
+    def test_work_item_lines_are_unchanged_for_old_consumers(self, root):
+        """Purely additive. A tail that reads {ts,item_id,status,seat,title}
+        must see exactly what it saw before — the whole point of putting both
+        classes on ONE stream is that nobody has to be told to re-plumb."""
+        item = _queue.add(root, "tech", title="scatter", brief="scatter")
+        _queue.set_status(root, item["id"], "dispatched")
+        line = [ln for ln in _notify_lines(root)
+                if ln.get("item_id") == item["id"]][-1]
+        for field in ("ts", "item_id", "status", "seat", "title"):
+            assert field in line
+        assert line["status"] == "dispatched"
+
+    def test_a_broken_stream_never_costs_the_registration(self, root, monkeypatch):
+        """The control. Losing a ping must not lose the artifact it was about."""
+        monkeypatch.setattr(artifacts, "_notify_line",
+                            lambda *a, **k: (_ for _ in ()).throw(OSError("full")))
+        with pytest.raises(OSError):
+            artifacts._notify_line(root, {})       # the fake really does raise
+        monkeypatch.setattr(artifacts, "_announce_candidate",
+                            lambda *a, **k: None)
+        assert _register(root)["id"]
+
+
+class TestPendingDecisions:
+    """The tool that did not exist."""
+
+    @pytest.fixture()
+    def call(self, root, monkeypatch):
+        import asyncio
+
+        from bgate_mcp import server
+
+        monkeypatch.setenv("BGATE_ROOT", str(root))
+
+        def _go(**kw):
+            out = asyncio.run(server.mcp.call_tool("pending_decisions", kw))
+            content = out[0] if isinstance(out, tuple) else out
+            block = content[0]
+            return json.loads(block.text) if hasattr(block, "text") else block
+        return _go
+
+    def test_an_idle_project_says_so(self, call):
+        got = call()
+        assert got["total"] == 0
+        assert got["note"] == "nothing is waiting on a human"
+
+    def test_a_candidate_is_listed_with_what_it_hangs_off(self, root, call):
+        item = _queue.add(root, "art", title="fox plate", brief="a fox")
+        art = _register(root, item_id=item["id"])
+        got = call()
+        assert [c for c in got["candidates"]
+                if c["artifact_id"] == art["id"]
+                and c["work_item_id"] == item["id"]]
+
+    def test_a_machine_verdict_is_distinguished_from_a_raw_candidate(self, root,
+                                                                     call):
+        """A candidate a QA agent already passed is a different ask: the human is
+        confirming a check, not performing the first one."""
+        art = _register(root)
+        artifacts.qa_verdict(root, art["id"], passed=True, note="full body, clean",
+                             actor="agent:item-3")
+        row = [c for c in call()["candidates"] if c["artifact_id"] == art["id"]][0]
+        assert row["machine_verdict"] == "pass"
+        assert "full body" in row["machine_note"]
+
+    def test_a_parked_item_is_reported_as_a_stopped_chain(self, root, call):
+        gates.set_mode(root, gates.BUILDERS)
+        item = _queue.add(root, "tech", title="scatter pass", brief="scatter")
+        _queue.complete(root, item["id"], result="scattered 850")
+        got = call()
+        assert [p for p in got["blocked_chains"] if p["item_id"] == item["id"]]
+
+    def test_it_reports_the_gate_mode(self, root, call):
+        gates.set_mode(root, gates.BUILDERS)
+        assert call()["gate"]["mode"] == "builders"
+
+    def test_a_decision_pending_under_gate_none_is_called_out(self, root, call):
+        """Under 'none' the board is not supposed to be stopping for anyone, so
+        a non-empty list is a defect to report rather than a queue to click
+        through. The tool says which one the agent is looking at."""
+        art = _register(root)
+        artifacts.qa_verdict(root, art["id"], passed=True, actor="agent:item-1")
+        gates.set_mode(root, gates.NONE)
+        got = call()
+        assert got["candidates"]                       # left over from before
+        assert "approval gate is 'none'" in got["note"]
+
+    def test_an_answered_candidate_drops_off(self, root, call):
+        art = _register(root)
+        assert call()["total"] == 1
+        artifacts.review(root, art["id"], "approved", actor="Adrian")
+        assert call()["total"] == 0

--- a/tests/test_queue_stop.py
+++ b/tests/test_queue_stop.py
@@ -1,0 +1,122 @@
+"""A stop is not a crash, and the difference has to survive without a reader.
+
+THE INCIDENT. Three items — #3 art, #13 tech, #14 director — flipped to
+``status: failed`` in the same second. Read as three separate bugs. They were one
+event: a human had pressed STOP ALL. The system said so, honestly, in the result
+note ("stopped by Adrian — this run was ended by hand, it did not die on its
+own") and nowhere else, so telling a kill from a crash meant reading English out
+of a prose field. Same-second multi-seat failure is the signature of a systemic
+event; nothing could see it.
+
+WHAT THIS DOES NOT DO, and the tests below pin it deliberately: it does not add a
+sixth status. 'failed' is keyed on in ~85 places — reopen()'s guard, the QA gate
+query, the chain interlock, the console lanes — and a new status changes
+behaviour in every one that filters by name, by omission and silently. The status
+was never the missing thing. The CAUSE was, and a cause is its own column.
+
+The other half is the heartbeat: a burst of identical 'failed' lines during a
+STOP ALL is exactly as unreadable on the stream as it was in the database.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from bgate_core import events, queue as _queue
+
+
+def _notify_lines(root):
+    path = root / ".bgate" / "notify.jsonl"
+    if not path.is_file():
+        return []
+    return [json.loads(ln) for ln in
+            path.read_text(encoding="utf-8").splitlines() if ln.strip()]
+
+
+@pytest.fixture()
+def running(root):
+    item = _queue.add(root, "tech", title="scatter pass", brief="scatter it")
+    _queue.set_status(root, item["id"], "dispatched")
+    return _queue.get(root, item["id"])
+
+
+class TestTheStopIsMachineReadable:
+    def test_stopped_by_names_the_person(self, root, running):
+        after = _queue.stop(root, running["id"], by="Adrian")
+        assert after["stopped_by"] == "Adrian"
+
+    def test_was_stopped_answers_without_reading_prose(self, root, running):
+        assert _queue.was_stopped(_queue.get(root, running["id"])) is False
+        _queue.stop(root, running["id"], by="Adrian")
+        assert _queue.was_stopped(_queue.get(root, running["id"])) is True
+
+    def test_a_real_failure_is_not_mistaken_for_a_stop(self, root, running):
+        """The control. Without it, a field that is always truthy would pass
+        every assertion above and distinguish nothing."""
+        _queue.complete(root, running["id"], result="the build never linked",
+                        failed=True)
+        item = _queue.get(root, running["id"])
+        assert item["status"] == "failed"
+        assert _queue.was_stopped(item) is False
+
+    def test_the_time_is_recorded(self, root, running):
+        assert _queue.stop(root, running["id"], by="Adrian")["stopped_at"]
+
+
+class TestTheStatusIsDeliberatelyStillFailed:
+    def test_it_banks_as_failed(self, root, running):
+        assert _queue.stop(root, running["id"], by="Adrian")["status"] == "failed"
+
+    def test_a_stopped_item_can_still_be_reopened(self, root, running):
+        """The reason for not inventing a status. A stopped run is usually 90%
+        landed and IS worth another round — reopen() guards on
+        done/failed/cancelled, and a 'stopped' status would have failed that
+        guard with no error anyone wrote."""
+        _queue.stop(root, running["id"], by="Adrian")
+        back = _queue.reopen(root, running["id"], "finish the scatter pass")
+        assert back["status"] == "queued"
+
+    def test_the_stop_record_survives_the_reopen(self, root, running):
+        """stopped_at is separate from updated_at so a re-run item still says it
+        was stopped once, three rounds ago, rather than claiming it just now."""
+        _queue.stop(root, running["id"], by="Adrian")
+        _queue.reopen(root, running["id"], "finish it")
+        assert _queue.get(root, running["id"])["stopped_by"] == "Adrian"
+
+
+class TestTheHeartbeatSaysStop:
+    def test_the_stream_carries_a_stopped_line(self, root, running):
+        _queue.stop(root, running["id"], by="Adrian")
+        assert [ln for ln in _notify_lines(root)
+                if ln.get("item_id") == running["id"]
+                and ln.get("status") == "stopped"]
+
+    def test_the_bus_carries_an_item_stopped_event(self, root, running):
+        _queue.stop(root, running["id"], by="Adrian")
+        kinds = [e["kind"] for e in events.since(root, 0)["events"]]
+        assert "item.stopped" in kinds
+
+    def test_the_event_names_who(self, root, running):
+        _queue.stop(root, running["id"], by="Adrian")
+        stopped = [e for e in events.since(root, 0)["events"]
+                   if e["kind"] == "item.stopped"][-1]
+        assert stopped["payload"]["by"] == "Adrian"
+
+    def test_the_kind_is_selectable_in_the_settings_panel(self):
+        """A kind emitted but absent from settings.EVENT_KINDS has no checkbox,
+        so it can never be added to notify.kinds and coerce() REFUSES it — which
+        is how chain.filed ended up emitted and unselectable at the same time.
+        (test_events pins the two lists equal in general; this pins the one kind
+        added here, so the failure names itself.)"""
+        from bgate_core import settings
+
+        assert "item.stopped" in events.KINDS
+        assert "item.stopped" in settings.EVENT_KINDS
+
+
+class TestFallback:
+    def test_an_unnamed_stopper_still_records_something(self, root, running):
+        """An anonymous stop is still a stop; recording nothing would put it back
+        in the crash bucket, which is the whole bug."""
+        assert _queue.stop(root, running["id"])["stopped_by"]

--- a/tests/test_seat_traps.py
+++ b/tests/test_seat_traps.py
@@ -1,0 +1,105 @@
+"""The traps ride in the brief, because memory is not a distribution mechanism.
+
+MEASURED: two agents independently hit the `.tscn` Transform3D transpose in one
+night. Once the trap list started being pasted into briefs by hand, nobody did.
+That is the whole argument — and the reason to move it out of a human's habit and
+into the thing the board generates, since the hand-pasting only happened because
+someone happened to remember.
+
+WHAT QUALIFIES. Every row is a bug that has already cost a real run AND produces
+no error a search would find. That second half is the load-bearing one: an agent
+can recover from a traceback on its own, so a traceback-producing bug in this
+list is pure cost. A brief is a budget and a list nobody finishes is a list
+nobody reads.
+
+The most important test here is the negative one: a 2D project must not be billed
+for the Transform3D paragraph. A trap list that goes out whole to everyone
+becomes boilerplate, and boilerplate gets skimmed — at which point the transpose
+bug comes back and the list is what made it invisible.
+"""
+from __future__ import annotations
+
+import json
+
+
+from bgate_core import project, seats
+
+
+def _brief(root, role="tech"):
+    return seats.brief(root, role)
+
+
+class TestTheListIsGated:
+    def test_a_2d_project_is_not_told_about_transform3d(self, root):
+        """The negative that keeps the list readable."""
+        text = " ".join(seats.traps_for("tech", "2d"))
+        assert "Transform3D" not in text
+        assert "winding" not in text.lower()
+
+    def test_a_3d_project_is(self, root):
+        text = " ".join(seats.traps_for("tech", "3d"))
+        assert "ROW-major" in text
+        assert "TRANSPOSE" in text
+
+    def test_a_mixed_project_gets_the_3d_traps_too(self):
+        """2d+3d is a 3D game with a 2D HUD, not a compromise between them."""
+        assert seats.traps_for("tech", "2d+3d") == seats.traps_for("tech", "3d")
+
+    def test_the_engine_traps_reach_every_dimension(self):
+        """A parse error looking like a hang has nothing to do with 3D."""
+        for dim in ("2d", "3d", "2d+3d"):
+            text = " ".join(seats.traps_for("tech", dim))
+            assert "PARSE ERROR" in text, dim
+            assert "preload" in text, dim
+
+    def test_the_srgb_trap_goes_to_the_seats_that_can_hit_it(self):
+        """Only art and tech touch the Blender→Godot material path."""
+        assert any("LINEAR" in t for t in seats.traps_for("art", "3d"))
+        assert not any("LINEAR" in t for t in seats.traps_for("qa", "3d"))
+
+
+class TestItIsInTheBrief:
+    def test_the_brief_carries_traps(self, root):
+        assert _brief(root)["traps"]
+
+    def test_the_brief_says_the_mcp_tools_are_deferred(self, root):
+        """Universal and non-obvious: an agent that has not been told concludes
+        the tools do not exist and works around their absence."""
+        rules = " ".join(_brief(root)["rules"])
+        assert "DEFERRED" in rules
+        assert "ToolSearch" in rules
+        assert "project_dir" in rules
+
+    def test_the_traps_follow_the_project_dimension(self, root):
+        """Not a static blob: the brief asks the project what it is. This is also
+        why project_set_dimension matters — a stale record aims this at the wrong
+        kind of game."""
+        before = _brief(root)["traps"]
+        project.set_dimension(root, "3d")
+        after = _brief(root)["traps"]
+        assert len(after) > len(before)
+        assert any("ROW-major" in t for t in after)
+
+    def test_the_existing_rules_survived(self, root):
+        """The tooling rule is prepended, not substituted — the lane rule and the
+        work manifest are what stop an agent writing outside its lanes and dying
+        without a checkpoint trail."""
+        rules = " ".join(_brief(root)["rules"])
+        assert "can_write is the oracle" in rules
+        assert "WORK MANIFEST" in rules
+
+
+class TestItStaysAffordable:
+    def test_the_traps_are_a_small_fraction_of_the_brief_budget(self, root):
+        """A brief is a budget. If this ever grows past a tenth of it, the bar
+        for adding a row has slipped."""
+        worst = sum(len(t) for t in seats.traps_for("art", "3d"))
+        assert worst < seats.BRIEF_CHARS // 5
+
+    def test_the_brief_still_fits(self, root):
+        project.set_dimension(root, "3d")
+        assert len(json.dumps(_brief(root), default=str)) <= seats.BRIEF_CHARS
+
+    def test_every_trap_is_one_paragraph_not_an_essay(self):
+        for trap in seats.TRAPS:
+            assert len(trap["text"]) < 600, trap["text"][:60]

--- a/tests/test_steer_long.py
+++ b/tests/test_steer_long.py
@@ -1,0 +1,103 @@
+"""A long correction can now reach a running agent without killing it.
+
+THE DEAD END. A steer is capped at 2000 characters and a longer one was REFUSED
+outright. Refusing rather than truncating is the right call and it stays —
+handing an agent half a sentence with no way to know it was cut is worse than
+either option. But the cap left no route at all for a genuinely long correction
+to reach a RUNNING agent: kill the run and re-pay for it, or watch it carry on
+doing the wrong thing.
+
+The fix is the discipline `ask_human` already asks of its callers — cite, do not
+paste. Past the cap the text becomes a file and the steer becomes an excerpt plus
+a path. What the agent receives is still an interruption: enough to judge whether
+to stop now, and a pointer for the rest.
+
+The load-bearing assertion in this file is that what lands in the inbox STILL
+FITS THE CAP. A "fix" that posts an over-cap message is the truncation bug
+wearing a hat, and it would fail inside the dashboard's delivery rather than here
+where someone can see it.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from bgate_core import steerbox
+
+SHORT = "that pose is off-model, use the pinned ref"
+LONG = ("Stop and re-read the brief. " + ("x" * 40 + " ") * 120).strip()
+
+
+def _inbox(root):
+    return sorted(steerbox.box(root).glob("*.json"))
+
+
+def _messages(root):
+    return [json.loads(p.read_text(encoding="utf-8")) for p in _inbox(root)]
+
+
+class TestShortIsUnchanged:
+    def test_it_posts_verbatim(self, root):
+        steerbox.post_long(root, 7, SHORT, by="director")
+        assert _messages(root)[0]["text"] == SHORT
+
+    def test_no_file_is_written_for_a_short_steer(self, root):
+        out = steerbox.post_long(root, 7, SHORT, by="director")
+        assert out["excerpted"] is False
+        assert out["note_path"] == ""
+        assert not steerbox.notes_dir(root).exists()
+
+    def test_an_empty_steer_is_still_refused(self, root):
+        with pytest.raises(ValueError):
+            steerbox.post_long(root, 7, "   ", by="director")
+
+
+class TestLongIsCited:
+    @pytest.fixture()
+    def posted(self, root):
+        assert len(LONG) > steerbox.MAX_TEXT      # the control: it really is long
+        return steerbox.post_long(root, 7, LONG, by="director")
+
+    def test_what_lands_in_the_inbox_fits_the_cap(self, root, posted):
+        """THE ONE THAT MATTERS. An over-cap message would fail at delivery
+        instead of here, inside the dashboard, out of sight."""
+        assert len(_messages(root)[0]["text"]) <= steerbox.MAX_TEXT
+
+    def test_the_full_text_is_on_disk_intact(self, root, posted):
+        body = open(posted["note_path"], encoding="utf-8").read()
+        assert LONG in body
+
+    def test_the_agent_is_told_where_to_read_it(self, root, posted):
+        text = _messages(root)[0]["text"]
+        assert posted["note_path"] in text
+        assert "READ THAT FILE" in text
+
+    def test_the_excerpt_is_the_opening_not_a_summary(self, root, posted):
+        """So the agent can judge whether to stop NOW, before opening anything."""
+        assert LONG[:200] in _messages(root)[0]["text"]
+
+    def test_it_says_how_much_was_left_out(self, root, posted):
+        """Silence about the remainder is how a truncated steer reads."""
+        assert "more characters" in _messages(root)[0]["text"]
+
+    def test_the_note_names_the_item_and_the_sender(self, root, posted):
+        body = open(posted["note_path"], encoding="utf-8").read()
+        assert "#7" in body
+        assert "director" in body
+
+    def test_two_long_steers_do_not_collide(self, root):
+        a = steerbox.post_long(root, 7, LONG, by="director")
+        b = steerbox.post_long(root, 7, LONG + " again", by="director")
+        assert a["note_path"] != b["note_path"]
+
+
+class TestItIsStillAnInterruption:
+    def test_the_note_lives_in_the_steer_box_not_the_brief(self, root):
+        """A correction that should outlive the run belongs in queue.update. This
+        one dies with the process it was aimed at, which is the honest lifetime
+        for 'no, not like that' — so it is filed under .bgate/steer, not on the
+        work item."""
+        out = steerbox.post_long(root, 7, LONG, by="director")
+        assert steerbox.box(root) in __import__("pathlib").Path(
+            out["note_path"]).parents


### PR DESCRIPTION
Ten defects from a lessons-learned pass over a real multi-agent build. They are one commit because eight of them are the same mistake wearing different clothes: a surface reported what it was ASKED to do rather than what it DID.

THE APPROVAL GATE DID NOT REACH THE CARDS IT CLAIMS TO CONTROL. With the selector on `none` — labelled "an agent's own word closes its item" — the console kept drawing SIGN-OFF cards over every finished item and APPROVAL cards over every candidate. Observed across art and director both, which ruled out "the art path forgot to check": routes/console.py::_gates never read gates.mode at all. A gate set to none is a sentence, "do not stop to ask me", and asking anyway either stalls work behind a card nobody knew to click or trains the human to rubber-stamp, which spends the gate's credibility on the runs where it IS on. It is now off at the DECISION, not at the drawing — artifacts.register auto-approves under none, because hiding the card while leaving the revision a candidate would leave the live path holding the previous image with the one surface that said so now hidden.

The inverse turned up while fixing it: under `builders` a completion parks in 'review' and the sign-off query asked for 'done', so the one mode that mandates a human decision was the one whose stopped chains had no card. Parked items are now listed, marked, never aged out, and accept routes to queue.approve — acking one into a workspace doc would have cleared the card and left the chain stopped.

CHECKS THAT GRADED THEIR OWN HOMEWORK:

- image_generate(tileable=True) reported success for a mirror pass that threw. Image.save dispatches on the destination suffix and an output named `litter_albedo` has none. Evidence arrived days later as a seam at 2.4m tiling across a full-screen floor. Format now comes from the source image; metadata records measured beside requested.
- The alpha keyer returned clean:true over an opaque pink slab. Krea paints a DESATURATED magenta (~#c0559f, 143 from the contract colour, outside tol=125), so the border keyed and the interior did not — and all five audit measurements inspect the CUT, none inspect what the cut left behind. Adds a pinkness pass ((R+B)-2G, unioned with the distance key, gated on the chroma being a pink) and residual_chroma to the audit, reported as None rather than 0.0 when unchecked, because "not checked" and "checked and clean" reading the same is how this shipped.
- blender_status conflated configured with running and hosted with local. An agent tried two local image-to-3D backends, got connection refused, and the path was written off for a session; the hosted one worked and had already produced every texture in that build.
- godot_screenshot's window never takes foreground focus on Windows, so anything gated on MOUSE_MODE_CAPTURED collapses in the shot. A previous pass "fixed" that with per-frame re-capture and a comment blaming the game.

MISSING SURFACES:

- pending_decisions: everything waiting on a human in one call. Human approval was dashboard-only, so a director could not see what was blocking its own board — and a blocking gate with no signal looks exactly like an agent quietly working. notify.jsonl and the bus now carry artifact.candidate/reviewed.
- queue_add(depends_on=): order for an item filed onto a board that already holds the work it waits on. Chains cannot be appended to, so a dependent follow-up had no correct form at all.
- project_set_dimension: the record was write-once, so a 2D prototype that grew a 3D scene reported "2d" forever — and the field steers scaffolding and brief wording.
- agent_steer past 2000 chars writes the full text to the steer box and hands over an excerpt plus the path. The cap is right and truncation is still never on the table; the refusal just left no route short of killing the run.
- glTF alphaMode:MASK is flagged at import. Godot 4.7 makes it DEPTH_PRE_PASS, not ALPHA_SCISSOR, so cutouts land in the sorted transparent pass — silent, and a framerate cliff on a forest.
- A human stop stamps stopped_by/stopped_at (migration 0019) and emits item.stopped. Deliberately NOT a sixth status: 'failed' is keyed on in ~85 places and a new one changes behaviour in each by omission. The status was never the missing thing; the cause was.

The traps list now ships in seats.brief(), gated by seat and dimension — two agents independently hit the .tscn Transform3D transpose in one night, and nobody did once the list went out with the brief.

Two notes on the chroma change. It is a deliberate widening: on random noise the pinkness pass keys ~13% more pixels, so a saturated magenta subject under a magenta key is now cut where it previously survived (pick() already chooses a chroma far from the art palette). And the per-pixel oracle in test_mcp_adjust caught a real near-miss — ImageMath floors integer division, so the band expression and the audit disagreed on colours sitting exactly on the threshold (84.5 vs 84) and only on those. Both compare in doubled integer arithmetic now, with a boundary test. The oracle was extended rather than loosened, and a distance-only parity case proves non-pink keys are byte-identical to before.
