### PR TITLE
board: agents can pick up work, and the board stops deadlocking itself

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 Builders Gate is an MCP server for building games with Claude Code.
 **[builders-gate.com](https://builders-gate.com)**
 
-It gives Claude 144 tools scoped to one game project: a design database, a work
+It gives Claude some 180 tools scoped to one game project: a design database, a work
 queue, reference-pinned art and music generation, Godot and Blender adapters, and
 playtest capture. State lives in one SQLite file in the project.
 
@@ -156,6 +156,11 @@ Full detail, including the API key table and the platform notes:
 
 ## Install and quickstart
 
+**Before you start:** Python 3.11 or newer, installed and on `PATH` — check with
+`python --version`. A virtual environment is optional but recommended, because
+`pip install -e .` otherwise puts Builders Gate and its dependencies in your
+system Python where another project can disagree with them.
+
 ```bash
 git clone https://github.com/Thepizzapie/BuildersGate
 cd BuildersGate
@@ -169,9 +174,27 @@ cd emberfall
 bgate serve                               # dashboard on http://127.0.0.1:7788
 ```
 
-`bgate doctor` exits 1 if **anything** on its list is unavailable. That is right
-for a CI step and alarming for a human: you only need Python and Godot for the
-core loop. Read the rows, not the exit code.
+**If `bgate` is "not recognized" on Windows**, the install worked and Python's
+`Scripts\` directory is not on your `PATH`. Two ways through: run
+`python -m pip install -e .` and then call the CLI as `python -m bgate_cli.main
+doctor` (every command works that way, `bgate` is only a shortcut), or re-run the
+Python installer, choose Modify, and tick **Add Python to PATH** — then open a
+new terminal, because `PATH` is read at shell start.
+
+`bgate doctor` exits 1 if **anything** on its list is unavailable, including the
+rows nobody needs on day one. Read the rows, not the exit code:
+
+| Row | Needed for |
+|---|---|
+| `python`, `godot` | **Required.** The core loop: a project, a build, a run |
+| `blender` | Optional. The 3D leg only |
+| `ffmpeg`, `ffprobe` | Optional. Playtest capture and cutscene transcoding |
+| `whisper` | Optional. Voice transcription during playtest |
+| `art_key`, `local_image` | Optional. Generated art — a rented key or a local model |
+| everything else | Optional. Capability inventory, not a gate |
+
+A red optional row is a feature you do not have yet, not a broken install. If
+`python` and `godot` are green, keep going.
 
 `bgate init` creates a NEW directory named after the project, not whatever
 directory you were standing in. It writes `.bgate/game.db`, unpacks the Godot
@@ -181,13 +204,19 @@ first-run screen that does the same thing from the browser.
 To let agents drive it:
 
 ```bash
+python -c "import sys; print(sys.executable)"    # <abs-python>, from the env
+                                                 # where pip install -e . ran
 claude mcp add builders-gate --scope user -- <abs-python> -m bgate_mcp.server
 bgate hook-install <game-project>         # lane/lock teeth
 ```
 
-Use the ABSOLUTE python path. The claude CLI's health check resolves a bare
-`python` differently than your shell and reports "failed to connect" against a
-server that runs fine.
+**Restart Claude Code before the tools appear.** A running session does not pick
+up a newly registered MCP server; a fresh one does. If `project_status` is not in
+the tool list after restarting, the server is not connected.
+
+Use the ABSOLUTE python path, which is what the `python -c` line above prints.
+The claude CLI's health check resolves a bare `python` differently than your
+shell and reports "failed to connect" against a server that runs fine.
 
 Other entry points, covered in [`docs/setup.md`](docs/setup.md):
 

--- a/bgate_adapters/kie.py
+++ b/bgate_adapters/kie.py
@@ -2614,8 +2614,22 @@ def download_tracks(tracks: list, out_dir: str | os.PathLike[str], *,
 def generate_music(prompt: str, out_dir: str | os.PathLike[str], *,
                    name: str = "", root: Any = None, logical_name: str = "",
                    work_item_id: Optional[int] = None,
-                   timeout: float = 900.0, **options: Any) -> dict:
+                   timeout: float = 900.0, on_submit: Any = None,
+                   **options: Any) -> dict:
     """Submit, wait, download every track. Returns {ok, tracks:[{path,...}]}.
+
+    ``on_submit`` IS CALLED WITH THE TASK ID THE INSTANT THERE IS ONE, the same
+    hook and for the same reason as :func:`generate_video`. The charge lands at
+    submit and the poll loop then runs for MINUTES; a caller that only learns
+    the task id from the RETURN VALUE learns it never if the process dies in
+    between, and a paid batch with no handle cannot be collected by anything —
+    not :func:`bgate_core.music.recover`, which needs the id, and not the sweep
+    that looks for uncollected work. Measured: every failure mode this module
+    already documents (the CDN 403 on download, a cancel, a timeout) carried the
+    id out on the RESULT, which survives a return and not a kill.
+
+    Its failure is swallowed on purpose — bookkeeping must not lose the file it
+    was bookkeeping.
 
     ONE REQUEST IS SEVERAL FILES, which is why this returns a list where the
     image path returns a path. Suno generates "multiple variations for each
@@ -2639,9 +2653,17 @@ def generate_music(prompt: str, out_dir: str | os.PathLike[str], *,
     false — never 0.0, which every budget check in this product reads as free.
     """
     started = time.monotonic()
+    # UNKNOWN, STATED, ON EVERY PATH — not absent, and never 0.0. The success
+    # path below has always said `credits_source` and left `estimated_usd` None
+    # when the rate is unconfigured, but a FAILED run returned none of these
+    # keys at all, so a caller reading `result.get("credits_consumed", 0)` or
+    # summing `estimated_usd or 0` scored a charge that may well have happened
+    # as free. Same rule estimate_usd holds for video: the two unknowns are
+    # named separately and neither folds to zero.
     base = {"ok": False, "provider": "kie", "kind": "audio",
             "model": str(options.get("model") or DEFAULT_SUNO_MODEL),
-            "estimated_usd": None}
+            "credits_consumed": None, "credits_source": "unavailable",
+            "accounted": False, "estimated_usd": None}
     task_id = ""
     # BEFORE THE SUBMIT, not before the download: the charge lands when the job
     # is accepted. Best effort — a balance that cannot be read must not stop a
@@ -2662,6 +2684,11 @@ def generate_music(prompt: str, out_dir: str | os.PathLike[str], *,
         job = submit_music(prompt, root=root, **options)
         task_id = job["task_id"]
         base["model"] = job["model"]
+        if on_submit:
+            try:
+                on_submit(task_id)
+            except Exception:                                    # noqa: BLE001
+                pass
         rec = poll_music(task_id, root=root, timeout=timeout,
                          on_progress=on_progress)
         tracks = music_tracks(rec)

--- a/bgate_cli/hook.py
+++ b/bgate_cli/hook.py
@@ -491,12 +491,23 @@ def _judge_path(target: str, payload: dict, seat: str,
                 return ALLOW, ""
 
     if blocker:
+        # WAITING IS NOT A PLAN. Observed: one run polled the same leased path
+        # 8 times over 24 minutes (each poll a full-context turn), another was
+        # killed mid-wait. When the holder is a work item, the board can do the
+        # waiting instead — that is exactly what depends_on is for.
+        route = ""
+        held_item = re.match(r"item-(\d+)$", str(blocker))
+        if held_item:
+            route = (" If your work cannot land without this file, do not poll "
+                     "and do not wait: file the follow-up with queue_add(your "
+                     f"seat, ..., depends_on={held_item.group(1)}) so it runs "
+                     "after that item finishes, and continue what you CAN do.")
         return BLOCK, (
             f"[builders-gate] {verdict['path']}: {verdict['reason']}. "
             f"{blocker} is in that file right now — coordinate with it "
             "(seat_post_note) or work on something else; do not edit around it. "
             "If that run is dead, the claim expires on its own; asset_status "
-            "shows what is held."
+            "shows what is held." + route
         )
 
     level = BLOCK if mode == "block" else WARN
@@ -507,10 +518,55 @@ def _judge_path(target: str, payload: dict, seat: str,
             "that lane does it and the QA gate sees it — or set "
             "BGATE_DIRECTOR_MODE=collide if you mean to edit it here."
             if seat == DIRECTOR_SEAT else
-            " Use seat_can_write to find your lanes, or asset_lock if you need to "
-            "claim a binary.")
+            _worker_route(root, str(rel), seat))
     return level, (f"{lead} may not write {verdict['path']}: "
                    f"{verdict['reason']}.{tail}")
+
+
+def _worker_route(root, rel: str, seat: str) -> str:
+    """The sentence after a worker's lane refusal — a route, not a wall.
+
+    This tail used to say "use seat_can_write to find your lanes", which
+    answers a question nobody asked: the agent knows where its lanes are, it
+    is standing at the edge of them holding work. The observed result was the
+    dead-end pattern — the write refused, a LEFTOVERS block or a seat note
+    filed, the item closed, and the work never queued for the seat that could
+    do it. Fifteen files carried those blocks; the notes outlived the last
+    board row by five hours. So the refusal now names the seat that owns the
+    path and the exact call that hands the work over. Best-effort by the same
+    rule as everything in this hook: an unreadable seat table degrades to the
+    generic route, never to a crash.
+    """
+    try:
+        from bgate_core import seats as _seats
+        owners = [o for o in _seats.lane_owners(root, rel) if o != seat]
+    except Exception:
+        owners = []
+    if owners:
+        named = owners[0]
+        also = f" (also in-lane: {', '.join(owners[1:])})" if len(owners) > 1 else ""
+        return (f" That path is the {named!r} seat's lane{also}. Do NOT stop, "
+                "and do not leave this in a note or a LEFTOVERS block — "
+                f"queue_add({named!r}, title, brief) files it for an agent that "
+                "CAN write it (pass depends_on=<your item id> if it needs your "
+                "output), then continue your own work. Handing work on IS part "
+                "of finishing yours.")
+    # NO OWNER IS USUALLY A LAYOUT MISMATCH, NOT AN EXOTIC PATH. The default
+    # lanes assume the scaffold layout (<root>/game, <root>/design); an ADOPTED
+    # repo — or one made by `bgate init`, which scaffolds into <root> — has its
+    # source somewhere no lane names, so EVERY seat is refused on contact with
+    # the real tree. Routing that to the director as a ruling is a dead end:
+    # the director's lane is design/** and it cannot write the path either.
+    # Say what is actually wrong, and name the one call that fixes it for good.
+    return (" NO SEAT'S LANE COVERS THAT PATH AT ALL, which usually means this "
+            "project's layout does not match the default lanes (they assume "
+            "<root>/game and <root>/design). This is a configuration problem, "
+            "not a routing one — a queue item for another seat would be "
+            "refused the same way. Report it in your result note, name the "
+            "path and the directory it lives in, and say that a human should "
+            "widen the owning seat with seat_configure(role, write_globs=[...]) "
+            "— an agent may not widen its own lanes. Then continue with "
+            "whatever part of your task IS inside your lanes.")
 
 
 def _decide_bash(command: str, payload: dict, seat: str,

--- a/bgate_cli/main.py
+++ b/bgate_cli/main.py
@@ -25,6 +25,8 @@
                                 reap orphans, and turn auto-deploy off.
                                 Works even when the dashboard is gone or wedged.
     bgate hook-install [DIR]    wire lane/lock enforcement into a game project
+    bgate hook-uninstall [DIR]  remove it again, leaving your other hooks alone
+    bgate un-adopt [DIR] --yes  delete this project's .bgate store; game untouched
     bgate hook-status [DIR]     prove the hook is installed AND biting
     bgate hook                  (internal) the PreToolUse hook itself
 
@@ -108,6 +110,59 @@ def _pin(config: dict) -> dict:
         {**h, "command": h["command"].replace(
             "python -m ", f'"{sys.executable}" -m ', 1)}
         for h in config["hooks"]]}
+
+
+def uninstall_hook(project_dir: str, scope: str = "project") -> dict:
+    """Remove OUR PreToolUse entry, and nothing else.
+
+    There was no way back out. Installing wrote into a settings.json the user
+    may share with other tooling, and backing it out meant hand-editing JSON —
+    which is a poor answer to "can I cleanly remove this", and the first
+    question anyone careful asks before installing anything.
+
+    Surgical by the same rule install_hook merges by: only entries whose
+    command mentions ``bgate_cli.hook`` are dropped, an entry that ends up with
+    no hooks left is dropped with it, and a settings file we did not write into
+    is reported untouched rather than rewritten. `hooks` and `PreToolUse` keys
+    are left in place even when empty — removing structure we did not create is
+    the same overreach in the other direction.
+    """
+    if scope not in ("project", "user"):
+        return {"ok": False, "error": f"unknown scope {scope!r}; use project|user"}
+    settings_path = (Path.home() / ".claude" / "settings.json" if scope == "user"
+                     else Path(project_dir) / ".claude" / "settings.json")
+    if not settings_path.exists():
+        return {"ok": True, "removed": 0, "path": str(settings_path),
+                "note": "no settings file here — nothing was installed"}
+    try:
+        settings = json.loads(settings_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return {"ok": False,
+                "error": f"{settings_path} is not valid JSON — refusing to "
+                         "rewrite it; remove the bgate_cli.hook entry by hand"}
+    groups = (settings.get("hooks") or {}).get("PreToolUse")
+    if not isinstance(groups, list):
+        return {"ok": True, "removed": 0, "path": str(settings_path),
+                "note": "no PreToolUse hooks here — nothing to remove"}
+    removed = 0
+    kept_groups = []
+    for group in groups:
+        hooks = [h for h in (group.get("hooks") or [])
+                 if "bgate_cli.hook" not in str(h.get("command", ""))]
+        removed += len(group.get("hooks") or []) - len(hooks)
+        if hooks:
+            kept_groups.append({**group, "hooks": hooks})
+        elif not (group.get("hooks") or []):
+            kept_groups.append(group)      # somebody else's empty group
+    if not removed:
+        return {"ok": True, "removed": 0, "path": str(settings_path),
+                "note": "the bgate hook was not installed here"}
+    settings["hooks"]["PreToolUse"] = kept_groups
+    settings_path.write_text(json.dumps(settings, indent=2) + "\n",
+                             encoding="utf-8")
+    return {"ok": True, "removed": removed, "path": str(settings_path),
+            "note": "lane and lock enforcement is OFF here now — agents can "
+                    "write anywhere their tools reach"}
 
 
 def install_hook(project_dir: str, scope: str = "project") -> dict:
@@ -270,6 +325,16 @@ def init_project(name: str, kind: str = "2d", dest: str = "", pitch: str = "",
         return 2
 
     project.init(root, name, pitch=pitch, engine="godot", dimension=kind)
+    # The scaffold writes project.godot, scenes/ and scripts/ straight into
+    # <root>, while the default seat lanes are written against <root>/game.
+    # Left alone, the gameplay seat cannot write the very scripts this command
+    # just created, and agents build a second tree under game/ that the engine
+    # does not load. Point the lanes at what was actually laid down.
+    try:
+        from bgate_core import seats as _seats
+        _seats.apply_layout(root)
+    except Exception:
+        pass
 
     print(f"created {name} ({kind}) — {len(made['files'])} files")
     # SAY WHAT WAS PROTECTED, or a careful run reads as a broken one. `force`
@@ -365,6 +430,16 @@ def adopt_project(directory: str = "", name: str = "", pitch: str = "",
             print(f"  !     {label}: {row['error']}")
         else:
             print(f"  {row['action'].ljust(9)} {row['path']}")
+    # THE LANES, WHEN THEY HAD TO MOVE. The default seat table is written
+    # against <root>/game; a repo laid out any other way has no seat owning its
+    # source tree, and every dispatched agent is refused on contact with it.
+    # Say so — a silent remap is a surprise the first time someone reads
+    # seat_list and finds globs they did not write.
+    lanes = report.get("lanes") or {}
+    if lanes.get("changed"):
+        print(f"  relaned   seats re-rooted at "
+              f"{lanes.get('prefix') or 'the project root'} "
+              "(the default lanes assume <root>/game)")
     print()
     if not proj.get("pitch"):
         print("no pitch recorded — the bible starts empty without one. Set it:")
@@ -691,7 +766,8 @@ def doctor(project_dir: str = "", as_json: bool = False) -> int:
         # one row per dependency and a consumer that iterates it would read
         # "settings" as a missing binary.
         print(json.dumps({**report,
-                          "settings": _doctor.settings_report(root or None)},
+                          "settings": _doctor.settings_report(root or None),
+                          "project": _doctor.project_report(root or None)},
                          indent=2))
     else:
         width = max(len(name) for name in report)
@@ -704,6 +780,28 @@ def doctor(project_dir: str = "", as_json: bool = False) -> int:
             print(f"{mark}  {name.ljust(width)}  {detail}")
         print()
         print(_doctor.summary(report))
+        # WHICH ROWS ACTUALLY BLOCK YOU. This command exits 1 when anything at
+        # all is missing, including things nobody needs on day one, so the
+        # exit code has to be read alongside a sentence saying what the core
+        # loop requires.
+        core = [n for n in ("python", "godot")
+                if not report.get(n, {}).get("available")]
+        print("core loop needs python + godot" + (
+            f" — MISSING: {', '.join(core)}" if core else ": both present")
+            + ". blender (3D), ffmpeg/ffprobe (video), whisper (voice) and "
+              "an art key (image generation) are optional — a red row there "
+              "is not a blocker.")
+        # Project-level faults: lanes that match no directory here, and a hook
+        # that was never installed. Neither is a missing binary, so neither can
+        # appear above, and both stop agents dead.
+        project_rows = _doctor.project_report(root or None)
+        if project_rows:
+            print()
+            for row in project_rows:
+                mark = "ok  " if row["ok"] else "WARN"
+                print(f"{mark}  {row['name']}  {row['detail']}")
+                if row["fix"]:
+                    print(f"      fix: {row['fix']}")
         # The other half of "why is this board not doing what I told it": an env
         # var in a shell profile silently winning over what the panel shows.
         # AFTER the summary and deliberately outside the exit code — a setting
@@ -990,6 +1088,50 @@ def main() -> int:
         # `--scope user` takes no directory: it is not about a directory.
         target = "." if scope == "user" else (positional[0] if positional else ".")
         result = install_hook(target, scope=scope)
+        print(json.dumps(result, indent=2))
+        return 0 if result.get("ok") else 1
+
+    if cmd == "un-adopt":
+        positional = [a for a in args[1:] if not a.startswith("-")]
+        target = Path(positional[0] if positional else ".").expanduser().resolve()
+        marker = target / ".bgate"
+        if not marker.is_dir():
+            print(f"{target} is not an adopted project — nothing to undo")
+            return 1
+        if "--yes" not in args:
+            print(f"This will DELETE {marker} — the board, the bible, the lore, "
+                  "the artifact ledger and the spend history for this project.")
+            print("Your game files are untouched, and so are the marked blocks "
+                  "in .gitignore and CLAUDE.md (delete those by hand if you "
+                  "want them gone — they are marker-delimited).")
+            print(f"Re-run with --yes to confirm:  bgate un-adopt {target} --yes")
+            return 1
+        import shutil
+        try:
+            from bgate_core import db as _db
+            _db.close_all()
+        except Exception:
+            pass
+        try:
+            shutil.rmtree(marker)
+        except OSError as exc:
+            print(f"error: could not remove {marker}: {exc}")
+            return 1
+        print(f"removed {marker}")
+        print("the game itself is untouched. `bgate hook-uninstall` if you also "
+              "want the lane hook out of this repo's .claude/settings.json.")
+        return 0
+
+    if cmd == "hook-uninstall":
+        rest = args[1:]
+        scope = "project"
+        if "--scope" in rest:
+            i = rest.index("--scope")
+            scope = rest[i + 1] if i + 1 < len(rest) else ""
+            rest = rest[:i] + rest[i + 2:]
+        positional = [a for a in rest if not a.startswith("-")]
+        target = "." if scope == "user" else (positional[0] if positional else ".")
+        result = uninstall_hook(target, scope=scope)
         print(json.dumps(result, indent=2))
         return 0 if result.get("ok") else 1
 

--- a/bgate_cli/session.py
+++ b/bgate_cli/session.py
@@ -35,6 +35,41 @@ from pathlib import Path
 # director that needs the sixth item can call queue_list; one that needs to know
 # the board is busy needs only the top of it.
 TOP_N = 5
+
+# How long a 'dispatched' row may sit untouched before it is shown as STALE
+# rather than RUNNING. Well past dispatch.HARD_RUNTIME_S (2h), so a genuinely
+# long run is never libelled — anything past this has outlived every ceiling
+# the dispatcher enforces and is almost certainly a row a dead dashboard left.
+STALE_RUN_MIN = 180
+
+
+def _age_min(stamp: str):
+    """Minutes since a SQLite `datetime('now')` stamp (UTC), or None.
+
+    Returns None rather than 0 for anything unparseable: "no age" and "just
+    now" mean opposite things to a reader deciding whether to trust a row.
+    """
+    from datetime import datetime, timezone
+
+    text = str(stamp or "").strip()
+    if not text:
+        return None
+    for fmt in ("%Y-%m-%d %H:%M:%S", "%Y-%m-%dT%H:%M:%S"):
+        try:
+            when = datetime.strptime(text[:19], fmt).replace(tzinfo=timezone.utc)
+        except ValueError:
+            continue
+        delta = (datetime.now(timezone.utc) - when).total_seconds() / 60.0
+        return max(0.0, delta)
+    return None
+
+
+def _ago(minutes: float) -> str:
+    if minutes < 90:
+        return f"{int(minutes)}m ago"
+    if minutes < 60 * 48:
+        return f"{int(minutes // 60)}h ago"
+    return f"{int(minutes // 1440)}d ago"
 BOARD_PORT = 7788
 PROBE_TIMEOUT_S = 0.25
 # The dashboard answers this without a token and it is on loopback, so the cost
@@ -274,8 +309,24 @@ def _lines(root) -> list[str]:
     except Exception:
         pass
 
+    # AGE, BECAUSE 'dispatched' IS NOT PROOF OF LIFE. _live dies with the
+    # dashboard and only dispatch.reconcile (which runs inside `bgate serve`)
+    # un-strands the rows it left behind — so a session opened days later was
+    # told three-week-old corpses were RUNNING, with nothing to distinguish
+    # them from an agent working right now.
     for item in running[:TOP_N]:
-        out.append(f"  RUNNING #{item['id']} [{item['seat']}] {item['title'][:64]}")
+        age = _age_min(item.get("updated_at") or "")
+        stale = age is not None and age >= STALE_RUN_MIN
+        mark = "STALE  " if stale else "RUNNING"
+        when = f" ({_ago(age)})" if age is not None else ""
+        out.append(f"  {mark} #{item['id']} [{item['seat']}] "
+                   f"{item['title'][:64]}{when}")
+    if any((_age_min(i.get("updated_at") or "") or 0) >= STALE_RUN_MIN
+           for i in running[:TOP_N]):
+        out.append("  ^ STALE = marked dispatched but untouched for "
+                   f"{STALE_RUN_MIN // 60}h+. If no agent is really running, "
+                   "`bgate serve` settles these on startup; until then they "
+                   "are neither running nor finished.")
     for item in queued[:TOP_N]:
         out.append(f"  queued  #{item['id']} [{item['seat']}] p{item['priority']} "
                    f"{item['title'][:64]}")

--- a/bgate_core/adopt.py
+++ b/bgate_core/adopt.py
@@ -298,6 +298,21 @@ def adopt(directory: str | os.PathLike[str], name: str = "", pitch: str = "",
         "gitignore": stamp_gitignore(base),
         "claude_md": stamp_claude_md(base, name),
     }
+    # LANES, POINTED AT THE REPO THAT IS ACTUALLY HERE. The default seat table
+    # is written against <root>/game and <root>/design; an adopted repo has
+    # whatever layout its author chose, and against an ordinary one
+    # (src/, assets/, scenes/) NO seat owns anything. With the hook installed
+    # that means every dispatched agent is refused on contact with the source
+    # tree, and the refusal reads as "wrong seat" rather than "wrong layout".
+    # adopt already knew the layout — it computed top_dirs and threw it away.
+    try:
+        from . import seats as _seats
+        lanes = _seats.apply_layout(base)
+    except Exception as exc:                 # never fail an adopt over lanes
+        lanes = {"changed": False, "why": f"could not set lanes: {exc}"}
+    # ITS OWN KEY, not a `written` entry: that map is one row per stamped FILE
+    # and every consumer reads action/path off it. A differently-shaped row in
+    # there is a KeyError in the CLI printer, which is where this landed first.
     project.set_active(base)
 
     return {
@@ -308,8 +323,11 @@ def adopt(directory: str | os.PathLike[str], name: str = "", pitch: str = "",
         "project": record,
         "detected": found,
         "written": written,
+        "lanes": lanes,
         "next": [
             "bgate doctor — check the toolchain (godot, blender, ...)",
+            "bgate hook-install . — make the lane rules bite (they are "
+            "advisory until you do)",
             "bgate serve — the dashboard, on this project",
             "read CLAUDE.md, then fill in the bible with bible_add",
         ],

--- a/bgate_core/brainstorm.py
+++ b/bgate_core/brainstorm.py
@@ -530,6 +530,45 @@ _SYNTH_COMMON = (
     "and say so in the summary."
 )
 
+# THE GAME-PLAN HALF, and only the director gets it.
+#
+# `items` answers "what should happen next"; a game needs an answer to "what
+# does this thing CONSIST of", and nothing produced one — so after a
+# decomposition the board was the only record and an empty queue was
+# indistinguishable from a finished game. The manifest is that second answer:
+# enumerable, seat-tagged, dependency-aware, and the thing plan_status
+# measures the build against forever after.
+#
+# ASKED FOR ONLY WHEN THE SESSION IS ABOUT A GAME OR A FEATURE, because a
+# brainstorm about a bug fix or a pipeline change has no manifest and inventing
+# one fills the coverage table with fiction that never gets built.
+_SYNTH_MANIFEST = (
+    "\n\nIF THIS SESSION DESIGNED A GAME, A FEATURE OR A CHUNK OF CONTENT, also "
+    'return "manifest": a list of everything the thing CONSISTS of — one row '
+    "per buildable piece:\n"
+    '  {"kind": "entity|asset|scene|system|sound|dialogue|level",\n'
+    '   "name": "unique_snake_case_name",\n'
+    '   "seat": "which seat builds it",\n'
+    '   "acceptance": "the test that settles whether it is done",\n'
+    '   "slice": true|false,\n'
+    '   "depends_on": ["names of rows this one needs first"]}\n'
+    "Rules for the manifest:\n"
+    "- MARK THE VERTICAL SLICE. slice:true is the smallest set that is "
+    "actually PLAYABLE — one scene, one character, one loop, end to end. Those "
+    "rows go on the board immediately; everything else is recorded and waits. "
+    "A slice of everything is not a slice.\n"
+    "- Names are unique and stable; they are how the row is matched forever.\n"
+    "- acceptance is a TEST, not a restatement of the name: 'boots headless "
+    "and the player spawns', not 'the hub room is done'.\n"
+    "- depends_on names other rows, never items or files. A scene that needs "
+    "the sprite AND the sound names both — dependencies are a graph now, not a "
+    "line.\n"
+    "- Cover the whole thing, including the parts nobody will build this week. "
+    "The manifest is what makes 'what is left' answerable; rows you leave out "
+    "are work nothing will ever notice is missing.\n"
+    "- Omit the key entirely if this session was not about building something."
+)
+
 _SYNTH_SEAT = {
     "director": (
         "You are the DIRECTOR turning a brainstorm into work for the board. "
@@ -544,7 +583,10 @@ _SYNTH_SEAT = {
 
 
 def synthesis_system(seat: str) -> str:
-    return f"{_SYNTH_SEAT.get(seat, _SYNTH_SEAT['director'])}\n\n{_SYNTH_COMMON}"
+    base = f"{_SYNTH_SEAT.get(seat, _SYNTH_SEAT['director'])}\n\n{_SYNTH_COMMON}"
+    # The narrative seat files canon, not buildable pieces; a manifest there
+    # would be a coverage table of lore entries nobody can mark 'wired'.
+    return base + (_SYNTH_MANIFEST if seat == "director" else "")
 
 
 def session_context(session: dict, msgs: list[dict]) -> str:

--- a/bgate_core/db.py
+++ b/bgate_core/db.py
@@ -1589,6 +1589,95 @@ _MIGRATIONS: list = [
     );
     CREATE INDEX idx_bible_ref_section ON bible_ref(section_id, rank);
     """,
+    # 0032 — THE CONTENT MANIFEST: what the game CONSISTS OF, enumerable.
+    #
+    # The board's only unit is the per-seat work_item, so "what remains to
+    # build" was unanswerable: an empty queue after a bad decomposition looks
+    # exactly like a finished game. plan_row is the missing organ — one row per
+    # thing the game needs (an entity, an asset, a scene, a system, a sound, a
+    # dialogue set, a level), written when the human approves a brainstorm's
+    # game plan and linked to the work item that builds it when one is filed.
+    #
+    # STATUS IS DERIVED, NOT STORED, past 'spec'. A row with no work_item_id is
+    # spec; with one, its progress IS the item's status plus the artifact link.
+    # Storing a second status column would be a cache that lies the first time
+    # a reopen moves the item and nothing moves the row.
+    #
+    # `slice` marks the vertical slice — the one playable moment built FIRST.
+    # `depends_on_names` is a JSON list of other rows' names, kept as authored:
+    # it compiles to work_item chains at deploy time, and keeping the source
+    # means a later re-compile (or the phase-5 DAG) does not have to reverse-
+    # engineer intent from chain rows.
+    #
+    # SET NULL, not CASCADE: deleting a work item un-links the row back to
+    # spec — the need for the thing survives the death of one attempt at it.
+    """
+    CREATE TABLE plan_row (
+        id            INTEGER PRIMARY KEY AUTOINCREMENT,
+        kind          TEXT NOT NULL DEFAULT 'asset'
+                          CHECK (kind IN ('entity','asset','scene','system',
+                                          'sound','dialogue','level')),
+        name          TEXT NOT NULL,
+        seat          TEXT NOT NULL,
+        acceptance    TEXT NOT NULL DEFAULT '',
+        slice         INTEGER NOT NULL DEFAULT 0,
+        depends_on_names TEXT NOT NULL DEFAULT '[]',
+        session_id    INTEGER,
+        work_item_id  INTEGER REFERENCES work_item(id) ON DELETE SET NULL,
+        artifact_id   INTEGER,
+        created_at    TEXT NOT NULL DEFAULT (datetime('now')),
+        UNIQUE (name)
+    );
+    CREATE INDEX idx_plan_row_item ON plan_row(work_item_id);
+    CREATE INDEX idx_plan_row_slice ON plan_row(slice, kind);
+    """,
+    # 0033 — MULTI-PARENT DEPENDENCIES. A game is a DAG, not a line.
+    #
+    # work_item.depends_on holds ONE predecessor, so a scene that needs the
+    # sprite AND the sound AND the script could only express one of the three;
+    # the other two raced it. Chains were the workaround and they are strictly
+    # linear, cannot be appended to, and a cancelled link blocks its successors
+    # forever with no repair verb.
+    #
+    # ADDITIVE, NOT A REWRITE. `depends_on` stays exactly as it is — every
+    # chain, every query and every test that reads it keeps working — and this
+    # table carries the EXTRA parents. queue.blocker() checks both and reports
+    # whichever is not satisfied. A one-parent item never touches this table.
+    #
+    # `satisfied_by_cut` is the repair verb's record: cutting a dependency is a
+    # human decision that has to survive in the audit ("this waited on #12,
+    # which was cancelled; a person released it on this date") rather than
+    # vanishing as a deleted row.
+    """
+    CREATE TABLE work_item_dep (
+        item_id     INTEGER NOT NULL REFERENCES work_item(id) ON DELETE CASCADE,
+        depends_on  INTEGER NOT NULL REFERENCES work_item(id) ON DELETE CASCADE,
+        cut_by      TEXT NOT NULL DEFAULT '',
+        cut_at      TEXT,
+        created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+        PRIMARY KEY (item_id, depends_on)
+    );
+    CREATE INDEX idx_item_dep_on ON work_item_dep(depends_on);
+    """,
+    # 0034 — WHICH SEAT SPENT IT.
+    #
+    # The ledger could answer what a project cost and what KIND of thing it was
+    # bought from, and nothing else. "Which seat is expensive" — the question
+    # anyone asks after a surprising month, and the one that decides where a
+    # budget should actually be cut — was unanswerable: there was no seat
+    # column, `record` took no seat argument, and most paid MCP paths pass no
+    # work_item_id either, so even the indirect join through the board failed.
+    #
+    # A plain column with an empty default rather than a lookup table: the seat
+    # vocabulary is eight fixed strings that live in code (seats.DEFAULT_SEATS),
+    # a row written by a human session legitimately has no seat at all, and a
+    # foreign key onto a table that does not exist would be a lie about where
+    # the truth lives. Empty means "not attributable", which is honest and is
+    # what every historical row is.
+    """
+    ALTER TABLE spend_event ADD COLUMN seat TEXT NOT NULL DEFAULT '';
+    CREATE INDEX IF NOT EXISTS idx_spend_seat ON spend_event(seat, created_at);
+    """,
 ]
 
 

--- a/bgate_core/dialogue.py
+++ b/bgate_core/dialogue.py
@@ -1,0 +1,360 @@
+"""Dialogue trees as an engine-loadable resource, validated BEFORE they land.
+
+The narrative seat owns ``design/**``, ``game/dialogue/**`` and ``content/**``,
+and had no tool that produced a file in any of them: lore_* writes the graph in
+the database and canon_check reads text back, so the one artifact the seat's
+mission names — "the lore graph, quests, and dialogue" — could only be produced
+by hand-writing JSON and hoping.
+
+WHY VALIDATION IS THE POINT, not the paperwork. A dialogue tree fails in ways
+that are invisible in the file and expensive in the game:
+
+  * a choice whose target does not exist — the branch dead-ends at runtime, on
+    a line most players never pick, weeks after it was written;
+  * a node nothing reaches — content that was paid for, reviewed, and is not in
+    the game, with nothing anywhere saying so;
+  * a reachable node from which no ending is reachable — the player is stuck in
+    a conversation loop with no way out, which reads as a hang.
+
+None of the three is visible to a JSON schema and all three are cheap to prove
+on a graph. So the graph is checked and the write is REFUSED, naming the
+offending node — a warning attached to a landed file is a warning nobody reads.
+
+CANON RUNS ON THE WAY IN. The seat's own mission says canon_check goes on every
+narrative write, and a check the author has to remember is a check that happens
+on the good days. A hard conflict refuses; a review-level flag rides along in
+the result, because "this name is not in the lore graph yet" is normal for a
+first draft and must not stop it.
+
+The file is plain JSON under the seat's lane, one object Godot's ``JSON.parse``
+loads directly. Not a .tres: a Resource script would have to exist in the game
+before the writer could produce anything, and dialogue is data the engine reads,
+not a class it instantiates.
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Iterable
+
+from .project import game_dir
+from .util import slugify
+
+FORMAT_VERSION = 1
+SUFFIX = ".dialogue.json"
+
+MAX_NODES = 400
+MAX_CHOICES = 12
+MAX_TEXT = 4000
+MAX_ID = 64
+
+
+class DialogueError(ValueError):
+    """A tree this module refuses to write, with the offending node named."""
+
+
+# ---------------------------------------------------------------------------
+# Where it lives
+# ---------------------------------------------------------------------------
+def dialogue_dir(root: str | os.PathLike[str]) -> Path:
+    """``<godot project>/dialogue`` — inside the narrative lane for BOTH layouts.
+
+    ``bgate init`` puts project.godot at the root while godot_scaffold puts it
+    in ``<root>/game``, and seats.lanes_for_layout re-roots ``game/dialogue/**``
+    to ``dialogue/**`` for the first. Resolving from game_dir() lands inside the
+    lane either way; hardcoding ``game/dialogue`` would write outside it — and
+    be refused by the write hook — on every CLI-created project.
+    """
+    base = game_dir(root) or (Path(root) / "game")
+    return base / "dialogue"
+
+
+def path_for(root: str | os.PathLike[str], name: str) -> Path:
+    return dialogue_dir(root) / f"{safe_name(name)}{SUFFIX}"
+
+
+def safe_name(name: str) -> str:
+    slug = slugify(str(name or ""))
+    if slug == "unnamed" and not str(name or "").strip():
+        raise DialogueError("a dialogue needs a name — it becomes the filename")
+    return slug[:MAX_ID]
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+def _node(raw: dict, index: int) -> dict:
+    where = f"nodes[{index}]"
+    if not isinstance(raw, dict):
+        raise DialogueError(f"{where} must be an object")
+    node_id = str(raw.get("id") or "").strip()
+    if not node_id:
+        raise DialogueError(f"{where} has no id — every node needs one, it is "
+                            "what choices point at")
+    if len(node_id) > MAX_ID:
+        raise DialogueError(f"{where} id {node_id!r} is longer than {MAX_ID} chars")
+
+    choices = []
+    raw_choices = raw.get("choices") or []
+    if not isinstance(raw_choices, list):
+        raise DialogueError(f"node {node_id!r}: choices must be a list")
+    if len(raw_choices) > MAX_CHOICES:
+        raise DialogueError(f"node {node_id!r} offers {len(raw_choices)} choices; "
+                            f"the cap is {MAX_CHOICES}")
+    for i, choice in enumerate(raw_choices):
+        if not isinstance(choice, dict):
+            raise DialogueError(f"node {node_id!r} choice {i} must be an object")
+        text = str(choice.get("text") or "").strip()
+        goto = str(choice.get("goto") or choice.get("to") or "").strip()
+        if not text:
+            raise DialogueError(f"node {node_id!r} choice {i} has no text — a "
+                                "player cannot pick an unlabelled option")
+        if not goto:
+            raise DialogueError(f"node {node_id!r} choice {i} ({text!r}) has no "
+                                "goto — say which node it leads to")
+        choices.append({"text": text[:MAX_TEXT], "goto": goto,
+                        "tag": str(choice.get("tag") or "")[:64],
+                        "condition": str(choice.get("condition") or "")[:200]})
+
+    return {
+        "id": node_id,
+        "speaker": str(raw.get("speaker") or "")[:80],
+        "text": str(raw.get("text") or "")[:MAX_TEXT],
+        "end": bool(raw.get("end")),
+        "choices": choices,
+        "tags": [str(t)[:40] for t in (raw.get("tags") or [])][:12],
+        "note": str(raw.get("note") or "")[:400],
+    }
+
+
+def validate(nodes: Iterable[dict], start: str = "") -> dict:
+    """Normalise and prove the graph. Raises :class:`DialogueError` naming the
+    node at fault; returns ``{"nodes": [...], "start": id, "ends": [...]}``."""
+    parsed = [_node(raw, i) for i, raw in enumerate(nodes or [])]
+    if not parsed:
+        raise DialogueError("a dialogue needs at least one node")
+    if len(parsed) > MAX_NODES:
+        raise DialogueError(f"{len(parsed)} nodes; the cap is {MAX_NODES}")
+
+    seen: dict[str, int] = {}
+    for i, node in enumerate(parsed):
+        if node["id"] in seen:
+            raise DialogueError(
+                f"two nodes share the id {node['id']!r} (nodes[{seen[node['id']]}] "
+                f"and nodes[{i}]) — a choice pointing at it would be ambiguous")
+        seen[node["id"]] = i
+    by_id = {node["id"]: node for node in parsed}
+
+    entry = str(start or "").strip() or parsed[0]["id"]
+    if entry not in by_id:
+        raise DialogueError(f"start node {entry!r} is not one of the nodes "
+                            f"({', '.join(sorted(by_id))})")
+
+    # 1. Every choice target exists. THE failure this whole function is for:
+    #    a typo'd goto is invisible in the file and dead-ends in the game.
+    for node in parsed:
+        for i, choice in enumerate(node["choices"]):
+            if choice["goto"] not in by_id:
+                raise DialogueError(
+                    f"node {node['id']!r} choice {i} ({choice['text']!r}) points "
+                    f"at {choice['goto']!r}, which is not a node in this "
+                    f"dialogue — fix the target or add the node")
+        if node["end"] and node["choices"]:
+            raise DialogueError(
+                f"node {node['id']!r} is marked end but still offers "
+                f"{len(node['choices'])} choice(s) — an ending has nowhere to go")
+        if not node["end"] and not node["choices"]:
+            raise DialogueError(
+                f"node {node['id']!r} has no choices and is not marked end — the "
+                "conversation stops there with no way out. Add a choice, or set "
+                "end: true if it IS an ending")
+
+    # 2. Everything is reachable from the start.
+    reachable = {entry}
+    frontier = [entry]
+    while frontier:
+        node = by_id[frontier.pop()]
+        for choice in node["choices"]:
+            if choice["goto"] not in reachable:
+                reachable.add(choice["goto"])
+                frontier.append(choice["goto"])
+    orphans = sorted(set(by_id) - reachable)
+    if orphans:
+        raise DialogueError(
+            f"nothing reaches {', '.join(repr(o) for o in orphans)} from "
+            f"{entry!r} — written, paid for, and not in the game. Link it or "
+            "drop it")
+
+    # 3. An ending is reachable from EVERY reachable node. A cycle with no exit
+    #    is not a syntax error and not a crash; it is a conversation the player
+    #    cannot leave, which reads as a hang.
+    ends = sorted(n["id"] for n in parsed if n["end"])
+    if not ends:
+        raise DialogueError("no node is marked end — this conversation never "
+                            "finishes. Mark the closing line(s) end: true")
+    escapes = set(ends)
+    changed = True
+    while changed:
+        changed = False
+        for node in parsed:
+            if node["id"] in escapes:
+                continue
+            if any(c["goto"] in escapes for c in node["choices"]):
+                escapes.add(node["id"])
+                changed = True
+    trapped = sorted(reachable - escapes)
+    if trapped:
+        raise DialogueError(
+            f"no ending is reachable from {', '.join(repr(t) for t in trapped)} "
+            "— the player enters and cannot leave. Give one of those nodes a "
+            "choice that leads to an ending")
+
+    return {"nodes": parsed, "start": entry, "ends": ends}
+
+
+# ---------------------------------------------------------------------------
+# Read / write
+# ---------------------------------------------------------------------------
+def dialogue_text(nodes: Iterable[dict]) -> str:
+    """Every written word in the tree, for the canon check. Lines and choice
+    labels both — a contradiction is as likely in an option as in a speech."""
+    parts = []
+    for node in nodes:
+        if node.get("text"):
+            parts.append(str(node["text"]))
+        for choice in node.get("choices") or []:
+            if choice.get("text"):
+                parts.append(str(choice["text"]))
+    return "\n".join(parts)
+
+
+def write(root: str | os.PathLike[str], name: str, nodes: Iterable[dict], *,
+          start: str = "", title: str = "", summary: str = "",
+          allow_canon_conflict: bool = False) -> dict:
+    """Validate, canon-check, then land the tree. In that order, deliberately.
+
+    Nothing is written until the graph proves out and canon has had its say: a
+    file on disk is a file somebody imports, and "it landed but it is broken"
+    is the state this refuses to create.
+    """
+    slug = safe_name(name)
+    graph = validate(nodes, start=start)
+
+    canon = _canon_check(root, dialogue_text(graph["nodes"]))
+    if (canon.get("verdict") == "conflict") and not allow_canon_conflict:
+        hard = [f.get("message") or f.get("code")
+                for f in canon.get("flags") or [] if f.get("level") == "conflict"]
+        raise DialogueError(
+            f"canon_check refuses {slug!r}: {'; '.join(str(h) for h in hard)}. "
+            "Fix the line, update the fact it contradicts, or pass "
+            "allow_canon_conflict=True if the canon is what changed")
+
+    doc = {
+        "format": "bgate.dialogue",
+        "version": FORMAT_VERSION,
+        "name": slug,
+        "title": str(title or name)[:120],
+        "summary": str(summary or "")[:600],
+        "start": graph["start"],
+        "ends": graph["ends"],
+        "nodes": graph["nodes"],
+    }
+    target = path_for(root, slug)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        target.write_text(json.dumps(doc, indent=2, ensure_ascii=False) + "\n",
+                          encoding="utf-8")
+    except OSError as exc:
+        raise DialogueError(f"could not write {target.name}: {exc}") from exc
+
+    return {
+        "name": slug,
+        "path": str(target),
+        "rel_path": _relative(root, target),
+        "res_path": _res_path(root, target),
+        "nodes": len(doc["nodes"]),
+        "start": doc["start"],
+        "ends": doc["ends"],
+        "choices": sum(len(n["choices"]) for n in doc["nodes"]),
+        # Always present, conflict or not: a review-level flag is the normal
+        # state of a first draft and the writer should see it without asking.
+        "canon": {"verdict": canon.get("verdict"),
+                  "flags": canon.get("flags") or []},
+    }
+
+
+def read(root: str | os.PathLike[str], name: str) -> dict:
+    path = path_for(root, name)
+    if not path.is_file():
+        raise LookupError(
+            f"no dialogue {safe_name(name)!r} in {dialogue_dir(root)} — "
+            "dialogue_list shows what is there")
+    try:
+        doc = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise DialogueError(f"{path.name} is unreadable: {exc}") from exc
+    doc["path"] = str(path)
+    doc["rel_path"] = _relative(root, path)
+    doc["res_path"] = _res_path(root, path)
+    return doc
+
+
+def list_dialogues(root: str | os.PathLike[str]) -> list[dict]:
+    """Every tree in the lane. A file that no longer validates says so here —
+    the listing is where a broken tree is cheapest to notice."""
+    base = dialogue_dir(root)
+    if not base.is_dir():
+        return []
+    out = []
+    for path in sorted(base.glob(f"*{SUFFIX}")):
+        entry = {"name": path.name[:-len(SUFFIX)], "path": str(path),
+                 "rel_path": _relative(root, path), "nodes": 0, "start": "",
+                 "title": "", "ok": False, "error": ""}
+        try:
+            doc = json.loads(path.read_text(encoding="utf-8"))
+            entry["title"] = str(doc.get("title") or "")
+            entry["start"] = str(doc.get("start") or "")
+            entry["nodes"] = len(doc.get("nodes") or [])
+            validate(doc.get("nodes") or [], start=entry["start"])
+            entry["ok"] = True
+        except (OSError, ValueError, DialogueError) as exc:
+            entry["error"] = f"{type(exc).__name__}: {exc}"
+        out.append(entry)
+    return out
+
+
+def _canon_check(root: str | os.PathLike[str], text: str) -> dict:
+    """canon.check, degraded to 'nothing to say' when it cannot run.
+
+    A project with no lore graph, or a database this call cannot open, must not
+    be a reason a writer cannot write. The verdict is reported either way, so a
+    skipped check is visible rather than mistaken for a clean one.
+    """
+    if not text.strip():
+        return {"verdict": "ok", "flags": [], "skipped": "no text"}
+    try:
+        from . import canon
+
+        return canon.check(root, text)
+    except Exception as exc:
+        return {"verdict": "unchecked", "flags": [],
+                "skipped": f"{type(exc).__name__}: {exc}"}
+
+
+def _relative(root: str | os.PathLike[str], path: Path) -> str:
+    try:
+        return path.resolve().relative_to(Path(root).resolve()).as_posix()
+    except ValueError:
+        return str(path)
+
+
+def _res_path(root: str | os.PathLike[str], path: Path) -> str:
+    """The ``res://`` the game loads it by, or '' when there is no Godot project."""
+    base = game_dir(root)
+    if base is None:
+        return ""
+    try:
+        return "res://" + path.resolve().relative_to(Path(base).resolve()).as_posix()
+    except ValueError:
+        return ""

--- a/bgate_core/doctor.py
+++ b/bgate_core/doctor.py
@@ -82,7 +82,11 @@ SUMMARY_CHECKS = ("local_runtimes", "agent_cli")
 # godot: the templates and the telemetry autoload are Godot 4 only.
 # whisper: faster-whisper's segment API (word confidences) settled at 0.10.
 MIN_REQUIRED = {
-    "python": "3.10",
+    # 3.11 because pyproject.toml's requires-python is >=3.11: a floor of 3.10
+    # here made `bgate doctor` report a green python row on an interpreter pip
+    # then REFUSES to install on, which is a false pass in the one check a
+    # first-time user reads before anything else works.
+    "python": "3.11",
     "art_key": "",
     # Next to art_key on purpose: the two answer one question between them —
     # "can this project generate anything" — from the two directions it can be
@@ -522,6 +526,66 @@ def check(root: Optional[str] = None, *, refresh: bool = False) -> dict:
     with _lock:
         _cache[key] = (time.monotonic(), {n: dict(r) for n, r in report.items()})
     return report
+
+
+def project_report(root: Optional[str] = None) -> list[dict]:
+    """Project-level configuration faults — the ones no binary probe can see.
+
+    SEPARATE FROM ``CHECKS`` ON PURPOSE. Every row there answers "is this
+    executable on this machine", is cached per machine, and has a test contract
+    that counts it. These rows answer "is THIS PROJECT wired correctly", need a
+    root, and are cheap enough to recompute every time.
+
+    Two faults, both of which used to be invisible until an agent hit them:
+    lanes that describe a directory layout the project does not have (every
+    dispatched agent then refused on contact with the source tree), and lane
+    rules that are not being enforced at all because the hook was never
+    installed — adopt does not install it, so that is the out-of-box state.
+
+    Returns [{name, ok, detail, fix}]. Never raises: a diagnostic that dies
+    takes the whole doctor run with it.
+    """
+    out: list[dict] = []
+    if not root:
+        return out
+    try:
+        from . import seats as _seats
+        layout = _seats.detect_layout(root)
+        owned = _seats.lane_owners(root, layout["prefix"] + "scenes/x.tscn")
+        ok = bool(owned)
+        out.append({
+            "name": "seat_lanes",
+            "ok": ok,
+            "detail": (
+                f"lanes cover this project's layout (game lives at "
+                f"{layout['prefix'] or 'the project root'})" if ok else
+                f"NO SEAT owns {layout['prefix'] or ''}scenes/** — the seat "
+                "lanes describe a layout this project does not have, so every "
+                "dispatched agent is refused on contact with the source tree"),
+            "fix": ("" if ok else
+                    "bgate adopt (re-runs layout detection and rewrites the "
+                    "lanes), or set them by hand with seat_configure"),
+        })
+    except Exception as exc:
+        out.append({"name": "seat_lanes", "ok": False,
+                    "detail": f"could not read the seat table: {exc}",
+                    "fix": ""})
+    try:
+        from bgate_cli import hook as _hook
+        state = _hook.selftest(root)
+        live = bool(state.get("installed") and state.get("enforcing"))
+        out.append({
+            "name": "lane_hook",
+            "ok": live,
+            "detail": ("lane and lock enforcement is live" if live else
+                       "the PreToolUse hook is not installed here, so lanes "
+                       "and locks are advisory — agents can write anywhere"),
+            "fix": "" if live else f"bgate hook-install {root}",
+        })
+    except Exception as exc:
+        out.append({"name": "lane_hook", "ok": False,
+                    "detail": f"could not probe the hook: {exc}", "fix": ""})
+    return out
 
 
 def summary(report: dict) -> str:

--- a/bgate_core/gameplan.py
+++ b/bgate_core/gameplan.py
@@ -1,0 +1,523 @@
+"""The game plan — a premise compiled into an enumerable manifest.
+
+The brainstorm room is the compiler's FRONT END: the human and the director
+talk a premise into pillars, a core loop, and a plan. What was missing is the
+back half — after approval, everything the game CONSISTS OF was implicit in
+prose, so "what remains to build" had no answer and an empty queue after a bad
+decomposition looked exactly like a finished game. (Measured: a director
+decomposed one ask into a 9-item chain with the objective ranked last; six
+items died superseded and nothing anywhere could say the game was not built.)
+
+This module is the back half. ``ingest`` writes the approved manifest as
+``plan_row`` rows — one per entity/asset/scene/system/sound/dialogue/level —
+and compiles the VERTICAL SLICE rows onto the board with real dependency
+links. Non-slice rows stay 'spec' on purpose: the board holds the slice, the
+manifest holds the game, and ``status`` is the reconciliation between them.
+
+Status past 'spec' is DERIVED from the linked work item, never stored — a
+second status column would be a cache that lies the first time a reopen moves
+the item and nothing moves the row.
+"""
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Optional
+
+from . import activity, db
+from .util import rows
+
+KINDS = ("entity", "asset", "scene", "system", "sound", "dialogue", "level")
+
+MAX_NAME = 120
+MAX_ACCEPTANCE = 2000
+
+
+def validate_manifest(manifest: Any) -> list[dict]:
+    """Strict, like brainstorm.validate_plan, and for the same reason: this
+    runs on a manifest a human confirmed, and repairing it here files
+    something other than what they approved. Raises ValueError, always with
+    the row number."""
+    from . import seats as _seats
+
+    if not isinstance(manifest, list) or not manifest:
+        raise ValueError("a manifest is a non-empty list of rows")
+    names: set[str] = set()
+    out: list[dict] = []
+    for i, raw in enumerate(manifest, 1):
+        if not isinstance(raw, dict):
+            raise ValueError(f"manifest row {i} is not an object")
+        name = str(raw.get("name") or "").strip()[:MAX_NAME]
+        if not name:
+            raise ValueError(f"manifest row {i} has no name")
+        if name in names:
+            raise ValueError(f"manifest row {i} duplicates the name {name!r}")
+        names.add(name)
+        kind = str(raw.get("kind") or "asset").strip()
+        if kind not in KINDS:
+            raise ValueError(
+                f"manifest row {i} ({name}): kind must be one of {KINDS}")
+        seat = str(raw.get("seat") or "").strip()
+        if seat not in _seats.DEFAULT_SEATS:
+            raise ValueError(
+                f"manifest row {i} ({name}): unknown seat {seat!r}")
+        deps = raw.get("depends_on") or []
+        if not isinstance(deps, list):
+            raise ValueError(
+                f"manifest row {i} ({name}): depends_on must be a list of row names")
+        out.append({
+            "kind": kind, "name": name, "seat": seat,
+            "acceptance": str(raw.get("acceptance") or "").strip()[:MAX_ACCEPTANCE],
+            "slice": bool(raw.get("slice")),
+            "depends_on": [str(d).strip() for d in deps if str(d).strip()],
+        })
+    # Dependencies must name rows that exist — a dep on a fiction would compile
+    # to nothing and the item it gates would dispatch immediately, which is the
+    # exact same-tick failure queue_add_chain exists to stop.
+    for row in out:
+        for dep in row["depends_on"]:
+            if dep not in names:
+                raise ValueError(
+                    f"{row['name']!r} depends on {dep!r}, which is not a "
+                    "manifest row")
+    return out
+
+
+def _ordered(rows_in: list[dict]) -> list[dict]:
+    """Dependency-respecting order (Kahn's), stable within a rank.
+
+    A cycle is a ValueError with the members named: a human wrote this
+    manifest and the fix is theirs to make, not ours to guess.
+    """
+    by_name = {r["name"]: r for r in rows_in}
+    placed: list[dict] = []
+    done: set[str] = set()
+    remaining = list(rows_in)
+    while remaining:
+        progress = [r for r in remaining
+                    if all(d in done or d not in by_name
+                           for d in r["depends_on"])]
+        if not progress:
+            stuck = ", ".join(r["name"] for r in remaining)
+            raise ValueError(f"the manifest has a dependency cycle among: {stuck}")
+        for r in progress:
+            placed.append(r)
+            done.add(r["name"])
+        remaining = [r for r in remaining if r["name"] not in done]
+    return placed
+
+
+def ingest(root: str | os.PathLike[str], manifest: Any,
+           session_id: Optional[int] = None, file_slice: bool = True) -> dict:
+    """Write the approved manifest and put its VERTICAL SLICE on the board.
+
+    One row per thing the game needs. Slice rows are compiled to work items
+    with real depends_on links (in dependency order, so every link names an
+    item that already exists); everything else stays 'spec' — visible in
+    ``status``, deliberately not queued, because a board holding the whole
+    game at once is a board nobody can read.
+
+    Idempotent on names: a row that already exists is updated in place rather
+    than duplicated, and a row that already has a live work item keeps it.
+    Call this only from a HUMAN-approved path (brainstorm_deploy) — the same
+    review-step reasoning that refuses a machine there applies here.
+    """
+    from . import queue as _queue
+
+    clean = _ordered(validate_manifest(manifest))
+    filed: list[dict] = []
+    kept = 0
+    item_for: dict[str, int] = {}
+    conn = db.connect(root)
+    for row in clean:
+        prior = conn.execute("SELECT * FROM plan_row WHERE name = ?",
+                             (row["name"],)).fetchone()
+        with db.tx(root) as tx:
+            if prior:
+                tx.execute(
+                    "UPDATE plan_row SET kind=?, seat=?, acceptance=?, slice=?, "
+                    "depends_on_names=?, session_id=COALESCE(?, session_id) "
+                    "WHERE name=?",
+                    (row["kind"], row["seat"], row["acceptance"],
+                     1 if row["slice"] else 0, json.dumps(row["depends_on"]),
+                     session_id, row["name"]))
+                kept += 1
+                if prior["work_item_id"]:
+                    item_for[row["name"]] = int(prior["work_item_id"])
+                    continue
+            else:
+                tx.execute(
+                    "INSERT INTO plan_row (kind, name, seat, acceptance, slice, "
+                    "depends_on_names, session_id) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                    (row["kind"], row["name"], row["seat"], row["acceptance"],
+                     1 if row["slice"] else 0, json.dumps(row["depends_on"]),
+                     session_id))
+        if not (file_slice and row["slice"]):
+            continue
+        # The slice goes on the board. Deps compile to depends_on links; the
+        # ordering above guarantees every named dep already has its item (a
+        # dep on a non-slice row is left to the manifest — queueing the whole
+        # closure would defeat the slice).
+        dep_items = [item_for[d] for d in row["depends_on"] if d in item_for]
+        # EVERY parent, not just the first. A scene that needs the sprite AND
+        # the sound AND the script used to be able to express one of the three;
+        # the rest raced it. The first rides the column (so chains and every
+        # existing query still see it), the others go in work_item_dep.
+        acceptance = row["acceptance"] or ("(none written — ask the director "
+                                           "via queue_add before building)")
+        brief = (f"[game plan: {row['kind']} '{row['name']}' — vertical slice]\n"
+                 f"ACCEPTANCE: {acceptance}")
+        item = _queue.add(root, row["seat"], f"{row['kind']}: {row['name']}",
+                          brief=brief, priority=5, source="game-plan",
+                          source_ref=row["name"],
+                          depends_on=dep_items[0] if dep_items else None)
+        item_for[row["name"]] = int(item["id"])
+        for extra in dep_items[1:]:
+            _queue.add_dependency(root, int(item["id"]), extra)
+        with db.tx(root) as tx:
+            tx.execute("UPDATE plan_row SET work_item_id = ? WHERE name = ?",
+                       (int(item["id"]), row["name"]))
+        filed.append({"id": int(item["id"]), "seat": row["seat"],
+                      "name": row["name"],
+                      "depends_on": dep_items[0] if dep_items else None})
+    activity.log(root, "game-plan",
+                 f"manifest ingested: {len(clean)} row(s), {len(filed)} slice "
+                 f"item(s) filed, {kept} updated in place",
+                 seat="director", ref=str(session_id or ""))
+    return {"rows": len(clean), "slice_filed": filed, "updated": kept}
+
+
+# The five states a plan row can be in, weakest first. They are DERIVED on
+# every read — a stored status column would be a cache that lies the first
+# time a reopen moves the item and nothing moves the row.
+#
+#   spec      nobody is building it. The board does not hold this.
+#   on_board  a work item exists and has not finished.
+#   lost      the item failed or was cancelled; the NEED survived the attempt.
+#   built     the item reached done. This is where the old ladder stopped, and
+#             it is the state that flatters: a sprite on disk that no scene
+#             references is not in the game.
+#   wired     something in the project actually REFERENCES it. Measured by
+#             reading the scenes, not by asking the agent that made it.
+#   verified  a QA gate passed on the item that built it.
+STATES = ("spec", "on_board", "lost", "built", "wired", "verified")
+
+
+def _referenced_names(root: str | os.PathLike[str]) -> set[str]:
+    """Every resource path referenced by a scene or resource in the project.
+
+    THE WIRED TEST, and it is deliberately a text scan rather than an engine
+    load: `.tscn` and `.tres` name their dependencies in ext_resource lines,
+    the harness already treats those files as the truth elsewhere, and a scan
+    costs nothing and cannot be fooled by an agent's own report. What it
+    answers is narrow and honest — "is this asset's name mentioned by
+    something the game loads" — which is exactly the gap between an asset on
+    disk and an asset in the game.
+    """
+    out: set[str] = set()
+    # NOT `root / "game"`. Two entrypoints disagree about the layout — bgate
+    # init scaffolds into <root>, godot_scaffold into <root>/game — and a
+    # hardcode here reports every row of a root-layout project as unwired
+    # forever, which is a coverage table that lies in the one direction nobody
+    # checks. game_dir() is asked first because it is the project's own answer;
+    # when there is no project.godot yet (a plan can be ingested before the
+    # engine project exists) both candidates are scanned rather than neither.
+    from pathlib import Path
+
+    from . import project as _project
+
+    try:
+        found = _project.game_dir(root)
+    except Exception:
+        found = None
+    roots = [found] if found else [Path(root) / "game", Path(root)]
+    for game in roots:
+        if not game.is_dir():
+            continue
+        out |= _scan_dir(game)
+    return out
+
+
+def _scan_dir(game) -> set[str]:
+    out: set[str] = set()
+    for pattern in ("**/*.tscn", "**/*.tres"):
+        for path in game.glob(pattern):
+            try:
+                text = path.read_text(encoding="utf-8", errors="ignore")
+            except OSError:
+                continue
+            for line in text.splitlines():
+                if "path=" not in line and "ExtResource" not in line:
+                    continue
+                out.add(line)
+    return out
+
+
+def _is_wired(name: str, blob: str) -> bool:
+    """Does the project reference this row's name at all?
+
+    Substring on the stem, because a manifest name ('hero_sheet') becomes a
+    family of files ('hero_sheet.png', 'hero_sheet_frames.tres'). It answers
+    'mentioned' rather than 'correctly wired' and the docstring says so: a
+    cheap true negative is worth more than an expensive maybe, and QA's own
+    checklist is what judges correctness.
+    """
+    stem = name.strip().lower()
+    return bool(stem) and stem in blob
+
+
+def _verdicts(root: str | os.PathLike[str]) -> set[int]:
+    """Work item ids whose QA gate returned PASS.
+
+    Reads the same 'VERDICT: PASS' marker the dashboard's history renderer
+    parses — one marker, one meaning, in both places. A gate that finished
+    without the marker is UNKNOWN and deliberately does not count as verified.
+    """
+    passed: set[int] = set()
+    try:
+        gates = rows(db.connect(root).execute(
+            "SELECT source_ref, result FROM work_item "
+            "WHERE source = 'qa-gate' AND status = 'done'"))
+    except Exception:
+        return passed
+    for gate in gates:
+        ref = str(gate["source_ref"] or "")
+        if ref.isdigit() and "VERDICT: PASS" in (gate["result"] or ""):
+            passed.add(int(ref))
+    return passed
+
+
+def digest(root: str | os.PathLike[str], hours: int = 12) -> dict:
+    """WHAT HAPPENED WHILE YOU WERE AWAY — the morning report.
+
+    There was no such surface. A board could run for eight hours and the only
+    way to reconstruct it was to read the activity ledger by hand: autodeploy
+    keeps one refusal (the LAST one), notices collapse past three into "11
+    items finished", and the heartbeat reports stalled chains rather than "the
+    board floored at 23:02 and never dispatched again". So the single most
+    common question after an overnight run — what got built, what broke, why
+    did it stop — had no answer anywhere.
+
+    Everything here is read from the board and the ledger; nothing is inferred
+    and nothing is spent. ``blocked`` is the important field: an empty board
+    with items still queued is the signature of a floor refusal, and naming it
+    is the difference between "it is working" and "it stopped six hours ago".
+    """
+    from . import queue as _queue
+    from . import spend as _spend
+
+    window = f"-{max(1, int(hours))} hour"
+    conn = db.connect(root)
+    moved = rows(conn.execute(
+        "SELECT id, seat, title, status, source, attempts, total_cost_usd, "
+        "updated_at, result FROM work_item "
+        "WHERE updated_at >= datetime('now', ?) ORDER BY updated_at DESC",
+        (window,)))
+    done = [r for r in moved if r["status"] == "done"]
+    failed = [r for r in moved if r["status"] == "failed"]
+    review = [r for r in moved if r["status"] == "review"]
+    try:
+        still_queued = _queue.list_items(root, status="queued") or []
+    except Exception:
+        still_queued = []
+    try:
+        running = _queue.list_items(root, status="dispatched") or []
+    except Exception:
+        running = []
+
+    # WHY IT STOPPED, if it did. Queued work with nothing running is either a
+    # dead dashboard or a floor refusal, and both look identical from the board.
+    blocked = ""
+    if still_queued and not running:
+        try:
+            from bgate_core import gitwork as _git
+            state = _git.dirty(root)
+            if state.get("available") and state.get("dirty"):
+                blocked = (f"{len(state['paths'])} uncommitted change(s) in the "
+                           "tree — dispatch refuses a dirty tree, and that "
+                           "refusal stops the WHOLE board, not one item. "
+                           "Commit or stash and it resumes.")
+        except Exception:
+            pass
+        if not blocked:
+            blocked = ("work is queued and nothing is running — either the "
+                       "dashboard is down (`bgate serve`), autopilot is off, "
+                       "or a budget ceiling is refusing every dispatch.")
+
+    try:
+        money = _spend.totals(root)
+    except Exception:
+        money = {}
+    return {
+        "window_hours": int(hours),
+        "finished": [{"id": r["id"], "seat": r["seat"], "title": r["title"][:90],
+                      "cost_usd": round(float(r["total_cost_usd"] or 0), 3)}
+                     for r in done[:25]],
+        "failed": [{"id": r["id"], "seat": r["seat"], "title": r["title"][:90],
+                    "attempts": int(r["attempts"] or 0),
+                    "why": str(r["result"] or "")[:200]} for r in failed[:25]],
+        "awaiting_you": [{"id": r["id"], "seat": r["seat"],
+                          "title": r["title"][:90]} for r in review[:25]],
+        "counts": {"finished": len(done), "failed": len(failed),
+                   "in_review": len(review), "still_queued": len(still_queued),
+                   "running": len(running)},
+        "blocked": blocked,
+        "spend": {"today_usd": money.get("today_usd"),
+                  "week_usd": money.get("week_usd"),
+                  "agent_runs": money.get("agent_runs")},
+        "coverage": status(root)["slice"] if _has_plan(root) else None,
+    }
+
+
+def _has_plan(root: str | os.PathLike[str]) -> bool:
+    try:
+        return bool(db.connect(root).execute(
+            "SELECT 1 FROM plan_row LIMIT 1").fetchone())
+    except Exception:
+        return False
+
+
+SLICE_CHECK_SOURCE = "slice-check"
+
+
+def slice_check_due(root: str | os.PathLike[str]) -> dict:
+    """Should a SLICE CHECK be filed right now? {due, why, open}.
+
+    THE GAME IS NOT REVIEWED BY ANYONE. The QA gate reviews items — did this
+    sprite land, did this scene get written — and a board of green items can
+    sit on top of a build that does not boot. Every ingredient of a real check
+    exists (godot_check_project, headless godot_run, screenshots, coverage);
+    nothing composed them.
+
+    Due when the slice's rows are all built (or better) and no check is open
+    for the current state of it. Idempotent by the same rule as the QA gate:
+    one open check at a time, and never a second for a slice that has not
+    moved since the last one.
+    """
+    state = status(root)
+    if not state["slice"]["rows"]:
+        return {"due": False, "why": "this project has no vertical slice rows",
+                "open": 0}
+    try:
+        existing = rows(db.connect(root).execute(
+            "SELECT id, status, source_ref FROM work_item "
+            "WHERE source = ? ORDER BY id DESC", (SLICE_CHECK_SOURCE,)))
+    except Exception:
+        return {"due": False, "why": "the board is unreadable", "open": 0}
+    live = [e for e in existing if e["status"] in ("queued", "dispatched")]
+    if live:
+        return {"due": False, "why": "a slice check is already open",
+                "open": int(live[0]["id"])}
+    built = state["slice"]["in_game"] + sum(
+        1 for r in state["remaining"] if r["slice"] and r["state"] == "built")
+    if built < state["slice"]["rows"]:
+        return {"due": False,
+                "why": (f"{built} of {state['slice']['rows']} slice rows are "
+                        "built — the slice is not ready to be played yet"),
+                "open": 0}
+    # The fingerprint is what stops a re-check of an unchanged slice: same
+    # counts, same check. A slice that gained a row, lost one, or had one
+    # wired since the last check reads differently and earns a fresh look.
+    ref = (f"{state['slice']['rows']}/{state['slice']['in_game']}/"
+           f"{state['built']}/{state['verified']}")
+    if any(str(e["source_ref"] or "") == ref for e in existing):
+        return {"due": False, "why": "the slice has not changed since the last "
+                                     "check", "open": 0, "ref": ref}
+    return {"due": True, "why": "every slice row is built and unchecked",
+            "open": 0, "ref": ref}
+
+
+def open_slice_check(root: str | os.PathLike[str]) -> dict:
+    """File ONE qa item that reviews THE GAME rather than an item."""
+    from . import queue as _queue
+
+    due = slice_check_due(root)
+    if not due["due"]:
+        return {"ok": False, "why": due["why"]}
+    state = status(root)
+    unwired = [r["name"] for r in state["remaining"] if r["slice"]]
+    brief = (
+        "SLICE CHECK — review THE GAME, not one item.\n\n"
+        f"Every row of the vertical slice ({state['slice']['rows']}) is built. "
+        "This is the check nothing else in the harness performs: the QA gate "
+        "reviews deliverables one at a time, so a board of green items can sit "
+        "on top of a build that does not boot.\n\n"
+        "Do all four, in order, and put the evidence in your result:\n"
+        "1. godot_check_project — the project parses and imports.\n"
+        "2. godot_run headless — the slice scene BOOTS. A parse error looks "
+        "exactly like a hang, so print and quit early if it does not.\n"
+        "3. godot_screenshot the slice scene at 640x360 and LOOK at it next to "
+        "the pinned refs. A black frame is a fail, not a screenshot.\n"
+        "4. plan_status — report the coverage line, and name anything built "
+        "but not referenced by any scene.\n\n"
+        + (f"BUILT BUT NOT REFERENCED BY ANY SCENE: {', '.join(unwired[:20])}. "
+           "Each of those is an asset that exists on disk and is not in the "
+           "game; say which are genuinely missing wiring and file "
+           "queue_add(<the seat that owns the scene>, ...) for them.\n\n"
+           if unwired else "")
+        + "VERDICT: PASS only if the game boots and the slice is playable. "
+          "Otherwise VERDICT: FAIL with the ranked list, and queue_add the "
+          "fixes — a failing slice check that dispatches nothing is a "
+          "complaint.")
+    item = _queue.add(root, "qa", "SLICE CHECK: does the game actually play?",
+                      brief=brief, priority=9, source=SLICE_CHECK_SOURCE,
+                      source_ref=str(due.get("ref") or ""))
+    activity.log(root, "game-plan",
+                 f"slice check filed as #{item['id']} — every slice row is built",
+                 seat="qa", ref=str(item["id"]))
+    return {"ok": True, "item": int(item["id"]), "ref": due.get("ref") or ""}
+
+
+def status(root: str | os.PathLike[str]) -> dict:
+    """Coverage: what the game consists of vs what is actually IN it.
+
+    THE answer to "what remains to build", and it deliberately does not stop
+    at 'built': a generated sprite no scene references, and a scene no
+    reviewer ever passed, are both work that looks finished from the board and
+    is not in the game. See STATES.
+    """
+    joined = rows(db.connect(root).execute(
+        "SELECT p.kind, p.name, p.seat, p.slice, p.work_item_id, "
+        "w.status AS item_status "
+        "FROM plan_row p LEFT JOIN work_item w ON w.id = p.work_item_id "
+        "ORDER BY p.slice DESC, p.id"))
+    blob = "\n".join(_referenced_names(root)).lower()
+    passed = _verdicts(root)
+    counts = {state: 0 for state in STATES}
+    remaining: list[dict] = []
+    for r in joined:
+        if not r["work_item_id"] or r["item_status"] is None:
+            state = "spec"
+        elif r["item_status"] in ("failed", "cancelled"):
+            state = "lost"
+        elif r["item_status"] != "done":
+            state = "on_board"
+        elif int(r["work_item_id"]) in passed:
+            state = "verified"
+        elif _is_wired(r["name"], blob):
+            state = "wired"
+        else:
+            state = "built"
+        counts[state] += 1
+        r["state"] = state
+        if state not in ("wired", "verified"):
+            remaining.append({"kind": r["kind"], "name": r["name"],
+                              "seat": r["seat"], "slice": bool(r["slice"]),
+                              "state": state,
+                              "item": r["work_item_id"]})
+    slice_rows = [r for r in joined if r["slice"]]
+    in_game = ("wired", "verified")
+    slice_in = sum(1 for r in slice_rows if r["state"] in in_game)
+    return {
+        "rows": len(joined),
+        **counts,
+        "in_game": counts["wired"] + counts["verified"],
+        "slice": {"rows": len(slice_rows), "in_game": slice_in,
+                  "complete": bool(slice_rows) and slice_in == len(slice_rows)},
+        "remaining": remaining[:60],
+        "note": ("no game plan ingested yet — brainstorm one and deploy it "
+                 "with a manifest" if not joined else
+                 "an empty queue is NOT a finished game, and 'built' is not "
+                 "'in the game': 'remaining' lists every row no scene "
+                 "references or no QA pass covers"),
+    }

--- a/bgate_core/gitwork.py
+++ b/bgate_core/gitwork.py
@@ -115,6 +115,55 @@ def dirty(root: str | os.PathLike[str]) -> dict:
     return {"available": True, "reason": "", "dirty": bool(paths), "paths": paths}
 
 
+def commit_paths(root: str | os.PathLike[str], paths: Sequence[str],
+                 message: str) -> dict:
+    """Commit EXACTLY these paths, leaving everything else uncommitted.
+
+    THE DEADLOCK THIS ENDS. Nothing in this system ever committed, and a
+    dispatch refuses a dirty tree by default — so the first agent to write a
+    file made the tree dirty and every later dispatch was refused, forever,
+    with a 20-second retry. Autopilot could not finish a second item without a
+    human running git by hand. An overnight board of thirty items woke up with
+    three done and the rest untouched.
+
+    PATHS, NOT `commit -a`, and that is the whole safety argument: the caller
+    passes the paths ITS OWN RUN touched (gitwork.touched since the run's base
+    commit), so a human's unrelated uncommitted work is never swept into an
+    agent's commit. If the human's edits are what make the tree dirty, it
+    STAYS dirty and the next dispatch is still refused — which is the original
+    rule working as intended rather than being bypassed.
+
+    Never raises: a failed commit is reported and the run stands. The commit
+    is bookkeeping on top of work that already landed on disk, and losing it
+    must not turn a successful run into a failed one.
+    """
+    state = probe(root)
+    if not state["available"]:
+        return {"ok": False, "reason": state["reason"], "committed": []}
+    wanted = [str(p).replace("\\", "/") for p in (paths or [])
+              if str(p).strip() and not _ignored(str(p).replace("\\", "/"))]
+    if not wanted:
+        return {"ok": False, "reason": "nothing to commit", "committed": []}
+    # -- ends the option list: a path that begins with a dash is a filename
+    # here, not a flag, and a generated asset legitimately can.
+    ok, _out, err = _run(root, ["add", "--", *wanted])
+    if not ok:
+        return {"ok": False, "reason": f"git add failed: {err}", "committed": []}
+    # Staged-only check: `add` on an unchanged path stages nothing, and
+    # `commit` with nothing staged is an error whose message reads like a
+    # fault. Asking first turns that into an honest "nothing changed".
+    ok, staged, _err = _run(root, ["diff", "--cached", "--name-only"])
+    if not ok or not staged.strip():
+        return {"ok": False, "reason": "nothing staged — no tracked change",
+                "committed": []}
+    ok, _out, err = _run(root, ["commit", "--no-verify", "-m", message])
+    if not ok:
+        return {"ok": False, "reason": f"git commit failed: {err}",
+                "committed": []}
+    return {"ok": True, "reason": "", "commit": head(root),
+            "committed": [p for p in staged.splitlines() if p.strip()]}
+
+
 def touched(root: str | os.PathLike[str], base: str) -> dict:
     """Every path that changed since ``base``, tracked edits AND new files.
 

--- a/bgate_core/music.py
+++ b/bgate_core/music.py
@@ -37,13 +37,33 @@ NO URL IS EVER THE ASSET. kie serves generated files for fourteen days. The
 adapter downloads inside the polling loop; this module records the source URL in
 metadata as PROVENANCE ONLY, stamped with the date it dies, so nothing can
 mistake it for a place to fetch from later.
+
+THE TASK ID IS WRITTEN BEFORE THE WAIT, NOT AFTER IT. A Suno batch is charged
+when it is ACCEPTED and then polled for about three minutes; until this module
+kept a pending ticket, the id first reached durable storage inside
+:func:`_absorb` — i.e. only after a download that had already succeeded. So the
+one window where the process dying costs money was the only window in which
+nothing had been written down: the batch rendered, was billed, and
+:func:`recover` — which needs a task id — could not be called, because the id
+had existed solely in a local variable in a dead process. Every generation now
+opens a ticket under ``.bgate_out/audio/.pending/`` BEFORE the submit and
+stamps the id onto it the instant kie hands one over (see
+``kie.generate_music``'s ``on_submit``), and :func:`stuck_tracks` is what
+NOTICES the tickets nobody came back for. The shape and the vocabulary are
+``bgate_core.cinematic``'s ``stuck_shots`` on purpose — someone who knows one
+knows the other. No new table: a ticket is a file beside the takes it is waiting
+for, under the same gitignored scratch directory.
 """
 from __future__ import annotations
 
+import json
 import os
 import shutil
+import time
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
+from uuid import uuid4
 
 from . import activity, artifacts, assets, db
 from .util import slugify
@@ -60,6 +80,21 @@ INSTALL_SUBDIR = "music"
 
 PRODUCER = "kie_music"
 AUDIO_SUFFIXES = {".mp3", ".wav", ".ogg"}
+
+# WHERE A SUBMITTED-BUT-UNCOLLECTED GENERATION IS REMEMBERED. One JSON ticket
+# per submit, beside the candidates it is waiting for — dotted so the audio
+# seat's own listings and the candidate walk never mistake one for a take, and
+# under .bgate_out because it is scratch that is deleted the moment the batch is
+# on disk. A file rather than a column: cine_shot already existed to hold
+# cinematic's task id, music has no table of its own, and a schema migration is
+# a heavy price for a handle whose whole life is three minutes.
+PENDING_DIR = CANDIDATE_DIR / ".pending"
+
+# How long a ticket may sit uncollected before it is worth asking kie about. A
+# Suno batch renders in about three minutes and generate() gives up at fifteen,
+# so ten is past any healthy run and still inside a live call's own patience —
+# a sweep must never call a poll loop stuck before that loop has given up.
+STUCK_AFTER_S = 600
 
 
 class MusicError(RuntimeError):
@@ -114,6 +149,10 @@ def generate(root: str | os.PathLike[str], prompt: str, *, name: str = "",
     per-model price, so there is no projected figure to check against a ceiling
     — but a project that has ALREADY blown its daily budget must not be able to
     buy music, and ``spend.check`` answers that with a projection of zero.
+
+    A PENDING TICKET IS OPENED BEFORE THE SUBMIT and closed only when the takes
+    are on disk. Everything between those two points is paid-for work nobody has
+    collected, which is exactly what :func:`stuck_tracks` sweeps for.
     """
     from bgate_adapters import kie
 
@@ -129,14 +168,40 @@ def generate(root: str | os.PathLike[str], prompt: str, *, name: str = "",
                 "logical_name": stem, "candidates": []}
 
     out_dir = Path(root) / CANDIDATE_DIR / stem
-    result = kie.generate_music(text, str(out_dir), name=stem, root=root,
-                                logical_name=stem, work_item_id=work_item_id,
-                                timeout=float(timeout), on_progress=on_progress,
-                                **suno)
+    # OPENED BEFORE THE CALL, exactly as cinematic sets a shot to 'generating'
+    # before it asks kie for one. A ticket with no task id on it is the worst
+    # category and it has to be REACHABLE: it means the process died between the
+    # submit leaving and the id coming back, which is a charge with no handle.
+    # Opening it afterwards would make that case indistinguishable from a run
+    # that never happened.
+    ticket = _open_ticket(root, stem, text)
+    result = kie.generate_music(
+        text, str(out_dir), name=stem, root=root, logical_name=stem,
+        work_item_id=work_item_id, timeout=float(timeout),
+        on_progress=on_progress,
+        # THE INSTANT IT EXISTS. Not on the return: the poll that follows runs
+        # for minutes and a return value does not survive a killed process.
+        on_submit=lambda task_id: _stamp_ticket(ticket, task_id=str(task_id or "")),
+        **suno)
     if not result.get("ok"):
+        if result.get("task_id"):
+            # Suno was already asked, so this batch is paid for whatever went
+            # wrong afterwards — the download, the timeout, a human cancelling.
+            # The ticket STAYS OPEN so the sweep reports it as collectable;
+            # cinematic can afford to close its row here because a shot row is
+            # permanent and this handle is not.
+            _stamp_ticket(ticket, task_id=str(result["task_id"]),
+                          error=str(result.get("error") or "")[:400])
+        else:
+            # Nothing reached kie that we know of — a prompt the model refused,
+            # a cancel in the first second. Leaving the ticket would report a
+            # refusal as lost money, which is the sweep crying wolf.
+            _close_ticket(ticket)
         return {**result, "logical_name": stem, "candidates": []}
-    return _absorb(root, stem, text, result, work_item_id=work_item_id,
-                   suno=suno, on_progress=on_progress)
+    out = _absorb(root, stem, text, result, work_item_id=work_item_id,
+                  suno=suno, on_progress=on_progress)
+    _close_ticket(ticket)
+    return out
 
 
 def recover(root: str | os.PathLike[str], task_id: str, *, name: str = "",
@@ -188,6 +253,10 @@ def recover(root: str | os.PathLike[str], task_id: str, *, name: str = "",
     fresh = [t for t in tracks if str(t.get("id") or "") not in known]
     skipped = len(tracks) - len(fresh)
     if not fresh:
+        # Every take of this task is already filed, so whatever ticket is still
+        # open for it is describing work that HAS been collected. Closing it
+        # here is what stops the sweep reporting the same non-problem for ever.
+        _close_task_tickets(root, state["task_id"])
         return {"ok": True, "task_id": state["task_id"], "logical_name": stem,
                 "candidates": [], "count": 0, "skipped": skipped,
                 "note": f"all {skipped} take(s) from this task are already "
@@ -205,6 +274,8 @@ def recover(root: str | os.PathLike[str], task_id: str, *, name: str = "",
     out = _absorb(root, stem, f"recovered from kie task {state['task_id']}",
                   {**carrier, "tracks": written}, work_item_id=work_item_id,
                   suno={}, on_progress=on_progress)
+    # The takes are on disk and filed: this task is no longer uncollected.
+    _close_task_tickets(root, state["task_id"])
     return {**out, "ok": True, "recovered": True, "skipped": skipped,
             "task_id": state["task_id"],
             "note": f"downloaded {len(written)} take(s) kie was already holding"
@@ -246,6 +317,130 @@ def status(root: str | os.PathLike[str], task_id: str) -> dict:
                  "put the audio on disk without paying for it again"
                  if tracks else
                  "kie is holding no audio for this task yet"),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Paid work nobody is watching any more
+# ---------------------------------------------------------------------------
+
+def stuck_tracks(root: str | os.PathLike[str], *,
+                 older_than_s: int = STUCK_AFTER_S, poll: bool = True,
+                 limit: int = 50) -> dict:
+    """Generations that were submitted and never collected. The music sweep.
+
+    THE FAILURE THIS SWEEPS FOR IS SILENT AND EXPENSIVE, and it is the same one
+    ``cinematic.stuck_shots`` exists for. A batch is charged at SUBMIT and then
+    polled for about three minutes; if the dashboard restarts, the agent is
+    killed or the connection drops in that window, nobody ever asks for the
+    audio again and kie holds two finished tracks, paid for, until the fourteen
+    days run out. :func:`recover` has always been able to collect one — what was
+    missing is anything that NOTICES, so recovery depended on a human
+    remembering a task id they never saw.
+
+    ``poll=False`` answers from the pending tickets alone: no network, no
+    provider call, safe on every dashboard refresh. ``poll=True`` asks kie about
+    each one, which is what turns "stale" into "finished, paid for, and one call
+    from being on disk".
+
+    A TICKET WITH NO TASK ID IS ITS OWN CATEGORY and the worst one. The submit
+    left; the handle did not come back. It is reported as ``lost`` rather than
+    folded in with the failures because the two want different things from a
+    human — one is a click, the other is kie's own dashboard.
+    """
+    root = str(root)
+    cutoff = max(0, int(older_than_s))
+    collected = _task_index(root)
+    stale = []
+    for path, record in _tickets(root):
+        age = _ticket_age_s(path, record)
+        if age < cutoff:
+            continue
+        stale.append((age, path, record))
+    stale.sort(key=lambda item: -item[0])
+    stale = stale[:max(1, int(limit))]
+
+    out = []
+    for age, path, record in stale:
+        entry = {"logical_name": record.get("logical_name") or "",
+                 "prompt": record.get("prompt") or "",
+                 "task_id": str(record.get("task_id") or ""),
+                 "ticket": Path(path).relative_to(Path(root)).as_posix(),
+                 "updated_at": record.get("updated_at") or "",
+                 "age_s": int(age), "recoverable": False}
+        if not entry["task_id"]:
+            out.append({**entry, "state": "lost",
+                        "note": "this generation was submitted with no task id "
+                                "recorded, so there is no handle to collect it "
+                                "with. If it reached kie it was charged for; "
+                                "kie's own dashboard is the only place left to "
+                                "look."})
+            continue
+        if entry["task_id"] in collected:
+            # A crash between the download and the ticket being closed leaves
+            # one of these. Reporting a batch that IS filed as money waiting to
+            # be spent again is the exact wrong answer, so the registry is asked
+            # first — one scan for the whole sweep, not one per ticket.
+            out.append({**entry, "state": "collected",
+                        "logical_name": collected[entry["task_id"]],
+                        "note": "the takes from this task are already "
+                                "registered — the ticket outlived the batch it "
+                                "was holding a place for and nothing is owed."})
+            continue
+        if not poll:
+            out.append({**entry, "state": "unpolled",
+                        "note": "stale, and not asked about — call with "
+                                "poll=True to find out whether kie is holding "
+                                "finished audio for it"})
+            continue
+        try:
+            state = status(root, entry["task_id"])
+        except Exception as exc:                                 # noqa: BLE001
+            out.append({**entry, "state": "unknown", "error": str(exc)[:300],
+                        "note": "kie could not be asked about this task, so "
+                                "whether it is running, finished or dead is "
+                                "unknown — not resolved."})
+            continue
+        if state.get("recoverable"):
+            out.append({**entry, "state": "recoverable", "recoverable": True,
+                        "provider_status": state.get("status", ""),
+                        "track_count": state.get("track_count", 0),
+                        "note": "PAID AND COLLECTABLE — kie is holding finished "
+                                "audio for this task. recover() puts it on disk "
+                                "without paying again; re-generating pays "
+                                "twice."})
+        elif state.get("failed"):
+            out.append({**entry, "state": "failed",
+                        "provider_status": state.get("status", ""),
+                        "error": state.get("error_message") or "",
+                        "note": "the generation failed at kie. It can be "
+                                "re-generated."})
+        else:
+            out.append({**entry, "state": "running",
+                        "provider_status": state.get("status", ""),
+                        "note": "still running at kie despite the age of the "
+                                "ticket — wait rather than re-generating."})
+
+    counts: dict[str, int] = {}
+    for entry in out:
+        counts[entry["state"]] = counts.get(entry["state"], 0) + 1
+    recoverable = counts.get("recoverable", 0)
+    return {
+        "ok": True,
+        "older_than_s": cutoff,
+        "polled": bool(poll),
+        "stale": len(out),
+        "counts": counts,
+        "recoverable": recoverable,
+        "retention_days": _retention_days(),
+        "tracks": out,
+        "note": (f"{recoverable} generation(s) are finished at kie, already "
+                 "charged for, and waiting to be collected with recover()"
+                 if recoverable else
+                 "no generation is sitting on a paid, uncollected batch"
+                 if poll else
+                 f"{len(out)} generation(s) are stale; kie was not asked about "
+                 "any of them, so none is resolved either way"),
     }
 
 
@@ -476,6 +671,146 @@ def _auto_installed(root: str, filed: list) -> Optional[dict]:
     return None
 
 
+# ---------------------------------------------------------------------------
+# The pending ledger — one file per submitted generation
+# ---------------------------------------------------------------------------
+#
+# A ticket exists for exactly as long as a batch is paid for and uncollected.
+# Every write below is BEST EFFORT and silent on failure, for the rule the whole
+# module holds: bookkeeping must never lose the audio it was bookkeeping. The
+# cost of a lost ticket is a sweep that misses one batch; the cost of a raise
+# here would be a generation that dies at the paperwork.
+
+def _open_ticket(root: str, stem: str, prompt: str) -> Path:
+    """Note that a generation is about to be submitted. Returns its ticket path.
+
+    Named for the moment rather than for the task, because there IS no task id
+    yet — that is the entire point. A ticket that never receives one is what the
+    sweep reports as ``lost``.
+    """
+    directory = Path(root) / PENDING_DIR
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S")
+    path = directory / f"{stamp}-{(stem or 'track')[:40]}-{uuid4().hex[:8]}.json"
+    try:
+        directory.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        return path
+    _write_ticket(path, {"logical_name": stem, "prompt": str(prompt)[:400],
+                         "task_id": "", "created_at": _now(),
+                         "updated_at": _now()})
+    return path
+
+
+def _stamp_ticket(path: str | os.PathLike[str], **fields: Any) -> None:
+    """Merge fields into a ticket. Called from kie's on_submit hook."""
+    record = _read_ticket(path) or {"created_at": _now()}
+    record.update(fields)
+    record["updated_at"] = _now()
+    _write_ticket(Path(path), record)
+
+
+def _close_ticket(path: str | os.PathLike[str]) -> None:
+    """The batch is on disk (or was never submitted). Nothing is owed."""
+    try:
+        Path(path).unlink()
+    except OSError:
+        pass
+
+
+def _close_task_tickets(root: str, task_id: str) -> int:
+    """Close every ticket holding this task id. The door :func:`recover` uses.
+
+    By id rather than by path because recover() is called by a human with a task
+    id and no memory of which ticket — often in a different process from the one
+    that opened it, which is the case the ticket exists for.
+    """
+    ident = str(task_id or "").strip()
+    if not ident:
+        return 0
+    closed = 0
+    for path, record in _tickets(root):
+        if str(record.get("task_id") or "") == ident:
+            _close_ticket(path)
+            closed += 1
+    return closed
+
+
+def _tickets(root: str | os.PathLike[str]) -> list:
+    """Every open ticket as ``(path, record)``. Unreadable ones are skipped —
+    a half-written JSON file must not take the whole sweep down with it."""
+    directory = Path(root) / PENDING_DIR
+    if not directory.is_dir():
+        return []
+    out = []
+    for path in sorted(directory.glob("*.json")):
+        record = _read_ticket(path)
+        if isinstance(record, dict):
+            out.append((path, record))
+    return out
+
+
+def _read_ticket(path: str | os.PathLike[str]) -> Optional[dict]:
+    try:
+        return json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+
+
+def _write_ticket(path: Path, record: dict) -> None:
+    try:
+        path.write_text(json.dumps(record, indent=2), encoding="utf-8")
+    except (OSError, TypeError, ValueError):
+        pass
+
+
+def _ticket_age_s(path: Path, record: dict) -> float:
+    """How long this generation has gone uncollected, in seconds.
+
+    The stamp on the record is preferred over the file's mtime because a copied
+    or restored .bgate_out would otherwise reset every ticket's age to now and
+    hide exactly the batches this sweep is for.
+    """
+    stamp = str(record.get("updated_at") or record.get("created_at") or "")
+    try:
+        when = datetime.fromisoformat(stamp)
+    except ValueError:
+        try:
+            return max(0.0, time.time() - path.stat().st_mtime)
+        except OSError:
+            return 0.0
+    if when.tzinfo is None:
+        when = when.replace(tzinfo=timezone.utc)
+    return max(0.0, (datetime.now(timezone.utc) - when).total_seconds())
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _retention_days() -> int:
+    """How long kie holds the audio a stale ticket points at — the deadline on
+    every recovery this sweep offers."""
+    from bgate_adapters import kie
+
+    return int(kie.SUNO_URL_TTL_DAYS)
+
+
+def _task_index(root: str) -> dict:
+    """Task id -> the logical name its takes were filed under. One scan.
+
+    Answers 'has this batch already been collected?' for the whole sweep and
+    for :func:`_stem_for_task`, which used to walk the same rows itself.
+    """
+    out: dict[str, str] = {}
+    for row in artifacts.list_revisions(root, limit=500):
+        if (row.get("producer") or "") != PRODUCER:
+            continue
+        ident = str((row.get("metadata") or {}).get("task_id") or "")
+        if ident:
+            out.setdefault(ident, str(row.get("logical_name") or ""))
+    return out
+
+
 def _known_suno_ids(root: str, stem: str) -> set:
     """Suno track ids already registered under this name, so a recovery does not
     download or file the same take twice."""
@@ -492,12 +827,22 @@ def _stem_for_task(root: str, task_id: str) -> str:
 
     A recovery should land beside the takes it belongs with, not under a name
     derived from a hex string — the whole point is that the batch is one batch.
+
+    THE TICKET IS ASKED SECOND AND IT IS WHAT MAKES THIS WORK AT ALL FOR THE
+    CRASH CASE. A registered revision only exists once a batch has been
+    collected, so a generation that died mid-poll — the exact case recover() is
+    reached for — had nothing here to match and came back named after twelve hex
+    characters. The pending ticket carries the name the human asked for, written
+    before the submit.
     """
-    for row in artifacts.list_revisions(root, limit=500):
-        if (row.get("producer") or "") != PRODUCER:
-            continue
-        if str((row.get("metadata") or {}).get("task_id") or "") == task_id:
-            return str(row.get("logical_name") or "")
+    filed = _task_index(root).get(str(task_id or ""))
+    if filed:
+        return filed
+    for _path, record in _tickets(root):
+        if str(record.get("task_id") or "") == str(task_id or ""):
+            name = str(record.get("logical_name") or "")
+            if name:
+                return name
     return ""
 
 

--- a/bgate_core/queue.py
+++ b/bgate_core/queue.py
@@ -33,6 +33,17 @@ STATUSES = ("queued", "dispatched", "review", "done", "failed", "cancelled")
 # of them: the whole point of the hold is that the next link waits.
 SATISFIED = ("done",)
 
+# Sources no automatic dispatcher may touch. Defined HERE because there are two
+# such dispatchers now — the dashboard's autodeploy loop and a worker's
+# claim_next — in different processes, and two copies of this tuple is how one
+# of them ends up grabbing an escalation a human was supposed to read.
+#   qa-gate-escalation — two agents could not agree and a human has to decide.
+#   chat — a message to the director; the console dispatches those itself.
+HELD_SOURCES = ("qa-gate-escalation", "chat")
+# A row created in two statements — INSERT with a placeholder, then UPDATE with
+# the real text — is briefly dispatchable with nothing in it.
+PLACEHOLDER_BRIEF = "(preparing%"
+
 # HOW MUCH OF A RESULT SURVIVES THE WRITE.
 #
 # This was 2000 characters and it was SILENTLY EATING THE DELIVERABLE. A chat
@@ -337,6 +348,30 @@ def _item_event_payload(item: dict) -> dict:
     }
 
 
+def emit_terminal(root, item_id: int) -> None:
+    """Announce an item's terminal status for a transition that BYPASSED complete().
+
+    The watchdog's ceiling kills (runtime, stall, cost, terminal CLI error) write
+    'failed' through set_status and then _reap skips complete() because the item
+    is no longer 'dispatched' — so the most expensive failures this system has
+    were the only ones that never reached the bus: no bell, no webhook, no
+    auto-reopen. This is their announcement path.
+
+    NOT wired into set_status itself, and complete()'s docstring says why:
+    set_status also moves items for reopen and for reject's parking step, and
+    emitting there would tell the router an agent crashed when a human simply
+    said no. This is called explicitly, by the one caller that knows its
+    transition is a genuine terminal outcome.
+    """
+    try:
+        item = get(root, item_id)
+    except LookupError:
+        return
+    kind = _COMPLETION_KINDS.get(item["status"])
+    if kind:
+        _emit(root, kind, ref=str(item_id), payload=_item_event_payload(item))
+
+
 def _with_observed_writes(root, item_id: int, status: str, result: str) -> str:
     """Append what the harness SAW this item write to what the agent CLAIMS.
 
@@ -416,24 +451,113 @@ def set_status(root: str | os.PathLike[str], item_id: int, status: str,
     return item
 
 
+def parents(root: str | os.PathLike[str], item_id: int) -> list[int]:
+    """Every predecessor of this item — the single column AND the extra table.
+
+    A game is a DAG: a scene can need the sprite, the sound and the script.
+    `depends_on` holds one parent (and every chain is built on it); the rest
+    live in work_item_dep. Cut dependencies are excluded — that is what
+    cutting means.
+    """
+    item = get(root, item_id)
+    out = [int(item["depends_on"])] if item.get("depends_on") else []
+    try:
+        extra = rows(db.connect(root).execute(
+            "SELECT depends_on FROM work_item_dep WHERE item_id = ? "
+            "AND cut_at IS NULL ORDER BY depends_on", (int(item_id),)))
+    except Exception:
+        extra = []             # pre-migration project: one parent is all there is
+    out.extend(int(r["depends_on"]) for r in extra
+               if int(r["depends_on"]) not in out)
+    return out
+
+
+def add_dependency(root: str | os.PathLike[str], item_id: int,
+                   depends_on: int) -> dict:
+    """Make this item wait for one MORE predecessor.
+
+    The multi-parent half of queue_add's depends_on. Refuses a dependency on
+    a fiction (an item silently waiting on nothing dispatches immediately —
+    the exact failure the wait was for) and refuses a self-loop.
+    """
+    get(root, item_id)
+    get(root, int(depends_on))
+    if int(depends_on) == int(item_id):
+        raise ValueError(f"item {item_id} cannot wait for itself")
+    with db.tx(root) as conn:
+        conn.execute(
+            "INSERT OR IGNORE INTO work_item_dep (item_id, depends_on) "
+            "VALUES (?, ?)", (int(item_id), int(depends_on)))
+    activity.log(root, "queue",
+                 f"item {item_id} now also waits for #{int(depends_on)}",
+                 ref=str(item_id))
+    return {"item": int(item_id), "parents": parents(root, item_id)}
+
+
+def cut_dependency(root: str | os.PathLike[str], item_id: int,
+                   depends_on: int, by: str = "") -> dict:
+    """THE REPAIR VERB. Release an item from a predecessor that will never land.
+
+    A cancelled predecessor satisfies nothing (SATISFIED is 'done' alone), so
+    before this the successors of a cut item waited forever with no operation
+    that could free them — the board's one unreachable state. Cutting is
+    recorded rather than deleted: "#13 waited on #12, which was cancelled, and
+    a person released it" is exactly the sentence an audit needs later.
+
+    The single `depends_on` column is cleared in place; an extra parent is
+    marked cut. Either way the item becomes dispatchable if nothing else holds
+    it, and it is the CALLER's job to have decided that is right.
+    """
+    item = get(root, item_id)
+    actor = (by or activity.current_actor() or "the dashboard")[:120]
+    dep = int(depends_on)
+    if item.get("depends_on") and int(item["depends_on"]) == dep:
+        with db.tx(root) as conn:
+            conn.execute("UPDATE work_item SET depends_on = NULL WHERE id = ?",
+                         (int(item_id),))
+    else:
+        with db.tx(root) as conn:
+            cur = conn.execute(
+                "UPDATE work_item_dep SET cut_by = ?, cut_at = datetime('now') "
+                "WHERE item_id = ? AND depends_on = ? AND cut_at IS NULL",
+                (actor, int(item_id), dep))
+            if cur.rowcount != 1:
+                raise LookupError(
+                    f"item {item_id} does not wait for #{dep} (already cut?)")
+    activity.log(root, "queue",
+                 f"item {item_id} released from #{dep} by {actor}",
+                 seat=item["seat"], ref=str(item_id))
+    remaining = parents(root, item_id)
+    return {"item": int(item_id), "cut": dep, "by": actor,
+            "still_waiting_on": remaining,
+            "ready": not remaining and item["status"] == "queued"}
+
+
 def blocker(root: str | os.PathLike[str], item_id: int) -> Optional[dict]:
     """The predecessor this item is still waiting on, or None if it can run.
 
     Returns the blocking row (id/seat/title/status) rather than a bool because
     every caller that refuses a dispatch has to SAY what it is waiting for —
     "blocked" with no antecedent is the least actionable refusal there is.
+    With several parents it reports the FIRST unsatisfied one and counts the
+    rest, so a fan-in does not have to be discovered one dispatch at a time.
     """
-    item = get(root, item_id)
-    if not item.get("depends_on"):
+    unsatisfied = []
+    for parent in parents(root, item_id):
+        try:
+            dep = get(root, int(parent))
+        except LookupError:
+            continue           # deleted predecessor: unblock rather than strand
+        if dep["status"] not in SATISFIED:
+            unsatisfied.append(dep)
+    if not unsatisfied:
         return None
-    try:
-        dep = get(root, int(item["depends_on"]))
-    except LookupError:
-        return None            # deleted predecessor: unblock rather than strand
-    if dep["status"] in SATISFIED:
-        return None
-    return {"id": dep["id"], "seat": dep["seat"], "title": dep["title"],
-            "status": dep["status"]}
+    dep = unsatisfied[0]
+    out = {"id": dep["id"], "seat": dep["seat"], "title": dep["title"],
+           "status": dep["status"]}
+    if len(unsatisfied) > 1:
+        out["also_waiting_on"] = [int(d["id"]) for d in unsatisfied[1:]]
+    return out
 
 
 def chain(root: str | os.PathLike[str], chain_id: str) -> list[dict]:
@@ -699,13 +823,128 @@ def next_for(root: str | os.PathLike[str], seat: str) -> Optional[dict]:
     so it starts, finds the file it was promised missing, and either stalls or
     invents one.
     """
-    row = db.connect(root).execute(
+    candidates = rows(db.connect(root).execute(
         "SELECT i.* FROM work_item i "
         "LEFT JOIN work_item d ON d.id = i.depends_on "
         "WHERE i.status = 'queued' AND i.seat = ? "
         "  AND (i.depends_on IS NULL OR d.id IS NULL OR d.status = 'done') "
-        "ORDER BY i.priority DESC, i.id LIMIT 1", (seat,)).fetchone()
-    return dict(row) if row else None
+        "ORDER BY i.priority DESC, i.id LIMIT 20", (seat,)))
+    # The SQL join can only see the single-column parent; extra parents live in
+    # work_item_dep, so readiness is settled by blocker() — the one place that
+    # knows about both. Handing an agent work whose OTHER parent has not landed
+    # is the failure this function's docstring is about.
+    for row in candidates:
+        if blocker(root, int(row["id"])) is None:
+            return dict(row)
+    return None
+
+
+def reserve(root: str | os.PathLike[str], item_id: int) -> bool:
+    """Atomically take a queued item for dispatch: queued -> dispatched.
+
+    There are two dispatchers now — the dashboard (autodeploy, buttons) and a
+    worker's claim_next — in different processes. Both used to be able to read
+    'queued' and proceed, which is two agents spawned against one item with
+    nothing to say so. The WHERE clause is the whole point: exactly one caller
+    wins the row, and the loser finds out here rather than two items later.
+
+    Deliberately touches ONLY status and updated_at. set_status also rewrites
+    the result column, and a reservation that wiped a reopened item's
+    "reopened: ..." note would destroy the one line explaining the round.
+    """
+    get(root, item_id)                       # LookupError if the item is fiction
+    with db.tx(root) as conn:
+        cur = conn.execute(
+            "UPDATE work_item SET status = 'dispatched', "
+            "updated_at = datetime('now') WHERE id = ? AND status = 'queued'",
+            (item_id,))
+        taken = cur.rowcount == 1
+    if taken:
+        item = get(root, item_id)
+        activity.log(root, "queue",
+                     f"item {item_id} -> dispatched: {item['title'][:60]}",
+                     seat=item["seat"], ref=str(item_id))
+        _notify(root, item)
+    return taken
+
+
+def release(root: str | os.PathLike[str], item_id: int) -> bool:
+    """Undo reserve(): dispatched -> queued, touching nothing else.
+
+    For a dispatch refused AFTER the reservation (dirty tree, missing runner,
+    failed worktree) — the item was never run, so it goes back exactly as it
+    was rather than through set_status, which would blank its result note.
+    """
+    with db.tx(root) as conn:
+        cur = conn.execute(
+            "UPDATE work_item SET status = 'queued', "
+            "updated_at = datetime('now') WHERE id = ? AND status = 'dispatched'",
+            (item_id,))
+        undone = cur.rowcount == 1
+    if undone:
+        activity.log(root, "queue",
+                     f"item {item_id} -> queued (dispatch refused after reserve)",
+                     ref=str(item_id))
+    return undone
+
+
+def claim_next(root: str | os.PathLike[str], seat: str,
+               actor: str) -> Optional[dict]:
+    """Atomically claim the next READY item for a seat — the worker pickup loop.
+
+    A finished worker used to have exactly one move: exit, and let autodeploy
+    pay a fresh agent's whole briefing to start the next item. This is the
+    other move: the same session claims the next item and keeps going, with
+    its context already paid for.
+
+    Readiness is next_for's rule plus autodeploy's holds (sources a human must
+    touch, placeholder briefs) — a pickup loop that could grab an escalation
+    would be an agent dispatching the item that exists because agents disagreed.
+    The claim itself is reserve(), so racing the dashboard is safe: whoever
+    loses the UPDATE simply tries the next candidate.
+
+    ``actor`` is the claiming EXECUTION (agent:item-<original id>). It is
+    stamped on the claimed row, which is what lets the dashboard keep the
+    session alive past its original item and requeue claims if the run dies.
+    """
+    if seat not in _seats.DEFAULT_SEATS:
+        raise ValueError(f"unknown seat {seat!r}; seats are {tuple(_seats.DEFAULT_SEATS)}")
+    if not str(actor or "").strip():
+        raise ValueError("claim_next needs the claiming execution's identity")
+    marks = ", ".join("?" * len(HELD_SOURCES))
+    candidates = rows(db.connect(root).execute(
+        f"SELECT i.id FROM work_item i "
+        f"LEFT JOIN work_item d ON d.id = i.depends_on "
+        f"WHERE i.status = 'queued' AND i.seat = ? "
+        f"  AND i.source NOT IN ({marks}) AND i.brief NOT LIKE ? "
+        "  AND (i.depends_on IS NULL OR d.id IS NULL OR d.status = 'done') "
+        "ORDER BY i.priority DESC, i.id LIMIT 10",
+        (seat, *HELD_SOURCES, PLACEHOLDER_BRIEF)))
+    for row in candidates:
+        if blocker(root, int(row["id"])) is not None:
+            continue                      # an extra parent has not landed
+        if not reserve(root, int(row["id"])):
+            continue                      # lost the race — next candidate
+        item = set_run_fields(root, int(row["id"]), actor=str(actor).strip())
+        activity.log(root, "queue",
+                     f"item {item['id']} claimed by {actor}",
+                     seat=seat, ref=str(item["id"]))
+        return item
+    return None
+
+
+def claimed_open(root: str | os.PathLike[str], actor: str) -> list[dict]:
+    """Dispatched items owned by this execution — the claims a run still holds.
+
+    The dashboard's watchdog asks this before closing a finished worker's
+    stdin, and _reap asks it to requeue whatever a dead run claimed and never
+    settled. Matches on the actor stamp claim_next wrote; an item dispatched
+    the ordinary way carries the dispatcher's actor, not the run's, so it
+    never appears here.
+    """
+    return rows(db.connect(root).execute(
+        "SELECT * FROM work_item WHERE status = 'dispatched' AND actor = ? "
+        "ORDER BY id", (str(actor or ""),)))
 
 
 def sync_promoted(root: str | os.PathLike[str]) -> dict:

--- a/bgate_core/seats.py
+++ b/bgate_core/seats.py
@@ -1025,6 +1025,135 @@ def can_write(root: str | os.PathLike[str], role: str, path: str,
     return {"allowed": True, "role": role, "path": rel, "owner": owner}
 
 
+def detect_layout(root: str | os.PathLike[str]) -> dict:
+    """Where this project's game actually lives, and whether the lanes agree.
+
+    THE DEFAULT LANES ASSUME ONE LAYOUT AND TWO ENTRYPOINTS PRODUCE ANOTHER.
+    Every glob in DEFAULT_SEATS is written against <root>/game and
+    <root>/design — but `bgate init` scaffolds the template straight into
+    <root> (project.godot, scenes/, scripts/ at the top level), and an ADOPTED
+    repo has whatever layout its author chose. Measured against the real
+    matcher on an ordinary Godot repo: src/player.gd, assets/hero.png and
+    scenes/level.tscn are owned by NO SEAT, so with the hook installed every
+    dispatched agent is refused on contact with the source tree — and the
+    refusal reads as "wrong seat" when the truth is "your lanes describe a
+    repo that does not exist here".
+
+    Returns {prefix, godot_dir, matches, top_dirs}. ``prefix`` is what the
+    lane globs should be rooted at: "game/" for the scaffold layout, "" when
+    the game is at the top level. ``matches`` is False when the default table
+    would refuse the project's own source directories, which is the condition
+    worth telling a human about.
+    """
+    from pathlib import Path
+
+    base = Path(root)
+    try:
+        from . import project as _project
+        godot = _project.game_dir(root)
+    except Exception:
+        godot = None
+    prefix = "game/"
+    if godot is not None:
+        try:
+            rel = godot.resolve().relative_to(base.resolve()).as_posix()
+        except (ValueError, OSError):
+            rel = "game"
+        prefix = "" if rel in (".", "") else rel.rstrip("/") + "/"
+    elif not (base / "game").is_dir():
+        # No engine project yet and no game/ directory: a source tree at the
+        # top level is the likelier reading than a directory nobody made.
+        prefix = ""
+    try:
+        top = sorted(p.name for p in base.iterdir()
+                     if p.is_dir() and not p.name.startswith((".", "_")))
+    except OSError:
+        top = []
+    return {"prefix": prefix, "godot_dir": str(godot) if godot else "",
+            "matches": prefix == "game/", "top_dirs": top}
+
+
+def lanes_for_layout(prefix: str) -> dict[str, list[str]]:
+    """The default lane table re-rooted at this project's actual layout.
+
+    Rewrites only the globs that START at the assumed root. A lane that is
+    already project-relative in a way the layout does not change (``blender/``,
+    ``art/``, ``tests/``, ``*.godot``) is left exactly as it is — re-rooting
+    those would move directories the seat model deliberately keeps outside the
+    engine project.
+    """
+    prefix = (prefix or "").strip()
+    if prefix and not prefix.endswith("/"):
+        prefix += "/"
+    out: dict[str, list[str]] = {}
+    for role, cfg in DEFAULT_SEATS.items():
+        lanes = []
+        for glob in cfg["write_globs"]:
+            if glob.startswith("game/"):
+                lanes.append(prefix + glob[len("game/"):] if prefix != "game/"
+                             else glob)
+            else:
+                lanes.append(glob)
+        # De-duplicated: with an empty prefix, game/** collapses to ** for the
+        # tech seat, which would hand it every path in the project including
+        # every other seat's. Dropping a bare ** keeps the table meaningful.
+        out[role] = [g for g in dict.fromkeys(lanes) if g not in ("**", "**/*")]
+    return out
+
+
+def apply_layout(root: str | os.PathLike[str], prefix: str = "") -> dict:
+    """Store lanes that match this project's layout. Idempotent.
+
+    Written through :func:`configure`, so the result is an ordinary per-project
+    seat override: visible in seat_list, editable by a human, and reversible.
+    Nothing here invents a seat or widens one beyond the shape the default
+    table already had — it is the same lanes, pointed at the right directory.
+    """
+    layout = detect_layout(root) if not prefix else {"prefix": prefix}
+    prefix = layout["prefix"]
+    if prefix == "game/":
+        return {"changed": False, "prefix": prefix,
+                "why": "the default lanes already match this layout"}
+    table = lanes_for_layout(prefix)
+    for role, lanes in table.items():
+        configure(root, role, write_globs=lanes)
+    return {"changed": True, "prefix": prefix, "lanes": table,
+            "why": f"lanes re-rooted at {prefix or 'the project root'} — the "
+                   "default table assumes <root>/game, which this project "
+                   "does not use"}
+
+
+def lane_owners(root: str | os.PathLike[str], path: str) -> list[str]:
+    """Which seats' lanes cover this path — the ROUTING half of a refusal.
+
+    A lane refusal that only names the wall teaches an agent to stop; naming
+    the seat on the other side turns the same refusal into an address. The
+    observed cost of not having this: fifteen LEFTOVERS blocks, four seat notes
+    asking for work that was never queued, and a 270-line integration script
+    written to route around cross-lane one-liners. The hook reads this to say
+    "that is the tech seat's file — queue_add('tech', ...)" instead of "no".
+
+    Overlap is normal (director and narrative both own design/**), so this is
+    a list — MOST SPECIFIC lane first, because tech's game/** covers nearly
+    everything under game/ and naming tech for a .png whose real owner is
+    art's game/assets/** would route every asset to the wrong seat. Longest
+    matching glob wins; table order breaks ties. Never raises: it feeds
+    refusal messages, and a routing hint must not be able to break the
+    refusal.
+    """
+    rel = str(path).replace("\\", "/").lstrip("/")
+    try:
+        table = roles_for(root)
+    except Exception:
+        return []
+    matched: list[tuple[int, int, str]] = []
+    for order, (role, cfg) in enumerate(table.items()):
+        hits = [g for g in cfg.get("write_globs", []) if _glob_re(g).match(rel)]
+        if hits:
+            matched.append((-max(len(g) for g in hits), order, role))
+    return [role for _len, _order, role in sorted(matched)]
+
+
 # ---------------------------------------------------------------------------
 # The brief — everything a seat needs, one call
 # ---------------------------------------------------------------------------
@@ -1048,6 +1177,7 @@ MAX_ARTIFACTS = 20
 MAX_CANON = 30
 MAX_FEEDBACK = 12
 MAX_LOCKS = 25
+MAX_BOARD = 15           # open work items shown — the peer-awareness slice
 MAX_SECTIONS = 14        # bible sections quoted in a brief
 BODY_CHARS = 600         # per bible section
 NOTE_CHARS = 300         # per blackboard note
@@ -1109,6 +1239,7 @@ def _fit(payload: dict) -> dict:
                                     (payload.get("approved_artifacts") or [])[:8]),
         lambda: payload.__setitem__("canon", (payload.get("canon") or [])[:12]),
         lambda: payload.__setitem__("notes", (payload.get("notes") or [])[:4]),
+        lambda: payload.__setitem__("board", (payload.get("board") or [])[:6]),
         lambda: trim_bible(120),
         lambda: trim_refs(8),
         lambda: payload.__setitem__(
@@ -1368,6 +1499,20 @@ def brief(root: str | os.PathLike[str], role: str, note_limit: int = 10) -> dict
         if len(body) > NOTE_CHARS:
             note["body"] = body[:NOTE_CHARS] + "…[seat_notes for the whole note]"
 
+    # THE BOARD — what every other agent is queued for or working on right now.
+    # A worker with no view of its peers duplicates work, edits files a
+    # dispatched run owns, and dead-ends at walls another seat's queued item
+    # would have explained. 'dispatched' first because a LIVE peer is the one
+    # you must not collide with; queue_list pages the rest.
+    board = rows(conn.execute(
+        "SELECT id, seat, title, status, priority, source, chain_id, "
+        "chain_pos, depends_on, actor FROM work_item "
+        "WHERE status IN ('queued', 'dispatched', 'review') "
+        "ORDER BY CASE status WHEN 'dispatched' THEN 0 WHEN 'queued' THEN 1 "
+        "ELSE 2 END, priority DESC, id LIMIT 40"))
+    for entry in board:
+        entry["title"] = str(entry.get("title") or "")[:120]
+
     return _fit({
         "role": role,
         "your_role": SEAT_IDENTITY,
@@ -1389,6 +1534,7 @@ def brief(root: str | os.PathLike[str], role: str, note_limit: int = 10) -> dict
                              for a in locked if a["lock_seat"] != role],
                             MAX_LOCKS, "asset_status (others)"),
         "notes": notes,
+        "board": cap(board, MAX_BOARD, "queue_list"),
         "truncated": truncated,
         # Bugs that have already been paid for, gated to this seat and this
         # project's dimension. See TRAPS for why they are in the brief and not
@@ -1415,7 +1561,10 @@ def brief(root: str | os.PathLike[str], role: str, note_limit: int = 10) -> dict
             "A NOTE IS A BULLETIN; A QUEUE ITEM IS A JOB. If another seat has "
             "to DO something because of your work, queue_add(that seat, title, "
             "brief) - that dispatches. seat_post_note is only for what nobody "
-            "has to act on. Handing the work on IS part of finishing yours.",
+            "has to act on. Handing the work on IS part of finishing yours. "
+            "Pass depends_on=<your item id> when it needs your output - two "
+            "ready items start in the same tick, and only a dependency stops "
+            "that.",
             # The kill-tax rule: agents die mid-flight constantly (interrupts are
             # normal usage). A successor must resume from ONE file read, never
             # from archaeology.

--- a/bgate_core/settings.py
+++ b/bgate_core/settings.py
@@ -202,6 +202,17 @@ SETTINGS: tuple[Setting, ...] = (
              "because the resulting diff cannot tell the agent's edits from "
              "yours — which is what makes a revert safe."),
     Setting(
+        key="dispatch.auto_commit", group="Dispatch", kind=BOOL, default=True,
+        store=("registry", "dispatch.auto_commit"), scope=MACHINE,
+        env="BGATE_AUTO_COMMIT", human_only=True,
+        help="Commit each finished run's OWN files, so the next dispatch is "
+             "not refused by the dirty tree the last one made. On, because "
+             "with it off nothing ever commits and the board deadlocks after "
+             "the first item that writes anything — measured: an overnight "
+             "queue of thirty finished three. It commits only the paths that "
+             "run touched, so your own uncommitted work is never swept in "
+             "(and still, correctly, blocks the next dispatch)."),
+    Setting(
         key="dispatch.isolation", group="Dispatch", kind=BOOL, default=False,
         store=("registry", "dispatch.isolation"), scope=MACHINE,
         env="BGATE_GIT_ISOLATION",

--- a/bgate_core/sfx.py
+++ b/bgate_core/sfx.py
@@ -1,0 +1,692 @@
+"""Procedural game SFX — synthesis, and the recipe that rebuilds the render.
+
+WHY SYNTHESIS AND NOT A PROVIDER. The audio seat's mission opens "Own SFX and
+music hooks" and every audio tool it had was a paid one — hosted music, hosted
+speech — so a project with no key could not produce a single game sound. SFX are
+the one asset class where that is not a compromise: a coin pickup, a laser, a
+jump are four oscillator parameters and an envelope, and a synthesized one is
+SHORTER, cleaner, loopable, and adjustable by the knob you wanted to move. A
+generated one is a 3-second stereo clip of a room with a coin in it. So this
+module has no provider, no key, no network, and no failure mode that begins
+"the API".
+
+THE RECIPE IS THE ASSET; THE WAV IS A RENDER OF IT. dispatch.SEAT_RULES["audio"]
+requires every synthesized asset to ship a ``<name>.synth.json`` sidecar holding
+the full parametric recipe, because a .wav whose knobs are lost is a dead end —
+nobody can nudge the decay of a file. Everything needed to reproduce the exact
+bytes lives in that sidecar: sample rate, master peak, seed, and every layer's
+wave/sweep/envelope/filter. :func:`rerender` takes the sidecar ALONE and gets
+the same file back, which is the property that makes the rule real rather than
+aspirational.
+
+DETERMINISM. The only non-arithmetic input is the noise stream, and it is a
+``random.Random(seed)`` derived per layer from the recipe's seed — never the
+module-level RNG, whose sequence depends on everything else the process did.
+The seed itself defaults to a hash of ``kind:name``, so regenerating "coin"
+tomorrow produces the identical file rather than a near-miss nobody can diff.
+The recipe carries no timestamp for the same reason: two runs must produce two
+identical sidecars, or the sidecar is not a recipe, it is a log entry.
+
+Pure stdlib (``wave``, ``math``, ``random``, ``array``). 16-bit mono PCM,
+because that is what Godot's WAV importer accepts — AudioStreamWAV is 8/16-bit
+PCM (or IMA-ADPCM/QOA), and a float WAV imports as silence with no error.
+
+Waveforms are NAIVE, not band-limited. The aliasing is the sound: a band-limited
+square at 200 Hz is a polite sine, and what a 2D game wants is the buzz.
+"""
+from __future__ import annotations
+
+import array
+import hashlib
+import io
+import json
+import math
+import os
+import random
+import sys
+import wave
+from pathlib import Path
+from typing import Optional
+
+from .project import game_dir
+
+RECIPE_VERSION = 1
+GENERATOR = "bgate.sfx/1"
+
+DEFAULT_RATE = 44100
+# 44100 rather than a retro 22050: these files get mixed and trimmed next to
+# music in the audio lab, and one rate through the whole project means nothing
+# downstream has to resample (audiolab's mixer sessions default to 44100 too).
+
+WAVES = ("sine", "square", "saw", "triangle", "noise")
+SWEEPS = ("exp", "lin")
+
+MAX_SECONDS = 10.0            # an SFX past this is music; use the music path
+MAX_LAYERS = 12
+MIN_RATE, MAX_RATE = 8000, 48000
+MAX_NAME = 48
+
+SIDECAR_SUFFIX = ".synth.json"
+
+
+class SfxError(ValueError):
+    """A recipe or a name this module refuses to render."""
+
+
+# ---------------------------------------------------------------------------
+# Presets — the kinds a game actually asks for
+# ---------------------------------------------------------------------------
+# Each entry is (description, nominal seconds, base Hz, layer list). The layers
+# are TEMPLATES: base_hz scales every tonal frequency and duration_s scales
+# every time, so `sfx_generate("laser", base_hz=600)` is a bigger gun rather
+# than a different tool. Frequencies below are written as MULTIPLES of the
+# preset's base so that scaling is one multiplication and not a table of
+# special cases.
+_PRESETS: dict[str, dict] = {
+    "blip": {
+        "about": "UI select/confirm — one short square beep. Menus, cursors.",
+        "base_hz": 880.0,
+        "layers": [
+            {"wave": "square", "duty": 0.5, "start_s": 0.0, "duration_s": 0.075,
+             "freq_start": 1.0, "attack_s": 0.002, "release_s": 0.05,
+             "sustain": 0.85, "gain": 0.7},
+        ],
+    },
+    "pickup": {
+        "about": "Coin/pickup — a short blip that steps up a fifth and rings.",
+        "base_hz": 660.0,
+        "layers": [
+            {"wave": "square", "duty": 0.5, "start_s": 0.0, "duration_s": 0.055,
+             "freq_start": 1.0, "attack_s": 0.002, "release_s": 0.012,
+             "gain": 0.6},
+            {"wave": "square", "duty": 0.5, "start_s": 0.052, "duration_s": 0.30,
+             "freq_start": 1.5, "attack_s": 0.002, "release_s": 0.24,
+             "sustain": 0.8, "gain": 0.6},
+        ],
+    },
+    "jump": {
+        "about": "Jump — square with a fast rising sweep. Platformer takeoff.",
+        "base_hz": 200.0,
+        "layers": [
+            {"wave": "square", "duty": 0.45, "start_s": 0.0, "duration_s": 0.22,
+             "freq_start": 1.0, "freq_end": 3.2, "sweep": "exp",
+             "attack_s": 0.004, "release_s": 0.13, "sustain": 0.75, "gain": 0.7},
+        ],
+    },
+    "laser": {
+        "about": "Laser/shoot — falling saw sweep under a closing filter.",
+        "base_hz": 1400.0,
+        "layers": [
+            {"wave": "saw", "start_s": 0.0, "duration_s": 0.28,
+             "freq_start": 1.0, "freq_end": 0.13, "sweep": "exp",
+             "attack_s": 0.002, "release_s": 0.22, "sustain": 0.7,
+             "lowpass_start_hz": 6000.0, "lowpass_end_hz": 900.0, "gain": 0.65},
+        ],
+    },
+    "explosion": {
+        "about": "Explosion — filtered noise burst over a falling sine thump.",
+        "base_hz": 120.0,
+        "layers": [
+            {"wave": "noise", "start_s": 0.0, "duration_s": 0.90,
+             "attack_s": 0.004, "decay_s": 0.10, "sustain": 0.55,
+             "release_s": 0.75,
+             "lowpass_start_hz": 4200.0, "lowpass_end_hz": 180.0, "gain": 0.9},
+            {"wave": "sine", "start_s": 0.0, "duration_s": 0.50,
+             "freq_start": 1.0, "freq_end": 0.33, "sweep": "exp",
+             "attack_s": 0.002, "release_s": 0.46, "gain": 0.8},
+        ],
+    },
+    "hit": {
+        "about": "Hit/thud — a clipped noise transient on a low triangle body.",
+        "base_hz": 170.0,
+        "layers": [
+            {"wave": "noise", "start_s": 0.0, "duration_s": 0.085,
+             "attack_s": 0.001, "release_s": 0.07, "sustain": 0.5,
+             "lowpass_start_hz": 3200.0, "lowpass_end_hz": 700.0, "gain": 0.7},
+            {"wave": "triangle", "start_s": 0.0, "duration_s": 0.16,
+             "freq_start": 1.0, "freq_end": 0.42, "sweep": "exp",
+             "attack_s": 0.001, "release_s": 0.14, "gain": 0.85},
+        ],
+    },
+    "powerup": {
+        "about": "Powerup — an ascending arpeggio that lands on a ringing top.",
+        "base_hz": 330.0,
+        "layers": [
+            {"wave": "square", "duty": 0.5, "start_s": 0.00, "duration_s": 0.07,
+             "freq_start": 1.0, "attack_s": 0.002, "release_s": 0.02, "gain": 0.5},
+            {"wave": "square", "duty": 0.5, "start_s": 0.07, "duration_s": 0.07,
+             "freq_start": 1.26, "attack_s": 0.002, "release_s": 0.02, "gain": 0.5},
+            {"wave": "square", "duty": 0.5, "start_s": 0.14, "duration_s": 0.07,
+             "freq_start": 1.50, "attack_s": 0.002, "release_s": 0.02, "gain": 0.5},
+            {"wave": "square", "duty": 0.5, "start_s": 0.21, "duration_s": 0.36,
+             "freq_start": 2.0, "attack_s": 0.002, "release_s": 0.30,
+             "sustain": 0.8, "vibrato_hz": 14.0, "vibrato_cents": 25.0,
+             "gain": 0.55},
+        ],
+    },
+    "sweep": {
+        "about": "Rising whoosh — filtered noise sweeping up. Transitions, dashes.",
+        "base_hz": 300.0,
+        "layers": [
+            {"wave": "noise", "start_s": 0.0, "duration_s": 0.55,
+             "attack_s": 0.20, "sustain": 1.0, "release_s": 0.18,
+             "lowpass_start_hz": 400.0, "lowpass_end_hz": 5200.0, "gain": 0.8},
+        ],
+    },
+}
+
+# The words people reach for that are not the preset's name. A kind nobody can
+# spell is a kind nobody uses, and "shoot" is what a designer writes on a card.
+ALIASES = {
+    "select": "blip", "beep": "blip", "click": "blip", "menu": "blip",
+    "coin": "pickup", "collect": "pickup", "gem": "pickup",
+    "shoot": "laser", "shot": "laser", "zap": "laser", "fire": "laser",
+    "boom": "explosion", "blast": "explosion", "noise_burst": "explosion",
+    "thud": "hit", "punch": "hit", "impact": "hit", "hurt": "hit",
+    "power_up": "powerup", "levelup": "powerup", "level_up": "powerup",
+    "whoosh": "sweep", "dash": "sweep", "transition": "sweep",
+}
+
+KINDS = tuple(_PRESETS)
+
+
+def kinds() -> list[dict]:
+    """Every kind, what it is for, and how long it comes out by default."""
+    out = []
+    for kind, preset in _PRESETS.items():
+        length = max(l.get("start_s", 0.0) + l.get("duration_s", 0.0)
+                     for l in preset["layers"])
+        out.append({
+            "kind": kind,
+            "about": preset["about"],
+            "seconds": round(length, 3),
+            "base_hz": preset["base_hz"],
+            "layers": len(preset["layers"]),
+            "aliases": sorted(a for a, k in ALIASES.items() if k == kind),
+        })
+    return out
+
+
+def resolve_kind(kind: str) -> str:
+    """Preset name for what the caller asked for. Raises naming the options."""
+    key = str(kind or "").strip().lower().replace("-", "_").replace(" ", "_")
+    key = ALIASES.get(key, key)
+    if key not in _PRESETS:
+        raise SfxError(f"no SFX kind {kind!r} — known kinds: {', '.join(KINDS)} "
+                       f"(aliases: {', '.join(sorted(ALIASES))})")
+    return key
+
+
+# ---------------------------------------------------------------------------
+# Recipes
+# ---------------------------------------------------------------------------
+def default_seed(kind: str, name: str) -> int:
+    """A seed derived from what this sound IS, not from the clock.
+
+    Regenerating "coin" next week has to produce the identical file — otherwise
+    every re-run is a diff nobody asked for, and the sidecar stops being a
+    recipe. sha256 rather than hash(): PYTHONHASHSEED randomises str hashing per
+    process, so hash() would have made the DEFAULT non-deterministic across runs
+    while looking fine inside one.
+    """
+    digest = hashlib.sha256(f"{kind}:{name}".encode("utf-8")).digest()
+    return int.from_bytes(digest[:4], "big")
+
+
+def _num(raw: dict, key: str, lo: float, hi: float, default: float,
+         where: str) -> float:
+    try:
+        value = float(raw.get(key, default))
+    except (TypeError, ValueError):
+        raise SfxError(f"{where}.{key} is not a number")
+    if not lo <= value <= hi:
+        raise SfxError(f"{where}.{key} is out of range [{lo}, {hi}]")
+    return value
+
+
+def _layer(raw: dict, index: int) -> dict:
+    """One validated layer. Every bound here is real — an unclamped release
+    longer than the layer silently produced a click at the join."""
+    where = f"layers[{index}]"
+    if not isinstance(raw, dict):
+        raise SfxError(f"{where} must be an object")
+    shape = str(raw.get("wave") or "sine")
+    if shape not in WAVES:
+        raise SfxError(f"{where}.wave must be one of {WAVES}")
+    sweep = str(raw.get("sweep") or "exp")
+    if sweep not in SWEEPS:
+        raise SfxError(f"{where}.sweep must be one of {SWEEPS}")
+    # freq_end 0 means "no sweep" rather than "sweep to DC": an exponential
+    # sweep to zero has no finite ratio, and a linear one ends in silence.
+    freq_start = _num(raw, "freq_start", 1.0, 20000.0, 440.0, where)
+    freq_end = _num(raw, "freq_end", 0.0, 20000.0, 0.0, where)
+    return {
+        "wave": shape,
+        "start_s": _num(raw, "start_s", 0.0, MAX_SECONDS, 0.0, where),
+        "duration_s": _num(raw, "duration_s", 0.001, MAX_SECONDS, 0.2, where),
+        "freq_start": freq_start,
+        "freq_end": freq_end,
+        "sweep": sweep,
+        "duty": _num(raw, "duty", 0.05, 0.95, 0.5, where),
+        "gain": _num(raw, "gain", 0.0, 1.0, 0.7, where),
+        "attack_s": _num(raw, "attack_s", 0.0, MAX_SECONDS, 0.005, where),
+        "decay_s": _num(raw, "decay_s", 0.0, MAX_SECONDS, 0.0, where),
+        "sustain": _num(raw, "sustain", 0.0, 1.0, 1.0, where),
+        "release_s": _num(raw, "release_s", 0.0, MAX_SECONDS, 0.05, where),
+        "noise_mix": _num(raw, "noise_mix", 0.0, 1.0, 0.0, where),
+        "vibrato_hz": _num(raw, "vibrato_hz", 0.0, 200.0, 0.0, where),
+        "vibrato_cents": _num(raw, "vibrato_cents", 0.0, 1200.0, 0.0, where),
+        "lowpass_start_hz": _num(raw, "lowpass_start_hz", 0.0, 20000.0, 0.0, where),
+        "lowpass_end_hz": _num(raw, "lowpass_end_hz", 0.0, 20000.0, 0.0, where),
+        # 0 = off. Anything from 3 to 8 is the retro sound on purpose.
+        "bits": int(_num(raw, "bits", 0, 16, 0, where)),
+    }
+
+
+def normalise(data: dict) -> dict:
+    """Validate a recipe. This is the copy that runs when the payload did not
+    come from :func:`recipe` — a hand-edited sidecar is a supported input."""
+    if not isinstance(data, dict):
+        raise SfxError("a recipe must be an object")
+    version = int(data.get("version") or RECIPE_VERSION)
+    if version > RECIPE_VERSION:
+        raise SfxError(
+            f"recipe version {version} was written by a newer Builders Gate "
+            f"than this one (understands {RECIPE_VERSION})")
+    raw_layers = data.get("layers") or []
+    if not raw_layers:
+        raise SfxError("a recipe needs at least one layer")
+    if len(raw_layers) > MAX_LAYERS:
+        raise SfxError(f"{len(raw_layers)} layers; the cap is {MAX_LAYERS}")
+    layers = [_layer(raw, i) for i, raw in enumerate(raw_layers)]
+
+    rate = int(data.get("sample_rate") or DEFAULT_RATE)
+    if not MIN_RATE <= rate <= MAX_RATE:
+        raise SfxError(f"sample rate {rate} is outside {MIN_RATE}-{MAX_RATE}")
+    total = max(l["start_s"] + l["duration_s"] for l in layers)
+    if total > MAX_SECONDS:
+        raise SfxError(f"{total:.2f}s of sound; the cap is {MAX_SECONDS:.0f}s — "
+                       "anything longer is music, not an effect")
+    kind = str(data.get("kind") or "custom")
+    return {
+        "version": RECIPE_VERSION,
+        "generator": GENERATOR,
+        "kind": kind,
+        "name": str(data.get("name") or kind)[:MAX_NAME],
+        "sample_rate": rate,
+        "seed": int(data.get("seed", default_seed(kind, str(data.get("name") or ""))))
+                & 0xFFFFFFFF,
+        "peak": _num(data, "peak", 0.05, 1.0, 0.89, "recipe"),
+        # Every render ends on a ramp to zero. A hard cut at a non-zero sample
+        # is a click, and a click on a sound that fires ten times a second is
+        # the thing that makes a game sound cheap.
+        "tail_fade_s": _num(data, "tail_fade_s", 0.0, 0.5, 0.004, "recipe"),
+        "seconds": round(total, 4),
+        "layers": layers,
+    }
+
+
+def recipe(kind: str, *, name: str = "", seed: Optional[int] = None,
+           base_hz: float = 0.0, duration_s: float = 0.0, gain: float = 1.0,
+           sample_rate: int = DEFAULT_RATE, bits: int = 0) -> dict:
+    """A full, self-contained recipe for one preset, with the knobs applied.
+
+    base_hz and duration_s SCALE the preset rather than replacing it: every
+    tonal frequency is a multiple of the preset's base and every time is a
+    fraction of its nominal length, so a laser at base_hz=600 is the same
+    gesture from a bigger gun instead of an unrelated sound.
+    """
+    resolved = resolve_kind(kind)
+    preset = _PRESETS[resolved]
+    label = str(name or resolved)[:MAX_NAME]
+
+    base = float(base_hz) if base_hz and base_hz > 0 else float(preset["base_hz"])
+    nominal = max(l.get("start_s", 0.0) + l.get("duration_s", 0.0)
+                  for l in preset["layers"])
+    stretch = (float(duration_s) / nominal) if duration_s and duration_s > 0 else 1.0
+    if stretch <= 0:
+        raise SfxError("duration_s must be positive")
+    level = float(gain) if gain and gain > 0 else 1.0
+
+    layers = []
+    for template in preset["layers"]:
+        layer = dict(template)
+        for key in ("start_s", "duration_s", "attack_s", "decay_s", "release_s"):
+            if key in layer:
+                layer[key] = layer[key] * stretch
+        for key in ("freq_start", "freq_end"):
+            if layer.get(key):
+                layer[key] = layer[key] * base
+        # A noise layer has no pitch, and _layer's floor on freq_start would
+        # reject the 0.0 the template omits — give it the base and ignore it.
+        layer.setdefault("freq_start", base)
+        layer["gain"] = min(1.0, layer.get("gain", 0.7) * level)
+        if bits:
+            layer["bits"] = int(bits)
+        layers.append(layer)
+
+    return normalise({
+        "kind": resolved,
+        "name": label,
+        "sample_rate": int(sample_rate or DEFAULT_RATE),
+        "seed": default_seed(resolved, label) if seed is None else int(seed),
+        "layers": layers,
+    })
+
+
+# ---------------------------------------------------------------------------
+# Synthesis
+# ---------------------------------------------------------------------------
+def _envelope(t: float, dur: float, attack: float, decay: float,
+              sustain: float, release: float) -> float:
+    """ADSR sampled at t seconds into a layer of `dur` seconds.
+
+    A/D/R are scaled down together when they overrun the layer, rather than
+    truncated: truncating the release is exactly the hard cut that clicks.
+    """
+    span = attack + decay + release
+    if span > dur and span > 0:
+        scale = dur / span
+        attack, decay, release = attack * scale, decay * scale, release * scale
+    if attack > 0 and t < attack:
+        return t / attack
+    if decay > 0 and t < attack + decay:
+        return 1.0 + (sustain - 1.0) * ((t - attack) / decay)
+    # No decay stage means the sustain level applies the moment the attack
+    # finishes, which is the shape every one-shot preset here wants: a blip is
+    # a step, not a ramp to a plateau it never reaches.
+    level = sustain
+    tail = dur - release
+    if release > 0 and t >= tail:
+        return level * max(0.0, (dur - t) / release)
+    return level
+
+
+def _osc(shape: str, phase: float, duty: float, rng: random.Random) -> float:
+    if shape == "noise":
+        return rng.uniform(-1.0, 1.0)
+    p = phase % 1.0
+    if shape == "sine":
+        return math.sin(2.0 * math.pi * p)
+    if shape == "square":
+        return 1.0 if p < duty else -1.0
+    if shape == "saw":
+        return 2.0 * p - 1.0
+    return 4.0 * abs(p - 0.5) - 1.0            # triangle
+
+
+def _layer_samples(layer: dict, rate: int, seed: int, index: int) -> list[float]:
+    """Render one layer to float samples in [-1, 1]."""
+    count = max(1, int(round(layer["duration_s"] * rate)))
+    # Per-layer stream, derived from the recipe seed. Never the module RNG:
+    # its sequence depends on everything else the process did, which would make
+    # two identical recipes render two different explosions.
+    rng = random.Random((seed * 1000003 + index) & 0xFFFFFFFF)
+    noise_rng = random.Random((seed * 2654435761 + index * 97 + 7) & 0xFFFFFFFF)
+
+    shape = layer["wave"]
+    f0 = layer["freq_start"]
+    f1 = layer["freq_end"]
+    swept = f1 > 0.0 and f1 != f0
+    exp_sweep = layer["sweep"] == "exp"
+    duty, gain = layer["duty"], layer["gain"]
+    vib_hz, vib_cents = layer["vibrato_hz"], layer["vibrato_cents"]
+    lp0, lp1 = layer["lowpass_start_hz"], layer["lowpass_end_hz"]
+    filtered = lp0 > 0.0 or lp1 > 0.0
+    if filtered:                       # one end left at 0 means "hold the other"
+        lp0 = lp0 or lp1
+        lp1 = lp1 or lp0
+    quant = (1 << (layer["bits"] - 1)) if layer["bits"] >= 2 else 0
+
+    dt = 1.0 / rate
+    out: list[float] = []
+    phase = 0.0
+    filter_state = 0.0
+    span = max(1, count - 1)
+    for i in range(count):
+        t = i * dt
+        progress = i / span
+        if swept:
+            freq = (f0 * (f1 / f0) ** progress if exp_sweep
+                    else f0 + (f1 - f0) * progress)
+        else:
+            freq = f0
+        if vib_hz > 0.0 and vib_cents > 0.0:
+            freq *= 2.0 ** ((vib_cents / 1200.0)
+                            * math.sin(2.0 * math.pi * vib_hz * t))
+        value = _osc(shape, phase, duty, rng)
+        phase += freq * dt
+        if layer["noise_mix"] > 0.0:
+            value = ((1.0 - layer["noise_mix"]) * value
+                     + layer["noise_mix"] * noise_rng.uniform(-1.0, 1.0))
+        if filtered:
+            cutoff = lp0 + (lp1 - lp0) * progress
+            # One-pole RC lowpass, coefficient recomputed per sample so the
+            # cutoff can sweep — the closing filter IS the explosion.
+            rc = 1.0 / (2.0 * math.pi * max(cutoff, 1.0))
+            alpha = dt / (rc + dt)
+            filter_state += alpha * (value - filter_state)
+            value = filter_state
+        value *= _envelope(t, layer["duration_s"], layer["attack_s"],
+                           layer["decay_s"], layer["sustain"],
+                           layer["release_s"]) * gain
+        if quant:
+            value = round(value * quant) / quant
+        out.append(value)
+    return out
+
+
+def render(data: dict) -> bytes:
+    """Recipe -> 16-bit mono PCM WAV bytes. The whole render path, no I/O."""
+    rec = normalise(data)
+    rate = rec["sample_rate"]
+    total = int(round(rec["seconds"] * rate)) + 1
+    buf = [0.0] * total
+
+    for index, layer in enumerate(rec["layers"]):
+        start = int(round(layer["start_s"] * rate))
+        for offset, value in enumerate(_layer_samples(layer, rate, rec["seed"],
+                                                      index)):
+            at = start + offset
+            if 0 <= at < total:
+                buf[at] += value
+
+    peak = max((abs(v) for v in buf), default=0.0)
+    if peak > 0.0:
+        # Normalised rather than clipped. Summed layers routinely exceed 1.0,
+        # and clipping a mix is the difference between a punchy hit and a
+        # crunch — one gain stage at the end keeps every kind at one loudness.
+        scale = rec["peak"] / peak
+        buf = [v * scale for v in buf]
+
+    fade = min(int(round(rec["tail_fade_s"] * rate)), total)
+    for n in range(fade):
+        buf[total - fade + n] *= (fade - 1 - n) / max(fade - 1, 1)
+
+    pcm = array.array(
+        "h", (max(-32768, min(32767, int(round(v * 32767.0)))) for v in buf))
+    if sys.byteorder == "big":
+        pcm.byteswap()               # WAV is little-endian, this host may not be
+    out = io.BytesIO()
+    with wave.open(out, "wb") as handle:
+        handle.setnchannels(1)
+        handle.setsampwidth(2)
+        handle.setframerate(rate)
+        handle.writeframes(pcm.tobytes())
+    return out.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Files — the wav, and the sidecar that can rebuild it
+# ---------------------------------------------------------------------------
+def sidecar_path(wav: str | os.PathLike[str]) -> Path:
+    """coin.wav -> coin.synth.json.
+
+    Keyed on the STEM, unlike audiolab's mix sessions which key on the whole
+    filename to survive a wav/ogg pair of one track. The audio house rule spells
+    this one ``<name>.synth.json`` verbatim, and an SFX has exactly one render,
+    so there is no pair to collide.
+    """
+    return Path(wav).with_suffix(SIDECAR_SUFFIX)
+
+
+def safe_name(name: str) -> str:
+    """A filename that cannot escape the directory it was aimed at."""
+    cleaned = "".join(c if (c.isalnum() or c in "-_") else "_"
+                      for c in str(name or "").strip())[:MAX_NAME].strip("_")
+    if not cleaned:
+        raise SfxError("a name is required — it becomes the .wav filename")
+    return cleaned
+
+
+def sfx_dir(root: str | os.PathLike[str]) -> Path:
+    """Where SFX land: inside the AUDIO SEAT'S OWN LANE, for both layouts.
+
+    ``bgate init`` puts project.godot at the root and godot_scaffold puts it in
+    ``<root>/game``; seats.lanes_for_layout re-roots the lane globs to match, so
+    the same directory relative to the GODOT project is inside the lane either
+    way. Hardcoding "game/assets/audio" would have written outside the lane —
+    and been refused by the write hook — for every CLI-created project.
+    """
+    base = game_dir(root) or (Path(root) / "game")
+    return base / "assets" / "audio" / "sfx"
+
+
+def write(rec: dict, wav_path: str | os.PathLike[str]) -> dict:
+    """Render a recipe to disk and drop its ``<name>.synth.json`` beside it.
+
+    The sidecar is written FIRST-CLASS, not best-effort: an audio asset without
+    its recipe violates the seat's house rule and is a file nobody can adjust,
+    so a sidecar that cannot be written fails the whole call rather than leaving
+    an orphan wav behind.
+    """
+    rec = normalise(rec)
+    target = Path(wav_path)
+    if target.suffix.lower() != ".wav":
+        raise SfxError(f"{target.name} — synthesis writes .wav (16-bit mono PCM, "
+                       "which is what Godot's WAV importer accepts)")
+    audio = render(rec)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    sidecar = sidecar_path(target)
+    try:
+        target.write_bytes(audio)
+        sidecar.write_text(json.dumps(rec, indent=2) + "\n", encoding="utf-8")
+    except OSError as exc:
+        raise SfxError(f"could not write {target.name}: {exc}") from exc
+    return {
+        "path": str(target),
+        "recipe_path": str(sidecar),
+        "bytes": len(audio),
+        "seconds": rec["seconds"],
+        "sample_rate": rec["sample_rate"],
+        "seed": rec["seed"],
+        "recipe": rec,
+    }
+
+
+def generate(root: str | os.PathLike[str], kind: str, name: str, *,
+             out_dir: Optional[str] = None, seed: Optional[int] = None,
+             base_hz: float = 0.0, duration_s: float = 0.0, gain: float = 1.0,
+             sample_rate: int = DEFAULT_RATE, bits: int = 0) -> dict:
+    """Synthesize one SFX into the project, with its recipe beside it."""
+    label = safe_name(name)
+    rec = recipe(kind, name=label, seed=seed, base_hz=base_hz,
+                 duration_s=duration_s, gain=gain, sample_rate=sample_rate,
+                 bits=bits)
+    directory = Path(out_dir) if out_dir else sfx_dir(root)
+    if not directory.is_absolute():
+        directory = Path(root) / directory
+    result = write(rec, directory / f"{label}.wav")
+    result["kind"] = rec["kind"]
+    result["name"] = label
+    result["rel_path"] = _relative(root, result["path"])
+    result["recipe_rel_path"] = _relative(root, result["recipe_path"])
+    # The res:// path is what a designer pastes into a scene, and computing it
+    # from the GODOT project (not the bgate root) is the only version that is
+    # right for both layouts.
+    result["res_path"] = _res_path(root, result["path"])
+    return result
+
+
+def rerender(recipe_path: str | os.PathLike[str],
+             out_path: Optional[str] = None) -> dict:
+    """Rebuild the wav from the SIDECAR ALONE — the property the rule demands.
+
+    Reports ``identical``: whether the bytes match what is already on disk. That
+    is the assertion that keeps the recipe honest, because a recipe that renders
+    something ELSE is worse than no recipe at all — it looks like provenance.
+    """
+    path = Path(recipe_path)
+    if not path.is_file():
+        raise SfxError(f"no recipe at {path}")
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise SfxError(f"{path.name} is unreadable: {exc}") from exc
+    rec = normalise(raw)
+
+    target = (Path(out_path) if out_path
+              else path.with_name(path.name[:-len(SIDECAR_SUFFIX)] + ".wav"))
+    before = target.read_bytes() if target.is_file() else b""
+    audio = render(rec)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(audio)
+    return {
+        "path": str(target),
+        "recipe_path": str(path),
+        "bytes": len(audio),
+        "seconds": rec["seconds"],
+        "kind": rec["kind"],
+        "name": rec["name"],
+        "identical": bool(before) and before == audio,
+        "had_previous": bool(before),
+        "recipe": rec,
+    }
+
+
+def list_sfx(root: str | os.PathLike[str],
+             directory: Optional[str] = None) -> list[dict]:
+    """Every synthesized effect in the project's SFX directory, recipe or not.
+
+    A wav with no sidecar is REPORTED rather than hidden: it is precisely the
+    file the house rule exists to prevent, and the seat can only fix what it can
+    see.
+    """
+    base = Path(directory) if directory else sfx_dir(root)
+    if not base.is_dir():
+        return []
+    out = []
+    for wav in sorted(base.glob("*.wav")):
+        sidecar = sidecar_path(wav)
+        entry = {"name": wav.stem, "path": str(wav),
+                 "rel_path": _relative(root, str(wav)),
+                 "bytes": wav.stat().st_size,
+                 "has_recipe": sidecar.is_file(), "kind": "", "seconds": None}
+        if sidecar.is_file():
+            try:
+                rec = json.loads(sidecar.read_text(encoding="utf-8"))
+                entry["kind"] = str(rec.get("kind") or "")
+                entry["seconds"] = rec.get("seconds")
+                entry["recipe_path"] = str(sidecar)
+            except (OSError, ValueError):
+                entry["has_recipe"] = False
+        out.append(entry)
+    return out
+
+
+def _relative(root: str | os.PathLike[str], path: str) -> str:
+    try:
+        return Path(path).resolve().relative_to(Path(root).resolve()).as_posix()
+    except ValueError:
+        return str(path)
+
+
+def _res_path(root: str | os.PathLike[str], path: str) -> str:
+    base = game_dir(root)
+    if base is None:
+        return ""
+    try:
+        return "res://" + Path(path).resolve().relative_to(
+            Path(base).resolve()).as_posix()
+    except ValueError:
+        return ""

--- a/bgate_core/spend.py
+++ b/bgate_core/spend.py
@@ -48,6 +48,22 @@ API, SUBSCRIPTION = "api", "subscription"
 BILLING = (API, SUBSCRIPTION)
 
 # Agent sessions run on the subscription; everything else buys from a vendor.
+#
+# UNCONDITIONAL, AND THAT IS THE DECISION RATHER THAN AN OVERSIGHT (2026-08-11).
+# It means agent runs never count against per_day_usd / per_project_usd, which
+# reads like a hole in the ceiling and has been reported as one. It is not:
+# every agent this harness spawns today runs on a subscription CLI, so its
+# dollar figure is the API-EQUIVALENT price of work already paid for, and
+# summing it into a budget meant an afternoon of uncharged agent work refused
+# an image generation that would have cost real money.
+#
+# WHAT WOULD CHANGE IT: a direct-API or local-model runner, which is wanted and
+# not built. When one exists, billing becomes a property of the RUNNER rather
+# than of the kind — the row is already shaped for that (spend_event.billing is
+# per row, not per kind) and `totals` already reports agent runs separately, so
+# the change is here and in the runner table, not in the schema.
+#
+# Until then this line is deliberate. Do not "fix" it.
 _BILLING_FOR_KIND = {"agent": SUBSCRIPTION}
 
 
@@ -73,7 +89,8 @@ def set_budget(root: str | os.PathLike[str], **fields) -> dict:
 
 def record(root: str | os.PathLike[str], usd: float, *, kind: str = "agent",
            work_item_id: Optional[int] = None, logical_name: str = "",
-           detail: str = "", model: str = "", tokens: Optional[dict] = None) -> None:
+           detail: str = "", model: str = "", tokens: Optional[dict] = None,
+           seat: str = "") -> None:
     """Append a spend event. Never raises — losing the ledger must not lose the
     work that produced it.
 
@@ -95,16 +112,22 @@ def record(root: str | os.PathLike[str], usd: float, *, kind: str = "agent",
     if kind not in KINDS:
         kind = "other"
     billing = _BILLING_FOR_KIND.get(kind, API)
+    # WHO SPENT IT, taken from the environment when the caller did not say.
+    # Every paid tool runs inside a seat's MCP server process (BGATE_SEAT is
+    # set by dispatch), so the attribution is available for free at the one
+    # place that writes the row — which is why nearly every call site can stay
+    # unchanged and still start answering "which seat is expensive".
+    seat = (seat or os.environ.get("BGATE_SEAT", "") or "").strip()[:32]
     try:
         with db.tx(root) as conn:
             conn.execute(
                 "INSERT INTO spend_event (kind, billing, work_item_id, "
                 "logical_name, usd, detail, model, input_tokens, output_tokens, "
-                "cache_read_tokens, cache_write_tokens) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                "cache_read_tokens, cache_write_tokens, seat) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (kind, billing, work_item_id, logical_name, max(0.0, float(usd or 0)),
                  detail[:500], model[:80], counts["input"], counts["output"],
-                 counts["cache_read"], counts["cache_write"]))
+                 counts["cache_read"], counts["cache_write"], seat))
             if work_item_id and usd and usd > 0:
                 conn.execute(
                     "UPDATE work_item SET total_cost_usd = total_cost_usd + ? "
@@ -127,20 +150,57 @@ def totals(root: str | os.PathLike[str]) -> dict:
     that tracks the limit that actually bites.
     """
     conn = db.connect(root)
+    # THE WINDOWS USED TO BE LIFETIME AND TODAY, AND NOTHING ELSE — so anyone
+    # coming back after a break asked "what did last month cost" and got a
+    # today figure of $0.00, which reads as "cheap" rather than "not measured".
+    # 7 and 30 days are the two windows a person actually asks about.
     row = conn.execute("""
         SELECT
           COALESCE(SUM(CASE WHEN billing = 'api' THEN usd END), 0)     AS project_usd,
           COALESCE(SUM(CASE WHEN billing = 'api'
                              AND created_at >= date('now')
                             THEN usd END), 0)                          AS today_usd,
+          COALESCE(SUM(CASE WHEN billing = 'api'
+                             AND created_at >= date('now', '-7 day')
+                            THEN usd END), 0)                          AS week_usd,
+          COALESCE(SUM(CASE WHEN billing = 'api'
+                             AND created_at >= date('now', '-30 day')
+                            THEN usd END), 0)                          AS month_usd,
           COUNT(*)                                                     AS events
         FROM spend_event
     """).fetchone()
     out = dict(row)
+    out["week_usd"] = round(out["week_usd"], 4)
+    out["month_usd"] = round(out["month_usd"], 4)
+    # AGENT RUNS ARE NOT IN ANY OF THE ABOVE, and that surprised people: kind
+    # 'agent' is billed 'subscription' unconditionally, so the ceilings and the
+    # headline dollar figure both exclude the single biggest thing a night of
+    # fan-out consumes. Reported alongside rather than folded in — a plan user's
+    # runs genuinely are not dollars — but never again invisible.
+    agent = conn.execute(
+        "SELECT COALESCE(SUM(usd), 0) AS usd, COUNT(*) AS runs "
+        "FROM spend_event WHERE kind = 'agent'").fetchone()
+    out["agent_runs"] = {
+        "runs": int(agent["runs"] or 0),
+        "usd": round(float(agent["usd"] or 0), 4),
+        "note": "agent sessions bill as subscription, so they are NOT counted "
+                "in project_usd/today_usd or against per_day_usd — the token "
+                "figures below are what actually runs out on a plan",
+    }
     by_kind = conn.execute(
         "SELECT kind, COALESCE(SUM(usd), 0) AS usd FROM spend_event GROUP BY kind"
     ).fetchall()
     out["by_kind"] = {r["kind"]: round(r["usd"], 4) for r in by_kind}
+    # BY SEAT — the cut that decides where a budget is actually reduced. Rows
+    # with no seat (a human's own session) are grouped under '' rather than
+    # dropped: an unattributed total that silently vanishes is how a by-seat
+    # view ends up not summing to the project total.
+    by_seat = conn.execute(
+        "SELECT seat, COALESCE(SUM(usd), 0) AS usd, COUNT(*) AS events "
+        "FROM spend_event GROUP BY seat ORDER BY usd DESC").fetchall()
+    out["by_seat"] = {(r["seat"] or "(unattributed)"):
+                      {"usd": round(r["usd"], 4), "events": int(r["events"])}
+                      for r in by_seat}
     out["project_usd"] = round(out["project_usd"], 4)
     out["today_usd"] = round(out["today_usd"], 4)
     out["subscription"] = subscription_totals(root)

--- a/bgate_core/steerbox.py
+++ b/bgate_core/steerbox.py
@@ -209,7 +209,13 @@ OPEN_LIMIT = 20
 # How far back a scan for open questions goes. Bounded because the console polls
 # this every few seconds, and a project that has answered a thousand questions
 # must not pay for all of them to draw the two that are open.
-QUESTION_SCAN = 200
+# How many UNANSWERED question events are examined. The query already excludes
+# answered ones, so this is a cap on how many open questions a project may have
+# before the oldest stop being surfaced — and an unanswered question that falls
+# out of the scan is invisible to pending_decisions, the console AND the stale
+# reminder at once. 200 was reachable on a busy week; a question nobody can see
+# is worse than a slower query, and the rows are small.
+QUESTION_SCAN = 2000
 
 
 class AlreadyAnswered(ValueError):

--- a/bgate_core/workflows.py
+++ b/bgate_core/workflows.py
@@ -90,8 +90,22 @@ _PICK_TYPES = {"control.select", "control.pick"}
 _CONSISTENCY_TYPES = {"control.consistency"}
 # Nodes that call a provider themselves. The palette's art.* steps stay agent
 # steps (they carry a seat); these are the model-is-the-node types.
-_GENERATE_TYPES = {"model.generate", "model.image", "image.generate",
-                   "gen.image", "llm.prompt"}
+#
+# ONLY 'model.image' IS DRAWN TODAY (wf_steps_model.js is the only file that
+# emits one). The other two are kept as LEGACY names because a run stores a
+# SNAPSHOT of the graph and a saved workflow is JSON on disk: drop a type from
+# this set and a node that used to generate falls through kind_for to 'passive',
+# which paints it green without generating anything — the silent success this
+# engine exists to remove. 'model.generate' is the pre-rename name and is still
+# what this module's own tests draw with; 'llm.prompt' was a real card, removed
+# from the palette on purpose (the note in wf_steps_model.js says why) but not
+# removable from graphs already saved.
+#
+# 'image.generate' and 'gen.image' were dropped: no palette, template, test,
+# doc or fixture in this repository has ever emitted either name, so they were
+# guarding nothing. The tool-node table's 'tool.image.generate' is a different
+# type entirely and is unaffected.
+_GENERATE_TYPES = {"model.image", "model.generate", "llm.prompt"}
 # Passive inputs whose config text IS their output — the head of a prompt wire.
 _TEXT_TYPES = {"input.task", "input.text", "input.prompt"}
 # World context nodes: the bible and the lore graph, on a prompt wire.
@@ -786,6 +800,22 @@ def _passive_output(root: str | os.PathLike[str], spec: dict,
             or _ref_output(root, spec))
 
 
+# Three writers, one meaning: this passive node could not do its job. Only
+# `flow_error` was ever inspected, so a bible section that did not exist and a
+# reference that did not resolve both painted the node GREEN and sent an empty
+# wire on — and a generate node behind that wire then billed for a prompt with
+# no subject and no style anchor. The whole promise of a Reference node is the
+# anchor; failing to resolve it is not a detail to carry through.
+_PASSIVE_ERROR_KEYS = ("flow_error", "context_error", "ref_error")
+
+
+def _passive_problem(produced: dict) -> str:
+    for key in _PASSIVE_ERROR_KEYS:
+        if produced.get(key):
+            return str(produced[key])
+    return ""
+
+
 # ---------------------------------------------------------------------------
 # Generate nodes — the only thing in this engine that runs in parallel
 # ---------------------------------------------------------------------------
@@ -910,6 +940,37 @@ def _tool_paid(spec: dict) -> bool:
     """Does running this node call a provider that bills? From the registry."""
     entry = _wfnodes.spec_for(str(spec.get("type") or ""))
     return bool(entry and entry.paid)
+
+
+def _node_spends(spec: dict) -> bool:
+    """Does starting this node reach something that charges the user?
+
+    Two kinds do, and only one of them was ever asked. The paid-tool rule was
+    written for the tool table and left the generate kind out — but a generate
+    node IS an image provider call by definition (bgate_core.generate does
+    nothing else), so a canvas that opened a run to host one ▶ press was firing
+    every other model card whose inputs happened to be satisfied. One predicate,
+    both kinds, so the money gate cannot be half-applied again.
+    """
+    kind = str(spec.get("kind") or "")
+    if kind == "generate":
+        return True
+    return kind == "tool" and _tool_paid(spec)
+
+
+def spends_money(root: str | os.PathLike[str], run_id: int, node_id: str) -> bool:
+    """Would pressing ▶ on this node bill the user? For the route's human gate.
+
+    The route cannot answer this from the request — the graph lives in the run's
+    snapshot — and it must answer it BEFORE calling :func:`run_node`, because
+    "an agent may not spend money" is a 403 about the caller, not a 409 about
+    the node's state.
+    """
+    _, specs, _, _ = _graph_of(root, run_id)
+    spec = specs.get(node_id)
+    if spec is None:
+        raise LookupError(f"run {run_id} has no node {node_id!r}")
+    return _node_spends(spec)
 
 
 def _tool_worker(root: str | os.PathLike[str], run_id: int, spec: dict,
@@ -1177,6 +1238,29 @@ def advance(root: str | os.PathLike[str], run_id: int,
         kind = spec.get("kind") or "passive"
         inputs = _inputs(root, run_id, node_id, ups, node_rows)
 
+        # A NODE THAT SPENDS MONEY IS NEVER STARTED BY A TICK.
+        #
+        # The canvas opens a run just to HOST a single-node execution (wf.js
+        # `_ensureRun`, dispatch off). Without this, pressing ▶ on one card also
+        # fires every other paid node whose inputs happen to be satisfied — a
+        # video shot, a music track, a variant grid, the other two arms of a
+        # model comparison — none of which the user asked for and all of which
+        # are real money. So a paid node waits for a person to press ▶ on IT,
+        # unless the whole workflow was started with Run (dispatch on), which is
+        # the explicit "yes, do all of this" act.
+        #
+        # This used to guard tool nodes only, which left the kind that is paid
+        # BY DEFINITION — generate — starting itself on every poll.
+        if _node_spends(spec) and not dispatch:
+            waiting = True
+            if not _info(row).get("awaiting_human"):
+                node_rows[node_id] = _set_node(
+                    root, run_id, node_id, "pending",
+                    message="this step spends money — press run on this "
+                            "card when you want it, or use Run workflow",
+                    info={"awaiting_human": True})
+            continue
+
         if kind == "generate":
             if slots <= 0:
                 waiting = True  # over the concurrency cap; the next tick takes it
@@ -1189,25 +1273,6 @@ def advance(root: str | os.PathLike[str], run_id: int,
                 node_rows[node_id] = _node_rows(root, run_id)[node_id]
             continue
         if kind == "tool":
-            # A PAID TOOL NODE IS NEVER STARTED BY A TICK.
-            #
-            # The canvas opens a run just to HOST a single-node execution
-            # (wf.js `_ensureRun`, dispatch off). Without this, pressing ▶ on a
-            # free node would also fire every paid node whose inputs happened to
-            # be satisfied — a video shot, a music track, a variant grid — none
-            # of which the user asked for and all of which are real money. So a
-            # paid node waits for a person to press ▶ on IT, unless the whole
-            # workflow was started with Run (dispatch on), which is the explicit
-            # "yes, do all of this" act.
-            if _tool_paid(spec) and not dispatch:
-                waiting = True
-                if not _info(row).get("awaiting_human"):
-                    node_rows[node_id] = _set_node(
-                        root, run_id, node_id, "pending",
-                        message="this step spends money — press run on this "
-                                "card when you want it, or use Run workflow",
-                        info={"awaiting_human": True})
-                continue
             exclusive = _tool_exclusive(spec)
             if exclusive:
                 if line_held:
@@ -1229,13 +1294,14 @@ def advance(root: str | os.PathLike[str], run_id: int,
             continue
         if kind == "passive":
             produced = _passive_output(root, spec, inputs)
-            # A glue node that could not do its job FAILS the run rather than
-            # passing an empty wire on. "the filter matched nothing" arriving as
-            # a green node is how a graph silently produces nothing at the end.
-            if produced.get("flow_error"):
+            # A passive node that could not do its job FAILS the run rather than
+            # passing an empty wire on. "the filter matched nothing", "no bible
+            # section matched", "could not resolve reference" arriving as a
+            # green node is how a graph silently produces nothing at the end.
+            problem = _passive_problem(produced)
+            if problem:
                 node_rows[node_id] = _set_node(
-                    root, run_id, node_id, "failed",
-                    message=str(produced["flow_error"]))
+                    root, run_id, node_id, "failed", message=problem)
                 failed = True
                 break
             if produced:
@@ -1431,6 +1497,11 @@ def run_node(root: str | os.PathLike[str], run_id: int, node_id: str, *,
         says which parent is not, rather than starting on missing input;
       * gates and picks are not runnable: they are resolved by a person, which
         is :func:`approve` / :func:`pick`, a different verb with its own guard;
+      * a node that SPENDS is human-only, exactly like a gate or a pick. This
+        is what ``actor`` is for; it was accepted here and then never read, so
+        an agent holding the dashboard token could POST run on a paid tool node
+        or a model card and bill the account, while the same agent was refused
+        at the gate two nodes upstream;
       * an agent step still respects the single-file rule — if another queue
         item from this run is in flight, this one refuses;
       * NOTHING cascades. Downstream nodes stay pending even if this one
@@ -1459,17 +1530,31 @@ def run_node(root: str | os.PathLike[str], run_id: int, node_id: str, *,
         raise ValueError(
             f"a {kind} step is not run, it is resolved by a human — "
             f"use {'pick' if kind == 'pick' else 'approve'} on {node_id!r}")
-    if row["status"] == "running" and kind in ("generate", "tool"):
-        raise ValueError(f"{label} is already running — wait for it to finish")
+    # Guarded twice, exactly like approve() and pick(): the route calls
+    # api.require_human, and the engine refuses an agent actor itself, because
+    # the guarantee belongs to the engine and not to the transport. Asked before
+    # the status checks — whether a robot may spend is not a question about what
+    # the node happens to be doing right now.
+    if _node_spends(spec) and is_agent_actor(actor):
+        raise PermissionError(
+            f"{label} spends money, so only a human can start it — "
+            f"{actor} is an agent")
     if row["status"] != "pending":
         # Say what happened and what to do about it. "is queued, not pending"
         # is this module's vocabulary, not the user's, and it was the only
         # feedback a second click produced.
         said = {
             "queued": f"{label} is already queued and waiting to start",
-            "running": f"{label} is already running — wait for it to finish",
-            "passed": f"{label} has already run; reopen the run to do it again",
-            "failed": f"{label} already failed — reopen the run to retry it",
+            # 'running' names :func:`reconcile` because a node whose worker died
+            # with its process is ALSO 'running' and waiting for it never ends —
+            # this message used to be the last thing such a run ever said.
+            "running": f"{label} is already running — wait for it to finish, or "
+                       "reconcile the run if Builders Gate was restarted while "
+                       "it was working",
+            "passed": f"{label} has already run; start the workflow again to "
+                      "do it over",
+            "failed": f"{label} already failed — start the workflow again to "
+                      "retry it",
             "skipped": f"{label} was skipped because an earlier step failed",
         }.get(row["status"], f"{label} is {row['status']} and cannot be started")
         raise ValueError(said)
@@ -1509,11 +1594,12 @@ def run_node(root: str | os.PathLike[str], run_id: int, node_id: str, *,
         return get(root, run_id)
     if kind == "passive":
         produced = _passive_output(root, spec, inputs)
-        if produced.get("flow_error"):
+        problem = _passive_problem(produced)
+        if problem:
             # Refused rather than failed: the human is standing at the card and
-            # can fix the template/index and press run again, which is a better
-            # afternoon than a node that has to be reopened out of 'failed'.
-            raise ValueError(f"{label}: {produced['flow_error']}")
+            # can fix the template/index/ref name and press run again, which is
+            # a better afternoon than a node stuck in 'failed'.
+            raise ValueError(f"{label}: {problem}")
         if produced:
             _set_output(root, run_id, node_id, produced)
         _set_node(root, run_id, node_id, "passed",
@@ -1555,6 +1641,72 @@ def observe(root: str | os.PathLike[str], run_id: int, node_id: str, *,
               info={"observed_score": value, "observed_detail": detail[:400],
                     "observed_by": actor})
     return advance(root, run_id)
+
+
+def reconcile(root: str | os.PathLike[str],
+              run_id: Optional[int] = None) -> dict:
+    """Release nodes a dead process left at 'running'. The exit that was missing.
+
+    :data:`_INFLIGHT` is in-memory and dies with the process. A generate or tool
+    node claimed by a worker that never came back — the dashboard restarted
+    mid-generation, the machine slept, ``bgate serve`` was Ctrl-C'd — keeps the
+    row it was claimed with for ever. Nothing else in this module can move it:
+    :func:`advance` reads 'running' as work in flight and an exclusive one holds
+    the whole line behind it, :func:`_sync_items` only looks at nodes that have
+    a queue item, and :func:`run_node` answers the second press with "already
+    running — wait for it to finish". There was no wait that ended.
+
+    Only worker-owned kinds are touched. A gate or a pick sits at 'running'
+    BECAUSE it is waiting for a human; an agent or consistency step's status
+    belongs to its queue item, which :func:`_sync_items` already reconciles
+    against the queue. Failing either of those here would be this function
+    inventing an outage.
+
+    Deliberate and caller-driven, never automatic: this process cannot tell a
+    worker that died from one belonging to a second live dashboard on the same
+    project, so the honest guard is that a person asks for it. A future this
+    process still holds and has not finished is left alone regardless.
+    """
+    if run_id is None:
+        ids = [int(r["id"]) for r in rows(db.connect(root).execute(
+            "SELECT id FROM workflow_run WHERE status = 'running' ORDER BY id"))]
+    else:
+        _run_row(root, run_id)      # LookupError -> 404, like every other verb
+        ids = [int(run_id)]
+
+    released: list[dict] = []
+    for rid in ids:
+        _, specs, _, _ = _graph_of(root, rid)
+        for node_id, row in _node_rows(root, rid).items():
+            if row["status"] != "running" or row.get("work_item_id"):
+                continue
+            kind = str((specs.get(node_id) or {}).get("kind") or row["kind"])
+            if kind not in ("generate", "tool"):
+                continue
+            with _INFLIGHT_LOCK:
+                future = _INFLIGHT.get((rid, node_id))
+            if future is not None and not future.done():
+                continue
+            _set_node(root, rid, node_id, "failed",
+                      message="this step was still running when Builders Gate "
+                              "stopped, so its result can never arrive — "
+                              "nothing was recorded for it. Start the workflow "
+                              "again to retry it.",
+                      info={"reconciled": True})
+            released.append({"run_id": rid, "node_id": node_id,
+                             "label": row["label"], "kind": kind})
+    for rid in sorted({r["run_id"] for r in released}):
+        activity.log(root, "workflow",
+                     f"run {rid} reconciled: "
+                     f"{len([r for r in released if r['run_id'] == rid])} "
+                     f"step(s) released from a dead worker", ref=str(rid))
+        # A failed node is a failed run, and advance is what says so — the same
+        # path a provider failure takes. It starts nothing: it breaks at the
+        # first failed node.
+        advance(root, rid)
+
+    touched = ids if run_id is not None else sorted({r["run_id"] for r in released})
+    return {"released": released, "runs": [get(root, i) for i in touched]}
 
 
 def cancel(root: str | os.PathLike[str], run_id: int, *, actor: str = "") -> dict:

--- a/bgate_mcp/server.py
+++ b/bgate_mcp/server.py
@@ -627,6 +627,31 @@ def _spend_gate(root: str, projected_usd: float, what: str,
     return None
 
 
+def _gate_images(root: str, count: int, quality: str, what: str,
+                 max_cost_usd: float = 0.0) -> Optional[dict]:
+    """The spend gate for a tool that buys N images. Refusal dict, or None.
+
+    THE GATE GUARDED ONE TOOL OUT OF TWELVE. _spend_gate was written for
+    image_sprites and called only there, so image_generate, image_edit,
+    item_generate, item_variants, image_talkhead, vfx_animate and
+    character_generate all billed first and recorded afterwards — which makes
+    the project budget an invoice for every path except the one it was
+    demonstrated on. An unattended loop on any of them could not be refused.
+
+    Priced off imagegen.IMAGE_PRICE_USD, the same table image_sprites quotes
+    from, so one tool's estimate cannot drift from another's. An unknown
+    quality prices as medium there rather than raising: an estimate must never
+    be the thing that blocks work.
+    """
+    try:
+        from bgate_adapters import imagegen as _imagegen
+        unit = _imagegen.price_per_image(quality or "medium")
+    except Exception:
+        return None                  # no price table is not a licence to refuse
+    return _spend_gate(root, unit * max(1, int(count)), what,
+                       _run_ceiling(root, max_cost_usd))
+
+
 def _register_artifact(logical_name: str, path: str, *, producer: str,
                        model: str = "", prompt: str = "",
                        refs: Optional[list[str]] = None,
@@ -2657,6 +2682,10 @@ def image_generate(prompt: str, filename: str, size: str = "1024x1024",
     """
     try:
         root = _Path(_scratch_root())
+        refused = _gate_images(str(root), 1, quality,
+                               f"generating {filename!r}")
+        if refused:
+            return refused
         out = _art_out(root, filename)
         from bgate_adapters import imagegen
         named = [str(r) for r in (ref_images or []) if str(r).strip()]
@@ -2754,6 +2783,9 @@ def image_edit(prompt: str, ref_images: list[str], filename: str,
     """
     try:
         root = _Path(_scratch_root())
+        refused = _gate_images(str(root), 1, quality, f"editing into {filename!r}")
+        if refused:
+            return refused
         out = _art_out(root, filename)
         from bgate_adapters import imagegen
         resolved = [_refs.resolve(root, r) for r in ref_images]
@@ -2924,6 +2956,9 @@ def item_generate(item_class: str, name: str, descriptor: str,
     item_variants. LOOK at the preview before importing into the game."""
     try:
         root = _Path(_root())
+        refused = _gate_images(str(root), 1, quality, f"generating item {name!r}")
+        if refused:
+            return refused
         style_clause = _item_style_clause(root, character)
         [spec] = _items.plan_variants(
             item_class, name, descriptor,
@@ -2973,6 +3008,12 @@ def item_variants(item_class: str, base_name: str, descriptor: str,
     before importing."""
     try:
         root = _Path(_root())
+        # `limit` bounds the COUNT and never bounded the money: a 12-item grid
+        # at high quality is ~$2 that an exhausted daily budget could not refuse.
+        refused = _gate_images(str(root), max(1, int(limit)), quality,
+                               f"generating up to {int(limit)} variants of {base_name!r}")
+        if refused:
+            return refused
         style_clause = _item_style_clause(root, character)
         specs = _items.plan_variants(item_class, base_name, descriptor,
                                      materials=materials, elements=elements,
@@ -3083,6 +3124,13 @@ def vfx_animate(key_frame: str, name: str, motion: str = "burst",
     COSTS NOTHING AND CALLS NO MODEL."""
     try:
         root = _Path(_root())
+        # Derived, not bought: vfx_animate transforms one existing key frame
+        # rather than generating N. Gated anyway at one unit, because the
+        # budget's job is to be asked on every paid path, and a path that is
+        # cheap today is a path nobody re-checks when it stops being cheap.
+        refused = _gate_images(str(root), 1, 'low', f"animating {key_frame!r}")
+        if refused:
+            return refused
         rel = _assets.normalize_path(root, key_frame)
         src = root / rel
         if not src.exists():
@@ -4070,6 +4118,10 @@ def image_talkhead(subject: str, name: str, anchor: str = "",
         from bgate_core import talkhead as _th
 
         root = _Path(_scratch_root())
+        refused = _gate_images(str(root), _th.FRAME_COUNT if hasattr(_th, 'FRAME_COUNT') else 4,
+                               quality, f"painting a talking head for {name!r}")
+        if refused:
+            return refused
         limit = float(drift_limit or _th.DRIFT_LIMIT)
         stage = root / ".bgate_out" / "art" / "talkheads" / name
         stage.mkdir(parents=True, exist_ok=True)
@@ -4200,6 +4252,144 @@ def godot_run(script: str, godot_project: Optional[str] = None,
     """
     try:
         return _godot.run_script(script, project_dir=godot_project, timeout=timeout)
+    except Exception as exc:
+        return _fail(exc)
+
+
+# THE QA SEAT HAD NO WAY TO RUN A TEST. Its mission is "Own tests, repro,
+# regression" and the brief it is dispatched with demands "tests at the known
+# baseline, no new failures" — a question that could only be answered by
+# hand-rolling a godot_run call per script, reading raw stdout, and counting by
+# eye. dispatch._verify_rule already NAMES this project's test scripts in every
+# seat prompt (game/tests/*.gd); this is the tool that runs the thing the prompt
+# points at, and returns a per-script verdict instead of a wall of engine chatter.
+#
+# The pass/fail convention is a marker in the output — a line containing FAIL is
+# a failure, one containing PASS is a pass — because that is what the existing
+# .gd test scripts already print and inventing a framework nobody's tests use
+# would make this tool answer about nothing. Exit code alone is not enough:
+# Godot prints SCRIPT ERROR and still exits 0, which is why godot_run reports
+# `errors` separately and why a script that errors is failed here regardless of
+# how many PASS lines it managed first.
+@_tool
+def godot_test_run(paths: Optional[list[str]] = None, timeout: int = 180,
+                   godot_project: Optional[str] = None) -> dict:
+    """Run this project's own Godot test scripts headless and score them.
+
+    Discovers `<godot project>/tests/*.gd` — resolved through the project's real
+    layout, so it works whether project.godot sits at the root (bgate init) or
+    in <root>/game (godot_scaffold). Pass `paths` to run a subset; each may be
+    absolute, project-relative, or relative to the Godot project.
+
+    Returns a per-script verdict — ok, PASS/FAIL marker counts, exit code,
+    seconds, engine errors, and the OUTPUT of the ones that failed — plus the
+    totals the QA brief asks for in one number: `scripts_failed` and
+    `failures`.
+
+    A PROJECT WITH NO TEST SCRIPTS IS NOT A PASS. It answers ok=false with
+    no_tests=true and says where it looked, because "0 failures" out of nothing
+    run is the single most misleading thing this tool could report — a regression
+    gate that silently tests nothing looks exactly like a green one.
+
+    Each script must `extends SceneTree` and call `quit()`, like godot_run.
+    """
+    try:
+        import re as _re
+
+        root = _root()
+        base = (_Path(godot_project) if godot_project
+                else _project.game_dir(root))
+        if base is None or not (_Path(base) / "project.godot").is_file():
+            return {"ok": False, "no_tests": True,
+                    "error": "no Godot project found — looked for project.godot "
+                             f"at {root} and {_Path(root) / 'game'}. Run "
+                             "godot_scaffold, or pass godot_project."}
+        base = _Path(base)
+        tests_dir = base / "tests"
+
+        scripts: list[_Path] = []
+        missing: list[str] = []
+        if paths:
+            for raw in paths:
+                for candidate in (_Path(raw), base / raw, _Path(root) / raw):
+                    if candidate.is_file():
+                        scripts.append(candidate)
+                        break
+                else:
+                    missing.append(str(raw))
+        else:
+            try:
+                scripts = sorted(p for p in tests_dir.glob("*.gd"))
+            except OSError:
+                scripts = []
+
+        if not scripts:
+            return {
+                "ok": False, "no_tests": True, "tests_dir": str(tests_dir),
+                "missing": missing, "scripts": [], "scripts_run": 0,
+                "error": (f"none of {missing} exist" if missing else
+                          f"no test scripts in {tests_dir} — this project has "
+                          "no regression baseline to check. Write one "
+                          "(extends SceneTree, print PASS/FAIL per assertion, "
+                          "call quit()) before claiming tests are green."),
+            }
+
+        fail_marker = _re.compile(r"\bFAIL(?:ED|URE|URES)?\b", _re.I)
+        pass_marker = _re.compile(r"\bPASS(?:ED|ES)?\b", _re.I)
+
+        results, failed, total_pass, total_fail = [], 0, 0, 0
+        for script in scripts:
+            rel = (script.resolve().relative_to(base.resolve()).as_posix()
+                   if str(script.resolve()).startswith(str(base.resolve()))
+                   else str(script))
+            try:
+                source = script.read_text(encoding="utf-8", errors="replace")
+            except OSError as exc:
+                results.append({"script": rel, "ok": False, "passed": 0,
+                                "failed": 0, "error": f"unreadable: {exc}"})
+                failed += 1
+                continue
+            run = _godot.run_script(source, project_dir=str(base),
+                                    timeout=timeout)
+            output = (run.get("stdout") or "") + (run.get("stderr") or "")
+            passes = len(pass_marker.findall(output))
+            fails = len(fail_marker.findall(output))
+            errors = run.get("errors") or []
+            ok = bool(run.get("ok")) and fails == 0 and not errors
+            entry = {
+                "script": rel, "ok": ok, "passed": passes, "failed": fails,
+                "exit_code": run.get("exit_code"), "seconds": run.get("seconds"),
+                "errors": errors,
+            }
+            if not ok:
+                # Only the failures carry their output. A green run's stdout is
+                # thousands of lines of engine boot chatter, and returning it
+                # for every script is how a passing suite stops fitting in a
+                # tool result.
+                entry["output"] = output[-4000:]
+                if run.get("error"):
+                    entry["error"] = run["error"]
+                failed += 1
+            total_pass += passes
+            total_fail += fails
+            results.append(entry)
+
+        return {
+            "ok": failed == 0,
+            "no_tests": False,
+            "tests_dir": str(tests_dir),
+            "godot_project": str(base),
+            "scripts_run": len(results),
+            "scripts_failed": failed,
+            "assertions_passed": total_pass,
+            "assertions_failed": total_fail,
+            "failures": [r["script"] for r in results if not r["ok"]],
+            "missing": missing,
+            "scripts": results,
+            "error": (f"{failed} of {len(results)} test script(s) failed: "
+                      + ", ".join(r["script"] for r in results if not r["ok"])
+                      if failed else ""),
+        }
     except Exception as exc:
         return _fail(exc)
 
@@ -6432,8 +6622,19 @@ def brainstorm_deploy(session_id: int, plan: dict, again: bool = False) -> dict:
                 "of under your own seat, where it is attributed to you.")
         root = _root()
         session = _bs.read(root, int(session_id))
-        return _bs.file_plan(root, session, plan, again=bool(again),
-                             by=_actor())
+        out = _bs.file_plan(root, session, plan, again=bool(again),
+                            by=_actor())
+        # THE GAME-PLAN BACK HALF. A plan carrying a `manifest` is the
+        # premise-to-plan compiler's output: rows land in plan_row (coverage),
+        # slice rows land on the board with real dependency links. Behind the
+        # same human gate as the items — the manifest IS the plan, at a finer
+        # grain. validate_plan ignores the key, so a manifest-free plan is
+        # exactly what it always was.
+        if isinstance(plan, dict) and plan.get("manifest"):
+            from bgate_core import gameplan as _gameplan
+            out["game_plan"] = _gameplan.ingest(
+                root, plan["manifest"], session_id=int(session_id))
+        return out
     except _bs.AlreadyFiled as exc:
         return {"ok": False, "error": str(exc), "already_filed": exc.entry}
     except _bs.PartialDeploy as exc:
@@ -6594,8 +6795,24 @@ def voice_speak(text: str, out_path: str = "",
         if not verdict["available"]:
             raise RuntimeError(verdict["reason"])
 
-        result = _deepgram.speak(str(text),
-                                 model=str(model or _deepgram.DEFAULT_SPEAK_MODEL))
+        # BILLED PER CHARACTER AND NEVER CHECKED. This path recorded its
+        # spend and never asked the budget — the one paid tool an
+        # unattended loop could run up with no gate at all. Priced from
+        # the same table the adapter bills from; an unpriced model quotes
+        # None there rather than 0.0, and an unknown price must not read
+        # as free, so it is gated at the most expensive known rate.
+        speak_model = str(model or _deepgram.DEFAULT_SPEAK_MODEL)
+        per_1k = _deepgram.USD_PER_1K_CHARS.get(speak_model)
+        if per_1k is None:
+            known = [v for v in _deepgram.USD_PER_1K_CHARS.values()
+                     if isinstance(v, (int, float))]
+            per_1k = max(known) if known else 0.0
+        refused = _spend_gate(
+            str(root), (len(str(text)) / 1000.0) * float(per_1k),
+            f"speaking {len(str(text))} characters", _run_ceiling(str(root)))
+        if refused:
+            return refused
+        result = _deepgram.speak(str(text), model=speak_model)
         if not result.get("ok"):
             raise RuntimeError(str(result.get("error") or "speech failed"))
 
@@ -6615,6 +6832,207 @@ def voice_speak(text: str, out_path: str = "",
                 "chars": result.get("chars"), "usd": result.get("usd"),
                 "model": result.get("model"),
                 "request_id": result.get("request_id")}
+    except Exception as exc:
+        return _fail(exc)
+
+
+# ---------------------------------------------------------------------------
+# SFX — synthesized, not generated
+# ---------------------------------------------------------------------------
+# THE AUDIO SEAT COULD NOT MAKE A GAME SOUND. Its mission opens "Own SFX and
+# music hooks" and every tool it had was a paid, keyed provider — kie_music_*
+# for beds, voice_* for speech — so a project without a key produced no audio at
+# all, and even with one there was no path to a coin pickup or a laser. These
+# three tools need no key, no network and no budget: an SFX is four oscillator
+# parameters and an envelope, and synthesis genuinely beats generation there.
+@_tool
+def sfx_kinds() -> dict:
+    """What game sounds this can synthesize, and the aliases each answers to.
+
+    Read this before guessing a kind — `sfx_generate("pew")` fails, `"laser"`
+    and its alias `"shoot"` do not. Every entry says how long it comes out and
+    what its base frequency is, which are the two knobs worth moving first.
+    """
+    try:
+        from bgate_core import sfx as _sfx
+
+        return {"kinds": _sfx.kinds(), "sample_rate": _sfx.DEFAULT_RATE,
+                "max_seconds": _sfx.MAX_SECONDS}
+    except Exception as exc:
+        return _fail(exc)
+
+
+@_tool
+def sfx_generate(kind: str, name: str, seed: Optional[int] = None,
+                 base_hz: float = 0.0, duration_s: float = 0.0,
+                 gain: float = 1.0, sample_rate: int = 44100,
+                 bits: int = 0, out_dir: str = "") -> dict:
+    """Synthesize a game sound effect into the project. No key, no provider.
+
+    kind        sfx_kinds() lists them: blip, pickup, jump, laser, explosion,
+                hit, powerup, sweep (plus aliases — "coin", "shoot", "thud").
+    name        becomes <name>.wav in the audio seat's lane.
+    base_hz     scales every pitch in the preset — a bigger gun, not a
+                different sound. 0 keeps the preset's own.
+    duration_s  scales every time in the preset. 0 keeps its nominal length.
+    bits        3-8 bit-crushes it for the retro sound; 0 leaves it clean.
+
+    WRITES TWO FILES, AND THAT IS THE POINT. `<name>.synth.json` lands beside
+    the wav carrying the complete parametric recipe — waves, sweeps, ADSR,
+    filter, seed — because the audio house rule requires it and because a .wav
+    whose knobs are lost cannot be nudged by anyone, ever. sfx_rerender rebuilds
+    the identical bytes from that sidecar alone.
+
+    Deterministic: the same kind and name give the same file every time, so
+    regenerating is a no-op rather than a diff nobody asked for. Pass an
+    explicit seed to get a different roll of the noise.
+    """
+    try:
+        from bgate_core import sfx as _sfx
+
+        root = _root()
+        result = _sfx.generate(root, kind, name, out_dir=out_dir or None,
+                               seed=seed, base_hz=base_hz,
+                               duration_s=duration_s, gain=gain,
+                               sample_rate=sample_rate, bits=bits)
+        artifact = _register_artifact(
+            f"sfx_{result['name']}", result["path"], producer="sfx_generate",
+            model="procedural",
+            prompt=f"{result['kind']} sfx",
+            metadata={"kind": result["kind"], "seed": result["seed"],
+                      "seconds": result["seconds"],
+                      "recipe": result["recipe_rel_path"]})
+        if artifact:
+            result["artifact"] = artifact
+        _log("audio", f"synthesized {result['kind']} sfx {result['name']} "
+                      f"({result['seconds']}s)", ref=result["rel_path"])
+        result.pop("recipe", None)     # the sidecar holds it; don't echo it twice
+        return {"ok": True, **result}
+    except Exception as exc:
+        return _fail(exc)
+
+
+@_tool
+def sfx_rerender(recipe_path: str, out_path: str = "") -> dict:
+    """Rebuild a .wav from its `<name>.synth.json` recipe ALONE.
+
+    This is the proof the recipe is a recipe: `identical` says whether the bytes
+    match the wav already on disk. A sidecar that renders something else is
+    worse than no sidecar — it looks like provenance and is not — so run this
+    after hand-editing a recipe, and read that field rather than assuming.
+
+    recipe_path may be absolute or relative to the project root.
+    """
+    try:
+        from bgate_core import sfx as _sfx
+
+        root = _root()
+        path = _Path(recipe_path)
+        if not path.is_absolute():
+            path = _Path(root) / recipe_path
+        result = _sfx.rerender(path, out_path=out_path or None)
+        _log("audio", f"re-rendered {result['name']} from its recipe "
+                      f"(identical={result['identical']})", ref=result["path"])
+        result.pop("recipe", None)
+        return {"ok": True, **result}
+    except Exception as exc:
+        return _fail(exc)
+
+
+@_tool
+def sfx_list() -> dict:
+    """Every synthesized effect in the project, and which ones lost their recipe.
+
+    A wav with no `.synth.json` is listed with has_recipe=false rather than
+    hidden: it is exactly the dead end the audio house rule exists to prevent,
+    and the seat can only fix what it can see.
+    """
+    try:
+        from bgate_core import sfx as _sfx
+
+        root = _root()
+        found = _sfx.list_sfx(root)
+        return {"dir": str(_sfx.sfx_dir(root)), "count": len(found),
+                "sfx": found,
+                "without_recipe": [f["name"] for f in found
+                                   if not f["has_recipe"]]}
+    except Exception as exc:
+        return _fail(exc)
+
+
+# ---------------------------------------------------------------------------
+# Dialogue — the narrative seat's own artifact
+# ---------------------------------------------------------------------------
+@_tool
+def dialogue_write(name: str, nodes: list[dict], start: str = "",
+                   title: str = "", summary: str = "",
+                   allow_canon_conflict: bool = False) -> dict:
+    """Author a dialogue tree as an engine-loadable resource, validated first.
+
+    nodes is a list of {id, speaker, text, choices: [{text, goto}], end}. `goto`
+    names another node's id; `end: true` marks a closing line, which must have
+    no choices. start defaults to the first node.
+
+    THE WRITE IS REFUSED, NOT WARNED, when the graph is broken, and the refusal
+    names the node: a choice pointing at a node that does not exist, a node
+    nothing reaches, a node from which no ending is reachable. All three are
+    invisible in the file and expensive in the game — a dead-ended branch is
+    found weeks later by a player, and a node with no exit reads as a hang.
+
+    canon_check runs on the way in, on the lines AND the choice labels. A hard
+    conflict refuses (pass allow_canon_conflict=True only when the canon is what
+    changed); review-level flags ride along in the result, because an unknown
+    name is the normal state of a first draft.
+
+    Lands at <godot project>/dialogue/<name>.dialogue.json — inside the
+    narrative seat's own lane, for both project layouts.
+    """
+    try:
+        from bgate_core import dialogue as _dialogue
+
+        result = _dialogue.write(_root(), name, nodes, start=start, title=title,
+                                 summary=summary,
+                                 allow_canon_conflict=bool(allow_canon_conflict))
+        _log("narrative", f"wrote dialogue {result['name']} "
+                          f"({result['nodes']} nodes, {result['choices']} choices, "
+                          f"canon {result['canon']['verdict']})",
+             ref=result["rel_path"])
+        return {"ok": True, **result}
+    except Exception as exc:
+        return _fail(exc)
+
+
+@_tool
+def dialogue_read(name: str) -> dict:
+    """One dialogue tree, whole — nodes, choices, start and ends.
+
+    Read before editing: dialogue_write replaces the file outright, so a partial
+    node list silently deletes every branch it left out.
+    """
+    try:
+        from bgate_core import dialogue as _dialogue
+
+        return {"ok": True, **_dialogue.read(_root(), name)}
+    except Exception as exc:
+        return _fail(exc)
+
+
+@_tool
+def dialogue_list() -> dict:
+    """Every dialogue tree in the project, and whether each still validates.
+
+    A file that no longer passes the graph checks is reported with ok=false and
+    the reason — hand edits and merges break `goto` targets, and the listing is
+    the cheapest place to find that out.
+    """
+    try:
+        from bgate_core import dialogue as _dialogue
+
+        root = _root()
+        found = _dialogue.list_dialogues(root)
+        return {"dir": str(_dialogue.dialogue_dir(root)), "count": len(found),
+                "dialogues": found,
+                "broken": [d["name"] for d in found if not d["ok"]]}
     except Exception as exc:
         return _fail(exc)
 
@@ -6801,11 +7219,153 @@ def queue_update(item_id: int, title: Optional[str] = None, brief: Optional[str]
 
 @_tool
 def queue_next(seat: str) -> dict:
-    """The highest-priority queued item for a seat — what to work on next."""
+    """The highest-priority queued item for a seat — what to work on next.
+
+    A READ: it changes nothing and reserves nothing. A dispatched worker that
+    wants to actually take the item it sees here uses queue_claim_next, which
+    claims atomically — acting on this read alone races the dashboard.
+    """
     try:
         from bgate_core import queue as _q
         item = _q.next_for(_root(), seat)
         return item if item else {"empty": True, "seat": seat}
+    except Exception as exc:
+        return _fail(exc)
+
+
+@_tool
+def board_digest(hours: int = 12) -> dict:
+    """WHAT HAPPENED WHILE YOU WERE AWAY — finished, failed, blocked, spent.
+
+    The morning report. Nothing else answers it: the autopilot keeps only its
+    LAST refusal, notices collapse past three into "11 items finished", and the
+    heartbeat reports stalled chains rather than "the board stopped at 23:02".
+    So after an overnight run the most common question had no surface at all.
+
+    The field to read first is ``blocked``. Queued work with nothing running is
+    either a dead dashboard or a floor refusal — most often a dirty tree, which
+    stops the WHOLE board rather than one item — and this names which.
+
+    Spends nothing. Read it at the start of a session before deciding anything.
+    """
+    try:
+        from bgate_core import gameplan as _gameplan
+        return _gameplan.digest(_root(), hours=int(hours))
+    except Exception as exc:
+        return _fail(exc)
+
+
+@_tool
+def queue_cut_dependency(item_id: int, depends_on: int) -> dict:
+    """Release an item from a predecessor that will never land. THE REPAIR VERB.
+
+    Only 'done' satisfies a dependency, so a CANCELLED predecessor blocks its
+    successors forever — the board's one state with no exit. Before this the
+    only escape was deleting and re-filing the work, losing its brief, its
+    round count and everything the harness observed it write.
+
+    Use it when the predecessor was cut, superseded, or turned out to be
+    unnecessary — NOT to jump a queue: the item you release starts writing
+    against whatever the predecessor was supposed to produce, so if that
+    output is genuinely still needed, this is how a run writes against a file
+    that does not exist. The cut is recorded with your identity, not deleted.
+
+    queue_get shows what an item waits on; the refusal message on a blocked
+    dispatch names it too.
+    """
+    try:
+        from bgate_core import queue as _q
+        return _q.cut_dependency(_root(), int(item_id), int(depends_on),
+                                 by=_actor())
+    except Exception as exc:
+        return _fail(exc)
+
+
+@_tool
+def queue_add_dependency(item_id: int, depends_on: int) -> dict:
+    """Make an item wait for one MORE predecessor — dependencies are a graph.
+
+    queue_add's own depends_on takes a single parent, which is all a chain
+    ever needed. A real feature is a fan-in: the scene needs the sprite AND
+    the sound AND the script. Call this for each extra parent; the item does
+    not dispatch until every one of them reaches 'done'.
+    """
+    try:
+        from bgate_core import queue as _q
+        return _q.add_dependency(_root(), int(item_id), int(depends_on))
+    except Exception as exc:
+        return _fail(exc)
+
+
+@_tool
+def plan_status() -> dict:
+    """Coverage: what the game consists of vs what is built — THE completeness
+    read.
+
+    An empty queue is NOT a finished game: after a bad decomposition the two
+    are indistinguishable from the board alone, which is how six items died
+    superseded while the objective ranked last. This reads the game-plan
+    manifest (plan_row, written when a human deploys a brainstorm plan that
+    carries one) joined live against the board: spec / on_board / built /
+    lost per row, slice completeness, and `remaining` — the rows the board
+    does not currently hold. Anyone may read it; the director reads it before
+    declaring anything finished, and uses queue_add to put uncovered rows on
+    the board.
+    """
+    try:
+        from bgate_core import gameplan as _gameplan
+        return _gameplan.status(_root())
+    except Exception as exc:
+        return _fail(exc)
+
+
+@_tool
+def queue_claim_next() -> dict:
+    """Claim the next READY item for YOUR seat and keep this session working.
+
+    THE PICKUP LOOP. A finished worker used to have one move — exit, and let
+    the board pay a fresh agent's entire briefing to start the next item. This
+    is the other move: claim the next item, complete your current one, and
+    continue in the same session with your context already paid for.
+
+    ORDER MATTERS: CLAIM FIRST, THEN queue_complete. The dashboard closes this
+    session shortly after your current item settles unless you already hold a
+    claim — a claim made after completing races that shutdown and loses.
+
+    The claim is atomic against the dashboard's own dispatcher: whoever loses
+    simply does not get the item, so a claim that returns a row is yours. It
+    honours the same holds autodeploy does (dependencies, human-only sources),
+    and it only ever claims for the seat you already hold — this is a loop,
+    not a way to change lanes. Your run's cost and runtime ceilings still come
+    from the ORIGINAL dispatch and bound the whole session; if the claimed
+    work will not fit under what remains, do not claim it.
+
+    Returns the claimed item (its brief is the task) or {empty: true}, which
+    means: queue_complete and finish — an empty board is a finished shift.
+    """
+    try:
+        from bgate_core import queue as _q
+        seat = _seat()
+        origin = _work_item_id()
+        if not seat or not origin:
+            raise PermissionError(
+                "queue_claim_next is the dispatched worker's pickup loop, and "
+                "this session was not dispatched against a work item. File "
+                "work with queue_add (it dispatches when `bgate serve` is up) "
+                "instead of claiming it.")
+        item = _q.claim_next(_root(), seat, actor=f"agent:item-{int(origin)}")
+        if item is None:
+            return {"empty": True, "seat": seat,
+                    "note": "nothing ready for your seat — queue_complete "
+                            "your current item and finish."}
+        _log("queue", f"claimed #{item['id']} to continue after "
+                      f"item {origin}", ref=str(item["id"]))
+        return {**item, "claimed": True,
+                "note": (f"item #{item['id']} is yours. queue_complete your "
+                         f"current item (#{origin}) first, then work this one "
+                         "under the same lanes and rules, and queue_complete "
+                         "it too when it lands. Claim again before that "
+                         "completion if you still have budget for more.")}
     except Exception as exc:
         return _fail(exc)
 
@@ -6838,22 +7398,28 @@ def queue_reopen(item_id: int, reason: str) -> dict:
     The QA gate's FAIL path: reason is the ranked nitpick list (specific
     problems + fixes). It is APPENDED to the item's brief so the next
     dispatched agent reads exactly what to fix, and recorded as the result.
+
+    ROUTED THROUGH queue.reopen, and the difference is not cosmetic. This tool
+    used to re-queue directly, which left ``attempts`` at zero forever — and
+    ``attempts`` is the round counter the QA gate's max-rounds cap reads, so
+    the fail/reopen loop the cap exists to stop could never trip it: an
+    unbounded money pump wearing the gate's own uniform. queue.reopen counts
+    the round AND carries the harness's record of what the last attempt
+    already wrote into the new brief, so a fix round continues instead of
+    regenerating.
     """
     try:
         from bgate_core import queue as _q
         root = _root()
         item = _q.get(root, item_id)
         if item["status"] not in ("done", "failed"):
+            # queue.reopen also accepts 'cancelled', deliberately not offered
+            # here: cancelled is a human calling work off, and a machine
+            # un-cancelling it is the human's call being overridden.
             raise ValueError(
                 f"item {item_id} is {item['status']!r} — only done/failed "
                 "items can be reopened")
-        reason = (reason or "").strip()
-        if not reason:
-            raise ValueError("reason is required — say exactly what to fix")
-        stamp = ("\n\n--- REOPENED (QA gate) ---\n" + reason)[:3000]
-        _q.update(root, item_id, brief=(item["brief"] or "") + stamp)
-        return _q.set_status(root, item_id, "queued",
-                             result=f"reopened: {reason[:1900]}")
+        return _q.reopen(root, item_id, (reason or "").strip())
     except Exception as exc:
         return _fail(exc)
 
@@ -7328,6 +7894,32 @@ def kie_music_status(task_id: str) -> dict:
 
 
 @_tool
+def music_stuck_tracks(older_than_s: int = 0, poll: bool = True) -> dict:
+    """Music generations that were PAID FOR and never collected. Finds money.
+
+    The music twin of cinematic_stuck_shots, and it exists for the same reason:
+    a batch is charged at SUBMIT, and everything after that — the poll loop, the
+    download, the absorb — can die without the charge going anywhere. Until the
+    task id was persisted before the provider call, a crash mid-poll lost the
+    only handle to work you had already bought, and nothing anywhere noticed.
+
+    Run it after any crash, kill or dashboard restart. `recoverable` is the list
+    worth acting on: those are finished generations sitting on the provider that
+    kie_music_recover can still collect — but only inside the provider's
+    retention window, which the result names. `poll=False` answers from local
+    tickets alone and reaches no provider, which is the right call when you only
+    want to know whether anything is outstanding.
+    """
+    try:
+        from bgate_core import music as _music
+        return _music.stuck_tracks(
+            _root(), older_than_s=int(older_than_s) or _music.STUCK_AFTER_S,
+            poll=bool(poll))
+    except Exception as exc:
+        return _fail(exc)
+
+
+@_tool
 def kie_music_recover(task_id: str, name: str = "") -> dict:
     """Download and register the tracks of a task ALREADY PAID FOR. Costs nothing.
 
@@ -7483,6 +8075,29 @@ def kie_video_generate(prompt: str, filename: str, seconds: Optional[int] = None
         root = _Path(_root())
         from bgate_adapters import kie
 
+        # THE MOST EXPENSIVE UNIT THIS PRODUCT BUYS, and it was ungated.
+        #
+        # kie reports an unknown price as None, never 0.0, and that distinction
+        # has to survive here or the gate reads "free" for exactly the models
+        # whose cost is least predictable. So: a KNOWN price is gated on the
+        # number. An UNKNOWN one still asks the budget (which catches a project
+        # already over its ceiling) and then says so in the result — a spend
+        # nobody could price is a fact the caller is owed, not something to
+        # bury under a passing check.
+        priced = None
+        try:
+            quote = kie.estimate_usd(model=model, seconds=seconds)
+            if isinstance(quote, dict) and quote.get("usd") is not None:
+                priced = float(quote["usd"])
+        except Exception:
+            priced = None
+        refused = _spend_gate(
+            str(root), priced or 0.0,
+            f"buying {seconds}s of video on {model or 'the default model'}"
+            + ("" if priced is not None else " (price UNKNOWN for this model)"),
+            _run_ceiling(str(root)))
+        if refused:
+            return refused
         base = (root / ".bgate_out" / "video").resolve()
         out = (base / (filename or "clip.mp4")).resolve()
         try:

--- a/bgate_ui/autodeploy.py
+++ b/bgate_ui/autodeploy.py
@@ -60,14 +60,18 @@ POLL_S = 4.0
 #     moment they are written, and the queue panel offers a deploy button for
 #     one that was refused; autopilot grabbing them is how a turn got dispatched
 #     with the placeholder brief still in it.
-HELD_SOURCES = ("qa-gate-escalation", "chat")
+#
+# DEFINED IN queue.py NOW, because a worker's queue_claim_next is a second
+# automatic dispatcher in a second process and must hold the same items back;
+# two copies of this tuple is how one of them grabs an escalation. The names
+# stay importable from here — this module is where the policy is explained.
+from bgate_core.queue import HELD_SOURCES, PLACEHOLDER_BRIEF  # noqa: E402
 
 # A row created in two statements — INSERT with a placeholder, then UPDATE with
 # the real text — is briefly dispatchable with nothing in it. Both the console
 # turn and the delegate item are built that way (the brief has to name the row's
-# own id), so autopilot skips anything still wearing the placeholder rather than
-# spending an agent on the word "(preparing)".
-PLACEHOLDER_BRIEF = "(preparing%"
+# own id), so autopilot (and claim_next) skips anything still wearing the
+# placeholder rather than spending an agent on the word "(preparing)".
 
 # How long an item that refused sits out before it is offered again.
 ITEM_COOLDOWN_S = 90.0
@@ -87,10 +91,40 @@ _lock = threading.Lock()
 _MEM: dict[str, dict] = {}
 
 
+# How many runs may die instantly, back to back, before the board stops
+# feeding the queue into whatever is broken — and how long it then waits.
+BURN_LIMIT = 3
+BURN_COOLDOWN_S = 300.0
+# A run that lasted less than this and reported nothing did not do any work.
+QUICK_FAIL_S = 45
+
+
 def _mem(root: str) -> dict:
     with _lock:
         return _MEM.setdefault(str(root), {"cool": {}, "floor_until": 0.0,
-                                           "last": None, "dispatched": 0})
+                                           "last": None, "dispatched": 0,
+                                           "quick_fails": 0})
+
+
+def note_run_ended(root, item_id: int, outcome: str, seconds: float) -> None:
+    """Told by the dispatcher how a run finished, so the loop can notice a
+    runner that is failing every time.
+
+    Counts CONSECUTIVE instant failures: any run that produced work — or that
+    merely lasted a while before failing — resets the counter, because a slow
+    failure is a real attempt at real work and a fast one is the runner
+    refusing to start.
+    """
+    mem = _mem(str(root))
+    with _lock:
+        if outcome == "done" or seconds >= QUICK_FAIL_S:
+            mem["quick_fails"] = 0
+        else:
+            mem["quick_fails"] = int(mem.get("quick_fails") or 0) + 1
+
+
+def _burning(root: str, mem: dict) -> bool:
+    return int(mem.get("quick_fails") or 0) >= BURN_LIMIT
 
 
 def enabled(root: str | os.PathLike[str]) -> bool:
@@ -190,7 +224,12 @@ def _candidates(root: str) -> list[dict]:
         "AND (i.depends_on IS NULL OR d.id IS NULL OR d.status = 'done') "
         "ORDER BY i.priority DESC, i.id LIMIT 40",
         (*HELD_SOURCES, PLACEHOLDER_BRIEF)).fetchall()
-    return [dict(r) for r in rows]
+    # The join sees only the single-column parent. An item with EXTRA parents
+    # (work_item_dep) is filtered here for the same reason the chained ones are:
+    # a refusal costs the item a cooldown and fills the "last refusal" slot with
+    # a non-event when the board is simply working as designed.
+    from bgate_core import queue as _q
+    return [dict(r) for r in rows if _q.blocker(root, int(r["id"])) is None]
 
 
 def tick(root: str | os.PathLike[str], *, force: bool = False) -> dict:
@@ -228,6 +267,28 @@ def tick(root: str | os.PathLike[str], *, force: bool = False) -> dict:
         item_id = int(item["id"])
         if mem["cool"].get(item_id, 0) > now:
             continue
+        # INSTANT-FAILURE BACKOFF. A dispatch that SPAWNS is a success here, so
+        # nothing rate-limited the case where every spawn dies on contact — an
+        # expired CLI login passes the PATH check, starts, exits without
+        # reporting, and is banked as failed. With no cooldown on a successful
+        # dispatch, autopilot walked the whole queue at four a tick and burned
+        # thirty items to 'failed' in about ten minutes, then idled till morning.
+        # Consecutive same-shaped failures are the signal; the fix is to stop
+        # feeding the queue into a broken runner, not to retry harder.
+        if _burning(root, mem):
+            entry = {"item_id": None, "code": "runner_failing",
+                     "message": (f"{mem.get('quick_fails', 0)} runs in a row "
+                                 "ended immediately without reporting — the "
+                                 "agent CLI is probably not able to start "
+                                 "(expired login?). Holding the board rather "
+                                 "than burning the queue; fix the CLI and it "
+                                 "resumes on its own."),
+                     "at": time.strftime("%H:%M:%S")}
+            with _lock:
+                mem["last"] = entry
+                mem["floor_until"] = now + BURN_COOLDOWN_S
+            refused.append(entry)
+            break
         result = _dispatch.dispatch(root, item_id, actor="autodeploy")
         if result.get("ok"):
             sent.append(item_id)

--- a/bgate_ui/dispatch.py
+++ b/bgate_ui/dispatch.py
@@ -540,16 +540,32 @@ def _prompt_for(root: str, item: dict, native_images: bool = False) -> str:
         + (policy + "\n\n" if policy else "")
         + "Protocol, in order:\n"
         "1. seat_brief for your role, ONCE. It carries mission, lanes, bible, "
-        "pinned refs and notes; a second call returns the same payload and "
-        "costs what the first one did.\n"
+        "pinned refs, notes and the BOARD — what every other agent is queued "
+        "for or working on right now. Read the board before touching a file a "
+        "dispatched peer owns or duplicating queued work; a second brief call "
+        "returns the same payload and costs what the first one did.\n"
         "2. Do the work inside your lanes. The PreToolUse hook enforces them, "
         "so write and let it refuse — seat_can_write is for when you need to "
         "know BEFORE a long generation, not a checkpoint before every edit. "
         "Lock binaries before editing.\n"
+        "   OUT-OF-LANE WORK IS ROUTED, NEVER DROPPED. If this task needs a "
+        "write another seat owns, queue_add(<that seat>, title, brief) files "
+        "it for an agent that CAN write it — pass depends_on="
+        f"{item['id']} when it needs this item's output — then keep working "
+        "on what is yours. A seat note, a LEFTOVERS block or a 'blocked' "
+        "result dispatches NOBODY; only a queue row does. Handing work on IS "
+        "part of finishing yours, and a result paragraph that names the items "
+        "you filed is a finished handoff.\n"
         f"3. Verify per house norms: {_verify_rule(root)}\n"
         f"4. Mark the item: call queue_complete with item_id={item['id']} and a "
         "one-paragraph result (status 'done', or 'failed' with the honest "
         "reason). That paragraph IS the record — no separate note is owed.\n"
+        "5. KEEP THE SEAT WARM. Before queue_complete, you may call "
+        "queue_claim_next() to claim the next READY item for your seat — then "
+        "complete this item and continue with the claimed one under the same "
+        "rules. Claim FIRST: once your item completes with nothing claimed, "
+        "the harness closes this session. An empty claim means you are done — "
+        "just complete and finish.\n"
         "\n"
         "Also: seat_post_note only when another seat must know something your "
         f"result paragraph will not tell them. Append to .bgate/progress/item-"
@@ -700,6 +716,22 @@ def _spawn(root: str, item_id: int, *, permission_mode: str = "acceptEdits",
                            k: v for k, v in verdict.items()
                            if k in ("scope", "spent", "ceiling")})
 
+    # THE RESERVATION — the queued->dispatched transition, taken atomically and
+    # FIRST. There are two dispatchers now (this function, and a worker's
+    # queue_claim_next in the MCP server process), and the old shape — read
+    # 'queued' here, write 'dispatched' after Popen — left a seconds-wide window
+    # in which both proceeded and one item got two agents. The UPDATE's WHERE
+    # clause means exactly one caller wins; every refusal past this point puts
+    # the item back through release(), which touches nothing but the status.
+    if not _queue.reserve(root, item_id):
+        return _refuse("not_queued",
+                       f"item {item_id} was taken by another dispatcher between "
+                       "the read and the reservation", item_id=item_id)
+
+    def _refused(code: str, message: str, **detail) -> dict:
+        _queue.release(root, item_id)
+        return _refuse(code, message, **detail)
+
     # The git boundary. A run dispatched on top of uncommitted work produces a
     # diff that cannot tell the agent's edits from the human's, so mixing them
     # has to be asked for.
@@ -707,10 +739,14 @@ def _spawn(root: str, item_id: int, *, permission_mode: str = "acceptEdits",
         allow_dirty = _flag(root, "dispatch.allow_dirty", "BGATE_ALLOW_DIRTY")
     state = _git.dirty(root)
     if state["available"] and state["dirty"] and not allow_dirty:
-        return _refuse("dirty_tree",
-                       f"{len(state['paths'])} uncommitted change(s) in the tree — "
-                       "commit or stash first, or dispatch with allow_dirty",
-                       paths=state["paths"][:50])
+        return _refused(
+            "dirty_tree",
+            f"{len(state['paths'])} uncommitted change(s) in the tree, so the "
+            "agent's edits could not be told from yours. Commit or stash them "
+            "and the board resumes on its own. (Finished runs commit their own "
+            "files when dispatch.auto_commit is on, which it is by default — so "
+            "what is dirty here is work the harness did not do.)",
+            paths=state["paths"][:50])
     base_commit = _git.head(root) if state["available"] else ""
     branch, worktree = "", ""
     cwd = str(root)
@@ -720,7 +756,7 @@ def _spawn(root: str, item_id: int, *, permission_mode: str = "acceptEdits",
     if base_commit and _flag(root, "dispatch.isolation", "BGATE_GIT_ISOLATION"):
         made = _git.make_worktree(root, item_id, base=base_commit)
         if not made["available"]:
-            return _refuse("worktree_failed", made["reason"])
+            return _refused("worktree_failed", made["reason"])
         branch, worktree = made["branch"], made["worktree"]
         cwd = worktree
 
@@ -733,11 +769,14 @@ def _spawn(root: str, item_id: int, *, permission_mode: str = "acceptEdits",
     exe = _executable(runner)
     blocked = _runners.preflight(runner, cwd, exe=exe)
     if blocked:
-        return _refuse("runner_unavailable", blocked, runner=runner.name)
+        return _refused("runner_unavailable", blocked, runner=runner.name)
     native_images = _native_images(root, runner)
 
     log_dir = Path(root) / ".bgate" / "agents"
-    log_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        log_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        return _refused("spawn_failed", f"cannot create the agent log dir: {exc}")
     log_path = log_dir / f"item-{item_id}.log"
 
     env = {
@@ -768,7 +807,10 @@ def _spawn(root: str, item_id: int, *, permission_mode: str = "acceptEdits",
                              model=model, cwd=cwd, native_images=native_images,
                              max_turns=_max_turns(root))
 
-    log_handle = open(log_path, "ab")
+    try:
+        log_handle = open(log_path, "ab")
+    except OSError as exc:
+        return _refused("spawn_failed", f"cannot open the agent log: {exc}")
     # RUN BOUNDARY: the log appends across re-dispatches, and both the activity
     # view and the steer-echo scanner must only look at THIS run — the stale
     # first-run result being shown as current, and old echoes falsely marking
@@ -780,9 +822,13 @@ def _spawn(root: str, item_id: int, *, permission_mode: str = "acceptEdits",
                                   "ts": _time.time()}) + "\n").encode("utf-8"))
     log_handle.flush()
     run_start_pos = log_handle.tell()
-    proc = subprocess.Popen(args, cwd=cwd, env=env,
-                            stdin=subprocess.PIPE, stdout=log_handle,
-                            stderr=log_handle, creationflags=_NO_WINDOW)
+    try:
+        proc = subprocess.Popen(args, cwd=cwd, env=env,
+                                stdin=subprocess.PIPE, stdout=log_handle,
+                                stderr=log_handle, creationflags=_NO_WINDOW)
+    except OSError as exc:
+        log_handle.close()
+        return _refused("spawn_failed", f"could not start the agent CLI: {exc}")
     # Deliver the task. A streaming runner takes it as the first user message
     # and keeps the pipe open as a steer channel; `codex exec` reads stdin ONCE
     # and acts on what it got, so the pipe has to be closed or the run never
@@ -800,6 +846,7 @@ def _spawn(root: str, item_id: int, *, permission_mode: str = "acceptEdits",
             proc.stdin.close()
     except OSError as exc:
         proc.kill()
+        _queue.release(root, item_id)
         return {"ok": False, "error": f"could not send prompt to agent: {exc}"}
     with _lock:
         _live[item_id] = {"proc": proc, "log": str(log_path), "handle": log_handle,
@@ -809,6 +856,10 @@ def _spawn(root: str, item_id: int, *, permission_mode: str = "acceptEdits",
                           # can be changed while this agent is mid-flight, and
                           # what it is running under is a fact about the run.
                           "runner": runner.name,
+                          # Carried for the auto-commit message: _finalize runs
+                          # after the item may already have been reopened, and
+                          # re-reading the row then would name the wrong round.
+                          "seat": item.get("seat") or "",
                           "cost_tracked": runner.cost_tracked,
                           "steerable": runner.steerable,
                           "native_images": native_images,
@@ -823,7 +874,9 @@ def _spawn(root: str, item_id: int, *, permission_mode: str = "acceptEdits",
                           # stop(item_id) has no root argument to be given one.
                           "root": str(root), "actor": actor,
                           "branch": branch, "worktree": worktree}
-    _queue.set_status(root, item_id, "dispatched")
+    # Status is already 'dispatched' — the reservation above wrote it before any
+    # of the slow work, which is what makes two dispatchers safe against each
+    # other. Writing it again here would wipe the item's result note for nothing.
     _queue.set_run_fields(root, item_id, base_commit=base_commit, branch=branch,
                           worktree=worktree, actor=actor or None,
                           max_cost_usd=ceiling_usd or None,
@@ -983,6 +1036,18 @@ def _trip(root: str, item_id: int, entry: dict, reason: str,
         _queue.set_status(root, item_id, "failed", result=note)
     except LookupError:
         pass
+    else:
+        # ANNOUNCE THE KILL. set_status never emits (by design — see
+        # queue.complete), and _reap skips complete() because the item is no
+        # longer 'dispatched' — so every ceiling kill was a failure with no
+        # item.failed event: no bell, no webhook, no auto-reopen, an item that
+        # just sat there. item.failed is in the default notify kinds; the most
+        # expensive failures this system has should be the loudest, not the
+        # only silent ones.
+        try:
+            _queue.emit_terminal(root, item_id)
+        except Exception:
+            pass
     _reap(root, item_id, entry, entry["proc"].poll())
 
 
@@ -1122,6 +1187,14 @@ def _watch_completion(root: str, item_id: int, poll_s: float = 2.0,
         if not entry.get("stdin_closed"):
             try:
                 if _queue.get(root, item_id)["status"] in ("done", "failed"):
+                    # THE PICKUP LOOP KEEPS THE PIPE OPEN. A worker that called
+                    # queue_claim_next before completing its item is still
+                    # working — closing stdin here would kill it mid-claim,
+                    # which turns the sanctioned loop into a trap. The run's
+                    # ceilings (runtime, stall, cost) still bound the whole
+                    # session, so this is not an escape from any limit.
+                    if _open_claims(root, item_id):
+                        continue
                     try:
                         entry["stdin"].close()
                     except OSError:
@@ -1144,6 +1217,21 @@ def _watch_completion(root: str, item_id: int, poll_s: float = 2.0,
             # run. Returning here left the entry in _live with a corpse in it,
             # which is exactly the stuck row this file keeps growing scars over.
             entry["eof_at"] = time.monotonic()
+
+
+def _open_claims(root: str, item_id: int) -> list[dict]:
+    """Items this run claimed via queue_claim_next and has not yet settled.
+
+    The claim stamp is the actor column (agent:item-<original id>), written by
+    queue.claim_next in the MCP server process — the DB is the only channel the
+    two processes share, which is why this is a query and not a field on the
+    _live entry. Best-effort: an unreadable DB answers 'no claims', which errs
+    toward closing a session rather than keeping a corpse alive.
+    """
+    try:
+        return _queue.claimed_open(root, f"agent:item-{item_id}")
+    except Exception:
+        return []
 
 
 def run_record_path(root: str, item_id: int) -> Path:
@@ -1202,6 +1290,53 @@ def _finalize(root: str, item_id: int, entry: dict) -> None:
                                                 scope["paths"])}
             run_record_path(root, item_id).write_text(
                 json.dumps(record), encoding="utf-8")
+    except Exception:
+        pass
+    _auto_commit(root, item_id, entry)
+
+
+def _auto_commit(root: str, item_id: int, entry: dict) -> None:
+    """Commit this run's own files, so the NEXT dispatch is not refused.
+
+    THE DEADLOCK. Nothing in this system committed anything, and dispatch
+    refuses a dirty tree by default — so the first agent to write a file
+    blocked every later dispatch, permanently, with a 20-second retry loop.
+    `dirty_tree` is a FLOOR refusal, so it stopped the whole board rather than
+    one item. Measured consequence: an overnight queue of thirty items woke up
+    with three done, twenty-six never started, and the autopilot toggle still
+    green.
+
+    ONLY THIS RUN'S PATHS (gitwork.commit_paths, never `commit -a`), so a
+    human's unrelated uncommitted work is not swept into an agent's commit —
+    and if THAT is what makes the tree dirty, it stays dirty and the next
+    dispatch is still refused, which is the rule working rather than being
+    bypassed.
+
+    Skipped for a worktree run: those already live on their own branch, which
+    is the isolation this exists to substitute for. Best effort throughout —
+    the work is on disk either way, and a failed commit must never turn a
+    finished run into a failed one.
+    """
+    if entry.get("worktree"):
+        return
+    if not _flag(root, "dispatch.auto_commit", "BGATE_AUTO_COMMIT"):
+        return
+    base = entry.get("base_commit") or ""
+    try:
+        scope = _git.touched(root, base)
+        if not scope.get("available") or not scope.get("paths"):
+            return
+        seat = str(entry.get("seat") or "")
+        made = _git.commit_paths(
+            root, scope["paths"],
+            f"bgate: item #{item_id}" + (f" [{seat}]" if seat else "")
+            + " — committed by the harness so the board keeps moving")
+        if made.get("ok"):
+            from bgate_core import activity as _act
+
+            _act.log(root, "dispatch",
+                     f"item {item_id}: committed {len(made['committed'])} "
+                     f"file(s) as {made['commit'][:8]}", ref=str(item_id))
     except Exception:
         pass
 
@@ -1272,6 +1407,18 @@ def _reap(root: str, item_id: int, entry: dict, code) -> dict:
                             failed=(outcome != "done"))
     except LookupError:
         pass
+    # CLAIMS DIE WITH THE RUN, BUT THE WORK DOES NOT. An item the agent claimed
+    # (queue_claim_next) and never completed goes back on the board as 'queued'
+    # rather than dying as a stranded 'dispatched' row — autodeploy re-dispatches
+    # it fresh, and nothing about it was attempted enough to call it failed.
+    try:
+        for claimed in _open_claims(root, item_id):
+            _queue.set_status(
+                root, int(claimed["id"]), "queued",
+                result=f"requeued: claimed by the agent on item {item_id}, "
+                       "which exited before starting or finishing it")
+    except Exception:
+        pass
     _finalize(root, item_id, entry)
     try:
         _unrecord_pid(root, entry["proc"].pid)
@@ -1290,6 +1437,19 @@ def _reap(root: str, item_id: int, entry: dict, code) -> dict:
     # the state this event is describing rather than 'dispatched'. Emitted for
     # every exit including a kill: "the agent is gone" is the fact, and the item's
     # own item.done/item.failed says whether the work landed.
+    # Tell autodeploy how this went. A runner that fails instantly on every
+    # item (an expired CLI login is the observed case) otherwise burns the whole
+    # queue to 'failed' inside ten minutes, because a dispatch that SPAWNS
+    # counts as a success and never triggers a cooldown.
+    try:
+        from bgate_ui import autodeploy as _auto
+
+        _auto.note_run_ended(
+            root, item_id, outcome,
+            float(max(0.0, time.monotonic() - float(entry["started_at"])))
+            if entry.get("started_at") else 0.0)
+    except Exception:
+        pass
     _emit(root, "agent.exited", ref=str(item_id),
           payload={"item": item_id, "outcome": outcome, "code": code,
                    "stopped_by": entry.get("stopped_by", ""),
@@ -1388,6 +1548,30 @@ def reconcile(root: str) -> dict:
         # again for everything the first had already made. Observed on #357:
         # marked failed at 02:54:07, generated another sheet at 02:54:22.
         if item_id in adopted_items:
+            continue
+        # A CLAIMED ITEM IS NOT A RUN OF ITS OWN. Its log lives under the
+        # CLAIMING item's id, so settling it against item-<id>.log below would
+        # always read "no result" and fail work that was merely queued behind a
+        # restart. If the claiming run is still alive (this server or adopted),
+        # leave the claim alone; otherwise requeue it untouched.
+        actor = str(item.get("actor") or "")
+        if actor.startswith("agent:item-"):
+            try:
+                origin = int(actor.split("agent:item-", 1)[1])
+            except ValueError:
+                origin = 0
+            with _lock:
+                origin_live = origin in _live
+            if origin and (origin_live or origin in adopted_items):
+                continue
+            try:
+                _queue.set_status(
+                    root, item_id, "queued",
+                    result="requeued: claimed by another run that did not "
+                           "survive a dashboard restart")
+                settled.append({"item_id": item_id, "status": "requeued"})
+            except Exception:
+                pass
             continue
         final = _final_event(root, item_id)
         if final.get("subtype") == "success":

--- a/bgate_ui/followup.py
+++ b/bgate_ui/followup.py
@@ -1346,6 +1346,19 @@ def tick(root: str | os.PathLike[str]) -> dict:
             _qa_gate.sweep(root)
         except Exception:
             pass
+        # THE SLICE CHECK — the only thing in the harness that reviews the GAME.
+        # On the sweep rather than a branch because it is not about any one
+        # event: it fires when the LAST slice row lands, whichever item that
+        # was, and its own due-check is idempotent (one open at a time, and
+        # never twice for an unchanged slice). A project with no game plan
+        # answers "not due" off one query.
+        try:
+            from bgate_core import gameplan as _gameplan
+
+            if _gameplan.slice_check_due(root).get("due"):
+                _gameplan.open_slice_check(root)
+        except Exception:
+            pass
     return {"seq": int(batch.get("seq") or main_seq),
             "notify_seq": int(pending.get("seq") or notify_seq),
             "actions": actions, "applied": applied,

--- a/bgate_ui/heartbeat.py
+++ b/bgate_ui/heartbeat.py
@@ -108,6 +108,19 @@ def _save(root, state: dict) -> None:
         pass
 
 
+def _due_again(mark: dict, threshold_s: int) -> bool:
+    """Has an already-reported stall gone unmentioned long enough to say again?
+
+    A mark records WHEN we last said something as well as what we said about.
+    Without the clock, "already reported" meant "never mention again", which is
+    right for the next ten minutes and wrong for the next three weeks.
+    """
+    said = float(mark.get("said_at") or 0.0)
+    if not said:
+        return False          # an old mark with no clock: stay quiet, as before
+    return (time.time() - said) >= max(int(threshold_s or 0), 3600)
+
+
 def _rows(root, sql: str, params: tuple = ()) -> list[dict]:
     try:
         return [dict(r) for r in db.connect(root).execute(sql, params).fetchall()]
@@ -224,9 +237,17 @@ def _tick(root: str | os.PathLike[str]) -> dict:
         if int(head.get("age_s") or 0) < threshold_s:
             continue                     # still inside the window
         covered.add(int(head["id"]))
-        if not moved:
+        if not moved and not _due_again(mark, threshold_s):
             # Already reported and nothing has changed since — stay quiet, but
             # keep the mark so it survives this tick's rewrite of the doc.
+            #
+            # NOT FOREVER, THOUGH. The mark is the subject's own updated_at, so
+            # a chain that stalled and then genuinely never moved kept matching
+            # its mark and was suppressed permanently — including across a
+            # three-week absence, where the stall is exactly what the person
+            # coming back needs told. _due_again re-reports a subject that is
+            # STILL stalled a full window after it was last mentioned, which
+            # bounds the repetition instead of silencing it.
             fresh_chain[chain_id] = mark
             continue
         why, held = _reason(root, head)
@@ -246,7 +267,7 @@ def _tick(root: str | os.PathLike[str]) -> dict:
         _events.emit(root, "chain.stalled", ref=chain_id, payload=payload)
         stalled.append(payload)
         fresh_chain[chain_id] = {"mark": str(head.get("updated_at") or ""),
-                                 "at": _stamp()}
+                                 "at": _stamp(), "said_at": time.time()}
 
     aging: list[dict] = []
     fresh_item: dict[str, dict] = {}
@@ -282,7 +303,7 @@ def _tick(root: str | os.PathLike[str]) -> dict:
         _events.emit(root, "item.aging", ref=str(item_id), payload=payload)
         aging.append(payload)
         fresh_item[key] = {"mark": str(row.get("updated_at") or ""),
-                           "at": _stamp()}
+                           "at": _stamp(), "said_at": time.time()}
 
     # Rewriting the doc from the marks we still believe in is what implements
     # "reset on movement": a subject that moved, closed, or dropped off the

--- a/bgate_ui/routes/workflows.py
+++ b/bgate_ui/routes/workflows.py
@@ -6,8 +6,10 @@ The canvas paints itself from these. Two rules shape the surface:
     graph — repainting must not re-ship what the browser already has. The graph
     comes back exactly once, from `GET .../runs/{id}?graph=1`, when a reloaded
     page re-attaches to a run it did not start;
-  * approving a gate goes through ``api.require_human``. A gate an agent can
-    open is decoration, and decoration is what the audit found here.
+  * approving a gate goes through ``api.require_human``, and so does starting a
+    node that spends. A gate an agent can open is decoration, and decoration is
+    what the audit found here — twice: the gate, and then the ▶ two nodes down
+    that could buy a video without passing the gate at all.
 
 Advancing is a POST rather than a side effect of the GET on purpose: a tick can
 create queue items and (optionally) spawn a session, and GETs skip the token
@@ -149,18 +151,48 @@ def run_one_node(run_id: int, node_id: str, request: Request,
     """
     payload = payload or {}
     r = root()
+    actor = api.current_actor(request)
     dispatch = payload.get("dispatch")
     if dispatch is not None:
         dispatch = bool(dispatch) and api.dispatch_enabled()
     try:
-        run = _workflows.run_node(r, run_id, node_id,
-                                  actor=api.current_actor(request),
+        # ▶ ON A PAID CARD IS A SPENDING DECISION, so it carries the same guard
+        # the gate and the pick routes carry. It did not: `actor` was passed
+        # through to an engine that ignored it, and this was the only route from
+        # which an agent could start a node that bills — a video shot, a music
+        # track, a model card — while being refused at the gate beside it.
+        if _workflows.spends_money(r, run_id, node_id):
+            api.require_human(actor, "running a step that spends money")
+        run = _workflows.run_node(r, run_id, node_id, actor=actor,
                                   dispatch=dispatch)
     except LookupError as exc:
         raise api.not_found(str(exc), run_id=run_id, node_id=node_id)
+    except PermissionError as exc:
+        raise api.ApiError(403, str(exc), code="forbidden")
     except ValueError as exc:
         raise api.conflict(str(exc), run_id=run_id, node_id=node_id)
     return api.ok(run)
+
+
+@router.post("/runs/{run_id}/reconcile")
+def reconcile_run(run_id: int) -> dict:
+    """Release steps a dead process left mid-flight, so the run can end.
+
+    The engine tracks in-flight workers in memory, so a restart during a
+    generation leaves the node at 'running' with nothing left to finish it. The
+    poll then waits for ever and an exclusive step holds everything behind it.
+    This is the verb the "wait for it to finish" message points at.
+    """
+    try:
+        return api.ok(_workflows.reconcile(root(), run_id))
+    except LookupError:
+        raise api.not_found(f"no workflow run {run_id}", run_id=run_id)
+
+
+@router.post("/reconcile")
+def reconcile_all() -> dict:
+    """The same sweep across every live run — what a dashboard boot wants."""
+    return api.ok(_workflows.reconcile(root()))
 
 
 @router.get("/runs/{run_id}/nodes/{node_id}/candidates")

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -13,7 +13,7 @@ Ordered roughly by when you will meet them.
 A standard way for an AI coding assistant to call tools that live outside
 itself. You register a server once; from then on, tools it exposes appear to the
 assistant as things it can call, the same way it can call "read a file".
-Builders Gate is one such server (`bgate_mcp/server.py`, some eighty tools). It runs on
+Builders Gate is one such server (`bgate_mcp/server.py`, some 180 tools). It runs on
 your machine, over stdin/stdout, with no network service and no cloud account.
 "Custom MCP" just means a server somebody wrote for their own domain instead of
 using an off-the-shelf one.

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -41,7 +41,7 @@ call the tools it exposes, the same way it calls "read a file". A "custom MCP"
 is nothing more exotic than a server somebody wrote for their own domain instead
 of using an off-the-shelf one.
 
-Builders Gate is one of those, for game development. It exposes some eighty
+Builders Gate is one of those, for game development. It exposes some 180
 tools: `godot_run`, `image_sprites`, `bible_add`, `asset_lock`,
 `playtest_start`, and so on. It runs on your machine as a local process talking
 over stdin and stdout. There is no network service, no account, no cloud. Each
@@ -132,6 +132,11 @@ developed against. Windows is the supported platform; Linux is best-effort and
 macOS is untested. Blender is optional and only matters for the 3D leg. An image
 API key (OpenAI or Krea) is optional and only matters for generated art.
 
+Python must be installed and on your `PATH` before any of this — check with
+`python --version`, and if that command is not found, install Python first. A
+virtual environment is optional but recommended, so this install cannot disagree
+with another project's dependencies.
+
 ```bash
 git clone https://github.com/Thepizzapie/BuildersGate
 cd BuildersGate
@@ -139,11 +144,33 @@ pip install -e .
 bgate doctor
 ```
 
-`bgate doctor` exits 1 if *anything* on its list of eight is missing. That is
-right for a CI step and alarming for a human: you only need Python and Godot for
-the core loop. Read the rows, not the exit code. The `art_key` row covers every
-art provider, so either `OPENAI_API_KEY` or `KREA_API_KEY` turns it green — and
-you can set either one from the dashboard (Settings → Art providers).
+**If `bgate` is "not recognized" on Windows**, nothing is broken: pip put the
+`bgate` shortcut in Python's `Scripts\` directory and that directory is not on
+your `PATH`. Either run `python -m pip install -e .` and then call every command
+the long way — `python -m bgate_cli.main doctor`, `python -m bgate_cli.main
+init`, and so on — or re-run the Python installer, choose Modify, tick **Add
+Python to PATH**, and open a new terminal, because `PATH` is read when the shell
+starts.
+
+### What `bgate doctor` is actually telling you
+
+It exits 1 if *anything* on its list is missing, and most of that list is
+optional. The exit code is right for a CI step and alarming for a human. Read the
+rows:
+
+| Row | Needed for |
+|---|---|
+| `python`, `godot` | **Required.** Making a project, building it, running it |
+| `blender` | Optional — the 3D leg |
+| `ffmpeg`, `ffprobe` | Optional — playtest capture, cutscene transcoding |
+| `whisper` | Optional — voice transcription while you play |
+| `art_key`, `local_image` | Optional — image generation, rented or local |
+| `imageto3d`, `local_runtimes`, `agent_cli`, `godot_web_templates` | Optional — capability inventory |
+
+**A red optional row is not a blocker.** If `python` and `godot` are green, go to
+the next step; you can add the rest the day you need it. The `art_key` row covers
+every art provider, so either `OPENAI_API_KEY` or `KREA_API_KEY` turns it green —
+and you can set either one from the dashboard (Settings → Art providers).
 
 ### 1. Make a project
 
@@ -195,12 +222,21 @@ without you) and the approval gate (does it FINISH without you).
 ### 3. Register the server and install the hook
 
 ```bash
+python -c "import sys; print(sys.executable)"    # prints <absolute-python-path>
 claude mcp add builders-gate --scope user -- <absolute-python-path> -m bgate_mcp.server
 bgate hook-install .
 bgate hook-status .
 ```
 
-Use the **absolute** python path. The Claude CLI's health check resolves a bare
+**Restart Claude Code now, before you look for the tools.** A session that was
+already running does not pick up a newly registered MCP server — only a fresh one
+does. Confirm it worked by asking Claude to call `project_status`; if that tool is
+not in its list, the server is not connected and nothing below will work.
+
+Use the **absolute** python path, and get it by running that first line *in the
+same environment where `pip install -e .` ran* — a different environment prints
+a Python that has no Builders Gate in it, and the registration then fails in a way
+that points nowhere near the cause. The Claude CLI's health check resolves a bare
 `python` differently than your shell does, and reports "failed to connect"
 against a server that runs fine.
 
@@ -236,6 +272,22 @@ work: writing the decision down where the fleet reads it.
 
 Pick something small. File it as a work item against `gameplay`. Dispatch it.
 Watch it in the Agents view. When it says it is done, look at the diff.
+
+#### Your first task, spelled out
+
+Ask Claude to file this, or type it into the dashboard's queue form:
+
+- **Seat:** `gameplay`
+- **Title:** Add a double jump
+- **Brief:** The player can jump once more while airborne, and the second jump
+  is weaker than the first. It resets on landing, not on a timer. Acceptance:
+  `godot_run` starts clean, and a `godot_screenshot` shows the player above the
+  height a single jump reaches.
+
+A brief that names what "done" looks like is the difference between one round
+and four. Filing it **files a database row and starts nothing** — the dashboard
+is what dispatches it, so `bgate serve` has to be running or the item just sits
+there looking exactly like work in flight.
 
 The loop the tool is built around, once you are past the first hour:
 

--- a/templates/shared/CLAUDE.md
+++ b/templates/shared/CLAUDE.md
@@ -65,7 +65,7 @@ This is the whole working cycle. Do it in this order.
 
 ## Seats
 
-Seven, fixed. `seat_list` for the live config, `seat_brief(role)` before you
+Eight, fixed. `seat_list` for the live config, `seat_brief(role)` before you
 work as one.
 
 | seat | owns |
@@ -76,31 +76,27 @@ work as one.
 | `tech` | engine, build, performance, project plumbing |
 | `art` | models, textures, sprites, the look |
 | `audio` | SFX, music hooks |
+| `cinematic` | cutscenes, trailers, attract-mode video |
 | `qa` | tests, repro, and the picky gate before anyone says "done" |
 
 Seats leave each other notes with `seat_post_note` / `seat_notes` — use it for
 "I changed the player collider, gameplay should re-tune the jump", not chat.
 
-### Leftovers: the integration you do not own
+### Integration you do not own: QUEUE IT
 
 You will constantly finish a system that needs one line in a file belonging to
-another seat. Do not half-land it and do not silently skip it. Write a
-**LEFTOVERS** block at the top of the file you *do* own, and put the same list
-in your spec:
+another seat. **`queue_add(that seat, title, brief)` — that is the whole
+answer.** Name the file, the call site and the exact line; pass
+`depends_on=<your item id>` if it needs your output first. Then keep working.
 
-```
-## LEFTOVERS: the integration this file deliberately does not make.
-## combat.gd is owned by another seat. Each is one line at a named site,
-## and NONE of them is written here.
-##
-##   combat.gd, the KO branch of _apply_damage():
-##     _inv.drop_all(u.id, u.pos)
-```
+A comment block, a seat note and a "blocked" result all dispatch **nobody**.
+Measured on a real board: fifteen files carried LEFTOVERS blocks, the newest
+of them was five hours newer than the last item anyone filed, and four
+generated assets were never wired in because the note asking for it was never
+a job. Handing the work on is part of finishing yours.
 
-One line, one named call site, verbatim. When somebody lands it, rewrite the
-entry in place with the date and what replaced it. Do not delete it. A
-leftover that vanishes silently teaches nobody anything, and a half-landed
-integration is indistinguishable from a bug.
+Leave a one-line comment at the call site too if it helps the next reader —
+but the queue row is the thing that makes it happen.
 
 ## Bible and lore — read before designing
 

--- a/tests/test_dialogue.py
+++ b/tests/test_dialogue.py
@@ -1,0 +1,268 @@
+"""Dialogue trees — the graph checks that run BEFORE the file lands.
+
+Every refusal here is a bug that is invisible in the JSON and expensive in the
+game: a choice pointing at a node that does not exist dead-ends on a branch most
+players never take, a node nothing reaches is content that was written and is
+not in the game, and a node from which no ending is reachable reads to a player
+as a hang. A schema catches none of the three; a graph walk catches all of them
+in microseconds.
+
+The refusal has to NAME the node. "invalid dialogue" hands the writer a hunt
+through 200 nodes for the one typo.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from bgate_core import dialogue, lore
+from bgate_mcp import server
+
+
+async def call(tool: str, /, **kwargs) -> dict:
+    result = await server.mcp.call_tool(tool, kwargs)
+    content = result[0] if isinstance(result, tuple) else result
+    block = content[0]
+    return json.loads(block.text) if hasattr(block, "text") else block
+
+
+@pytest.fixture()
+def wired(root, monkeypatch):
+    monkeypatch.setenv("BGATE_ROOT", str(root))
+    return root
+
+
+def tree() -> list[dict]:
+    """A small, valid conversation: a fork, a loop back, and two endings."""
+    return [
+        {"id": "greet", "speaker": "Keeper", "text": "The gate is shut.",
+         "choices": [{"text": "Open it.", "goto": "refuse"},
+                     {"text": "Who shut it?", "goto": "who"}]},
+        {"id": "who", "speaker": "Keeper", "text": "The ones who left.",
+         "choices": [{"text": "Then open it.", "goto": "refuse"},
+                     {"text": "I will wait.", "goto": "wait"}]},
+        {"id": "refuse", "speaker": "Keeper", "text": "Not for you.",
+         "choices": [{"text": "Ask again.", "goto": "who"},
+                     {"text": "Leave.", "goto": "leave"}]},
+        {"id": "wait", "speaker": "Keeper", "text": "Then wait.", "end": True},
+        {"id": "leave", "speaker": "Keeper", "text": "Go well.", "end": True},
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+class TestValidation:
+    def test_a_sound_tree_passes_and_reports_its_shape(self):
+        got = dialogue.validate(tree())
+        assert got["start"] == "greet"
+        assert got["ends"] == ["leave", "wait"]
+        assert len(got["nodes"]) == 5
+
+    def test_a_dangling_choice_target_is_refused_and_named(self):
+        nodes = tree()
+        nodes[0]["choices"][1]["goto"] = "whoo"          # one letter, weeks later
+        with pytest.raises(dialogue.DialogueError) as exc:
+            dialogue.validate(nodes)
+        message = str(exc.value)
+        assert "'greet'" in message and "'whoo'" in message
+        assert "not a node" in message
+
+    def test_an_orphan_node_is_refused_and_named(self):
+        nodes = tree()
+        nodes.append({"id": "secret", "text": "Nobody hears this.", "end": True})
+        with pytest.raises(dialogue.DialogueError) as exc:
+            dialogue.validate(nodes)
+        assert "'secret'" in str(exc.value)
+
+    def test_a_conversation_with_no_way_out_is_refused(self):
+        """A cycle with no reachable ending is not a crash and not a syntax
+        error — it is a player stuck in a loop, which reads as a hang."""
+        nodes = [
+            {"id": "a", "text": "...", "choices": [{"text": "on", "goto": "b"}]},
+            {"id": "b", "text": "...", "choices": [{"text": "back", "goto": "a"}]},
+            {"id": "out", "text": "bye", "end": True},
+        ]
+        with pytest.raises(dialogue.DialogueError) as exc:
+            dialogue.validate(nodes)
+        # The orphan check fires first here and names the unreachable ending;
+        # remove it and the trap itself is what refuses.
+        assert "'out'" in str(exc.value)
+
+        nodes = nodes[:2]
+        with pytest.raises(dialogue.DialogueError) as exc:
+            dialogue.validate(nodes)
+        assert "never finishes" in str(exc.value)
+
+    def test_a_trap_with_an_ending_elsewhere_is_still_refused(self):
+        nodes = tree()
+        # 'wait' stops being an ending and loops onto itself: reachable, linked,
+        # and a hole the player cannot climb out of.
+        nodes[3] = {"id": "wait", "text": "Then wait.",
+                    "choices": [{"text": "Keep waiting.", "goto": "wait"}]}
+        with pytest.raises(dialogue.DialogueError) as exc:
+            dialogue.validate(nodes)
+        assert "'wait'" in str(exc.value)
+        assert "cannot leave" in str(exc.value)
+
+    def test_a_node_that_neither_ends_nor_continues_is_refused(self):
+        nodes = tree()
+        nodes[3] = {"id": "wait", "text": "Then wait."}      # end flag forgotten
+        with pytest.raises(dialogue.DialogueError) as exc:
+            dialogue.validate(nodes)
+        assert "'wait'" in str(exc.value) and "end: true" in str(exc.value)
+
+    def test_an_ending_that_still_offers_choices_is_refused(self):
+        nodes = tree()
+        nodes[4]["choices"] = [{"text": "wait, no", "goto": "greet"}]
+        with pytest.raises(dialogue.DialogueError) as exc:
+            dialogue.validate(nodes)
+        assert "'leave'" in str(exc.value)
+
+    def test_duplicate_ids_are_refused_before_anything_points_at_them(self):
+        nodes = tree()
+        nodes[1]["id"] = "greet"
+        with pytest.raises(dialogue.DialogueError) as exc:
+            dialogue.validate(nodes)
+        assert "ambiguous" in str(exc.value)
+
+    def test_an_unlabelled_or_untargeted_choice_is_refused(self):
+        nodes = tree()
+        nodes[0]["choices"][0] = {"text": "", "goto": "refuse"}
+        with pytest.raises(dialogue.DialogueError):
+            dialogue.validate(nodes)
+        nodes = tree()
+        nodes[0]["choices"][0] = {"text": "Open it."}
+        with pytest.raises(dialogue.DialogueError) as exc:
+            dialogue.validate(nodes)
+        assert "goto" in str(exc.value)
+
+    def test_a_start_that_is_not_a_node_is_refused(self):
+        with pytest.raises(dialogue.DialogueError) as exc:
+            dialogue.validate(tree(), start="prologue")
+        assert "prologue" in str(exc.value)
+
+    def test_the_start_may_be_any_node_not_just_the_first(self):
+        nodes = tree()
+        nodes[0]["choices"].append({"text": "Wait here.", "goto": "wait"})
+        got = dialogue.validate(nodes, start="greet")
+        assert got["start"] == "greet"
+
+
+# ---------------------------------------------------------------------------
+# Writing
+# ---------------------------------------------------------------------------
+class TestWrite:
+    def test_it_lands_in_the_narrative_seats_own_lane(self, root):
+        got = dialogue.write(root, "Gate Keeper", tree())
+        assert got["name"] == "gate-keeper"
+        assert got["rel_path"] == "game/dialogue/gate-keeper.dialogue.json"
+        assert Path(got["path"]).is_file()
+
+    def test_the_file_is_json_godot_can_parse(self, root):
+        dialogue.write(root, "keeper", tree())
+        doc = json.loads(dialogue.path_for(root, "keeper").read_text("utf-8"))
+        assert doc["format"] == "bgate.dialogue"
+        assert doc["start"] == "greet"
+        assert [n["id"] for n in doc["nodes"]][0] == "greet"
+        assert doc["nodes"][0]["choices"][0]["goto"] == "refuse"
+
+    def test_a_broken_tree_writes_nothing_at_all(self, root):
+        nodes = tree()
+        nodes[0]["choices"][0]["goto"] = "nowhere"
+        with pytest.raises(dialogue.DialogueError):
+            dialogue.write(root, "keeper", nodes)
+        # The state this refuses to create: a file on disk that somebody imports.
+        assert not dialogue.path_for(root, "keeper").exists()
+
+    def test_read_and_list_round_trip(self, root):
+        dialogue.write(root, "keeper", tree())
+        got = dialogue.read(root, "keeper")
+        assert len(got["nodes"]) == 5
+        listing = dialogue.list_dialogues(root)
+        assert [d["name"] for d in listing] == ["keeper"]
+        assert listing[0]["ok"] is True
+
+    def test_a_hand_broken_file_is_flagged_by_the_listing(self, root):
+        dialogue.write(root, "keeper", tree())
+        path = dialogue.path_for(root, "keeper")
+        doc = json.loads(path.read_text("utf-8"))
+        doc["nodes"][0]["choices"][0]["goto"] = "gone"
+        path.write_text(json.dumps(doc), encoding="utf-8")
+        entry = dialogue.list_dialogues(root)[0]
+        assert entry["ok"] is False and "gone" in entry["error"]
+
+    def test_reading_something_that_is_not_there_says_so(self, root):
+        with pytest.raises(LookupError):
+            dialogue.read(root, "nobody")
+
+
+class TestCanonOnTheWayIn:
+    """The seat's mission says canon_check runs on every narrative write, and a
+    check the author has to remember is a check that happens on the good days."""
+
+    def _canon(self, root) -> None:
+        lore.add_entity(root, "faction", "The Ashen Order", status="canon")
+        lore.add_fact(root, "The Ashen Order",
+                      "The Ashen Order worships the flame.", locked=True)
+
+    def test_a_hard_conflict_refuses_the_write(self, root):
+        self._canon(root)
+        nodes = [{"id": "line", "end": True,
+                  "text": "The Ashen Order does not worship the flame."}]
+        with pytest.raises(dialogue.DialogueError) as exc:
+            dialogue.write(root, "heresy", nodes)
+        assert "canon_check" in str(exc.value)
+        assert not dialogue.path_for(root, "heresy").exists()
+
+    def test_the_conflict_can_be_overridden_when_the_canon_is_what_changed(self, root):
+        self._canon(root)
+        nodes = [{"id": "line", "end": True,
+                  "text": "The Ashen Order does not worship the flame."}]
+        got = dialogue.write(root, "heresy", nodes, allow_canon_conflict=True)
+        assert got["canon"]["verdict"] == "conflict"
+        assert dialogue.path_for(root, "heresy").is_file()
+
+    def test_choice_labels_are_checked_too_not_just_the_lines(self, root):
+        self._canon(root)
+        nodes = [
+            {"id": "ask", "text": "Well?",
+             "choices": [{"text": "The Ashen Order does not worship the flame.",
+                          "goto": "done"}]},
+            {"id": "done", "text": "...", "end": True},
+        ]
+        with pytest.raises(dialogue.DialogueError):
+            dialogue.write(root, "sly", nodes)
+
+    def test_a_review_flag_rides_along_instead_of_blocking(self, root):
+        got = dialogue.write(root, "keeper", tree())
+        # An unknown proper noun is the normal state of a first draft.
+        assert got["canon"]["verdict"] in ("ok", "review")
+        assert dialogue.path_for(root, "keeper").is_file()
+
+
+# ---------------------------------------------------------------------------
+# The MCP surface
+# ---------------------------------------------------------------------------
+@pytest.mark.anyio
+class TestMcpSurface:
+    async def test_the_narrative_seat_can_now_write_its_own_lane(self, wired):
+        got = await call("dialogue_write", name="keeper", nodes=tree())
+        assert got.get("ok") is True and got["nodes"] == 5
+        assert Path(got["path"]).is_file()
+
+    async def test_a_dangling_target_comes_back_as_an_error_payload(self, wired):
+        nodes = tree()
+        nodes[0]["choices"][1]["goto"] = "whoo"
+        got = await call("dialogue_write", name="keeper", nodes=nodes)
+        assert got.get("ok") is False
+        assert "whoo" in got["error"]
+
+    async def test_read_and_list_through_the_surface(self, wired):
+        await call("dialogue_write", name="keeper", nodes=tree())
+        got = await call("dialogue_read", name="keeper")
+        assert got["start"] == "greet"
+        listing = await call("dialogue_list")
+        assert listing["count"] == 1 and listing["broken"] == []

--- a/tests/test_gameplan.py
+++ b/tests/test_gameplan.py
@@ -1,0 +1,360 @@
+"""The game-plan compiler: manifest -> plan_row -> slice on the board."""
+from __future__ import annotations
+
+import pytest
+
+from bgate_core import gameplan, queue
+
+
+MANIFEST = [
+    {"kind": "scene", "name": "hub_room", "seat": "gameplay", "slice": True,
+     "acceptance": "boots headless, player node spawns"},
+    {"kind": "asset", "name": "hero_sheet", "seat": "art", "slice": True,
+     "acceptance": "idle+walk4, passes consistency_check",
+     "depends_on": ["hub_room"]},
+    {"kind": "sound", "name": "ambience_bed", "seat": "audio", "slice": False},
+]
+
+
+class TestValidate:
+    def test_rejects_unknown_kind_seat_and_dangling_dep(self):
+        with pytest.raises(ValueError, match="kind"):
+            gameplan.validate_manifest([{"kind": "vibe", "name": "x",
+                                         "seat": "art"}])
+        with pytest.raises(ValueError, match="seat"):
+            gameplan.validate_manifest([{"kind": "asset", "name": "x",
+                                         "seat": "wizard"}])
+        with pytest.raises(ValueError, match="not a manifest row"):
+            gameplan.validate_manifest([{"kind": "asset", "name": "x",
+                                         "seat": "art",
+                                         "depends_on": ["ghost"]}])
+
+    def test_rejects_a_cycle_naming_its_members(self):
+        two = [{"kind": "asset", "name": "a", "seat": "art",
+                "depends_on": ["b"]},
+               {"kind": "asset", "name": "b", "seat": "art",
+                "depends_on": ["a"]}]
+        with pytest.raises(ValueError, match="cycle"):
+            gameplan._ordered(gameplan.validate_manifest(two))
+
+
+class TestIngest:
+    def test_slice_rows_reach_the_board_with_their_dependency(self, root):
+        got = gameplan.ingest(root, MANIFEST, session_id=1)
+        assert got["rows"] == 3
+        assert len(got["slice_filed"]) == 2      # ambience_bed stays spec
+        hub = next(f for f in got["slice_filed"] if f["name"] == "hub_room")
+        hero = next(f for f in got["slice_filed"] if f["name"] == "hero_sheet")
+        assert hero["depends_on"] == hub["id"]   # a real link, not a priority
+        assert queue.get(root, hero["id"])["source"] == "game-plan"
+
+    def test_ingest_is_idempotent_on_names(self, root):
+        gameplan.ingest(root, MANIFEST, session_id=1)
+        again = gameplan.ingest(root, MANIFEST, session_id=1)
+        assert again["updated"] == 3
+        assert again["slice_filed"] == []        # items kept, not duplicated
+
+
+class TestStatus:
+    def test_status_answers_what_remains(self, root):
+        gameplan.ingest(root, MANIFEST, session_id=1)
+        before = gameplan.status(root)
+        assert before["rows"] == 3
+        assert before["spec"] == 1 and before["on_board"] == 2
+        assert before["slice"]["complete"] is False
+
+        for item in queue.list_items(root):
+            queue.set_status(root, item["id"], "done", result="landed")
+        after = gameplan.status(root)
+        assert after["built"] == 2
+        # BUILT IS NOT IN THE GAME. Nothing references these yet, so the slice
+        # is not complete and every row is still remaining — the whole point of
+        # the wired/verified states (see TestWiredAndVerified).
+        assert after["slice"]["complete"] is False
+        assert {r["name"] for r in after["remaining"]} == {
+            "hub_room", "hero_sheet", "ambience_bed"}
+
+    def test_a_failed_item_reads_lost_not_built(self, root):
+        gameplan.ingest(root, MANIFEST, session_id=1)
+        first = queue.list_items(root)[0]
+        queue.set_status(root, first["id"], "failed", result="died")
+        got = gameplan.status(root)
+        assert got["lost"] == 1
+
+
+class TestMultiParent:
+    """A game is a DAG: the scene needs the sprite AND the sound AND the script."""
+
+    FAN_IN = [
+        {"kind": "asset", "name": "hero_png", "seat": "art", "slice": True},
+        {"kind": "sound", "name": "step_wav", "seat": "audio", "slice": True},
+        {"kind": "scene", "name": "hero_scene", "seat": "gameplay", "slice": True,
+         "depends_on": ["hero_png", "step_wav"]},
+    ]
+
+    def test_every_parent_holds_the_child_not_just_the_first(self, root):
+        got = gameplan.ingest(root, self.FAN_IN, session_id=1)
+        scene = next(f for f in got["slice_filed"] if f["name"] == "hero_scene")
+        art = next(f for f in got["slice_filed"] if f["name"] == "hero_png")
+        audio = next(f for f in got["slice_filed"] if f["name"] == "step_wav")
+        assert sorted(queue.parents(root, scene["id"])) == sorted(
+            [art["id"], audio["id"]])
+
+        # The first parent landing is NOT enough — that was the old behaviour.
+        queue.set_status(root, art["id"], "done", result="painted")
+        held = queue.blocker(root, scene["id"])
+        assert held is not None and held["id"] == audio["id"]
+        assert queue.next_for(root, "gameplay") is None
+
+        queue.set_status(root, audio["id"], "done", result="recorded")
+        assert queue.blocker(root, scene["id"]) is None
+        assert queue.next_for(root, "gameplay")["id"] == scene["id"]
+
+    def test_blocker_names_the_others_it_is_also_waiting_on(self, root):
+        got = gameplan.ingest(root, self.FAN_IN, session_id=1)
+        scene = next(f for f in got["slice_filed"] if f["name"] == "hero_scene")
+        held = queue.blocker(root, scene["id"])
+        assert "also_waiting_on" in held
+
+
+class TestCutDependency:
+    def test_a_cancelled_predecessor_no_longer_strands_its_successor(self, root):
+        first = queue.add(root, "art", "the anchor")
+        second = queue.add(root, "gameplay", "needs it", depends_on=first["id"])
+        queue.set_status(root, first["id"], "cancelled", result="dropped")
+        assert queue.blocker(root, second["id"]) is not None   # the dead state
+
+        got = queue.cut_dependency(root, second["id"], first["id"], by="adrian")
+        assert got["ready"] is True
+        assert queue.blocker(root, second["id"]) is None
+        assert queue.next_for(root, "gameplay")["id"] == second["id"]
+
+    def test_cutting_an_extra_parent_leaves_the_others(self, root):
+        a = queue.add(root, "art", "a")
+        b = queue.add(root, "audio", "b")
+        child = queue.add(root, "tech", "c", depends_on=a["id"])
+        queue.add_dependency(root, child["id"], b["id"])
+        got = queue.cut_dependency(root, child["id"], b["id"], by="adrian")
+        assert got["still_waiting_on"] == [a["id"]]
+        assert got["ready"] is False
+
+    def test_cutting_what_is_not_a_dependency_is_refused(self, root):
+        a = queue.add(root, "art", "a")
+        b = queue.add(root, "tech", "b")
+        with pytest.raises(LookupError):
+            queue.cut_dependency(root, b["id"], a["id"])
+
+
+class TestWiredAndVerified:
+    """'built' flatters: a sprite on disk no scene references is not in the game."""
+
+    def _built(self, root):
+        gameplan.ingest(root, MANIFEST, session_id=1)
+        for item in queue.list_items(root):
+            queue.set_status(root, item["id"], "done", result="landed")
+
+    def test_a_built_row_no_scene_references_is_not_in_the_game(self, root):
+        self._built(root)
+        got = gameplan.status(root)
+        assert got["built"] == 2 and got["wired"] == 0
+        assert got["slice"]["complete"] is False        # built != playable
+        assert {r["name"] for r in got["remaining"]} >= {"hero_sheet"}
+
+    def test_a_scene_reference_moves_the_row_to_wired(self, root):
+        self._built(root)
+        scenes = root / "game" / "scenes"
+        scenes.mkdir(parents=True, exist_ok=True)
+        (scenes / "hub.tscn").write_text(
+            '[ext_resource type="Texture2D" path="res://assets/hero_sheet.png" '
+            'id="1"]\n', encoding="utf-8")
+        got = gameplan.status(root)
+        assert got["wired"] >= 1
+        assert "hero_sheet" not in {r["name"] for r in got["remaining"]}
+
+    def test_a_qa_pass_marks_the_row_verified(self, root):
+        self._built(root)
+        target = queue.list_items(root)[0]
+        gate = queue.add(root, "qa", "QA gate: verify", source="qa-gate",
+                         source_ref=str(target["id"]))
+        queue.set_status(root, gate["id"], "done",
+                         result="VERDICT: PASS — screenshots attached")
+        assert gameplan.status(root)["verified"] == 1
+
+    def test_a_gate_with_no_verdict_marker_does_not_verify(self, root):
+        self._built(root)
+        target = queue.list_items(root)[0]
+        gate = queue.add(root, "qa", "QA gate: verify", source="qa-gate",
+                         source_ref=str(target["id"]))
+        queue.set_status(root, gate["id"], "done", result="looked at it, seems ok")
+        assert gameplan.status(root)["verified"] == 0
+
+
+class TestSliceCheck:
+    def test_not_due_until_every_slice_row_is_built(self, root):
+        gameplan.ingest(root, MANIFEST, session_id=1)
+        assert gameplan.slice_check_due(root)["due"] is False
+        for item in queue.list_items(root):
+            queue.set_status(root, item["id"], "done", result="landed")
+        assert gameplan.slice_check_due(root)["due"] is True
+
+    def test_it_files_one_qa_item_that_reviews_the_game(self, root):
+        gameplan.ingest(root, MANIFEST, session_id=1)
+        for item in queue.list_items(root):
+            queue.set_status(root, item["id"], "done", result="landed")
+        got = gameplan.open_slice_check(root)
+        assert got["ok"] is True
+        filed = queue.get(root, got["item"])
+        assert filed["seat"] == "qa"
+        assert "godot_run" in filed["brief"] and "plan_status" in filed["brief"]
+        # And it names what is built but not referenced — the real finding.
+        assert "NOT REFERENCED" in filed["brief"]
+
+    def test_it_does_not_file_twice_for_an_unchanged_slice(self, root):
+        gameplan.ingest(root, MANIFEST, session_id=1)
+        for item in queue.list_items(root):
+            queue.set_status(root, item["id"], "done", result="landed")
+        first = gameplan.open_slice_check(root)
+        assert gameplan.slice_check_due(root)["due"] is False   # one is open
+        queue.set_status(root, first["item"], "done", result="VERDICT: PASS")
+        assert gameplan.slice_check_due(root)["due"] is False   # unchanged
+
+
+class TestLayoutLanes:
+    """The lanes must describe the repo that is actually here.
+
+    The default table assumes <root>/game; `bgate init` scaffolds into <root>
+    and an adopted repo has whatever its author chose. Against an ordinary
+    layout NO seat owned anything, so every dispatched agent was refused on
+    contact with the source tree.
+    """
+
+    def test_a_root_layout_project_is_detected_and_relaned(self, root):
+        from bgate_core import seats
+        (root / "project.godot").write_text(
+            'run/main_scene="res://scenes/main.tscn"\n', encoding="utf-8")
+        layout = seats.detect_layout(root)
+        assert layout["prefix"] == ""
+        assert layout["matches"] is False
+
+        # Before: the real source tree has no owner. (scripts/** happens to be
+        # in tech's lane already; scenes and assets are owned by nobody, which
+        # is what refuses the gameplay and art seats on contact.)
+        assert seats.lane_owners(root, "scenes/main.tscn") == []
+        assert seats.lane_owners(root, "assets/hero.png") == []
+        seats.apply_layout(root)
+        # After: the seats that own these in the scaffold layout own them here.
+        assert "gameplay" in seats.lane_owners(root, "scenes/main.tscn")
+        assert "art" in seats.lane_owners(root, "assets/hero.png")
+        assert seats.can_write(root, "gameplay", "scripts/player.gd")["allowed"]
+
+    def test_the_scaffold_layout_is_left_alone(self, root):
+        from bgate_core import seats
+        game = root / "game"
+        game.mkdir(exist_ok=True)
+        (game / "project.godot").write_text("\n", encoding="utf-8")
+        assert seats.detect_layout(root)["prefix"] == "game/"
+        got = seats.apply_layout(root)
+        assert got["changed"] is False
+        assert seats.can_write(root, "gameplay", "game/scripts/x.gd")["allowed"]
+
+    def test_relaning_never_hands_one_seat_the_whole_project(self, root):
+        from bgate_core import seats
+        lanes = seats.lanes_for_layout("")
+        # tech's game/** would collapse to a bare ** and swallow every other
+        # seat's lane; it must not survive the rewrite.
+        assert "**" not in lanes["tech"]
+        assert "*.godot" in lanes["tech"]
+
+    def test_doctor_reports_a_layout_mismatch(self, root):
+        from bgate_core import doctor
+        (root / "project.godot").write_text("\n", encoding="utf-8")
+        rows_ = {r["name"]: r for r in doctor.project_report(str(root))}
+        assert rows_["seat_lanes"]["ok"] is False
+        assert "bgate adopt" in rows_["seat_lanes"]["fix"]
+
+
+class TestDigest:
+    """The morning report — nothing else answered 'what happened overnight'."""
+
+    def test_it_separates_finished_failed_and_awaiting_you(self, root):
+        from bgate_core import gameplan as gp
+        a = queue.add(root, "art", "painted")
+        b = queue.add(root, "tech", "broke")
+        queue.set_status(root, a["id"], "done", result="landed")
+        queue.set_status(root, b["id"], "failed", result="killed: ceiling")
+        got = gp.digest(root)
+        assert [f["id"] for f in got["finished"]] == [a["id"]]
+        assert [f["id"] for f in got["failed"]] == [b["id"]]
+        assert "ceiling" in got["failed"][0]["why"]
+
+    def test_it_names_a_dirty_tree_as_the_reason_the_board_stopped(self, root):
+        import subprocess
+        from bgate_core import gameplan as gp
+        for args in (["init"], ["config", "user.email", "t@t"],
+                     ["config", "user.name", "t"]):
+            subprocess.run(["git", *args], cwd=root, capture_output=True)
+        (root / "seed.txt").write_text("s\n", encoding="utf-8")
+        subprocess.run(["git", "add", "-A"], cwd=root, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "seed"], cwd=root,
+                       capture_output=True)
+        queue.add(root, "art", "waiting forever")
+        (root / "someone_edited.gd").write_text("x\n", encoding="utf-8")
+        got = gp.digest(root)
+        # The signature of the deadlock, named rather than left to be guessed.
+        assert "uncommitted" in got["blocked"]
+        assert "whole board" in got["blocked"].lower()
+
+    def test_a_quiet_board_with_nothing_queued_is_not_reported_as_blocked(self, root):
+        from bgate_core import gameplan as gp
+        assert gp.digest(root)["blocked"] == ""
+
+
+class TestSpendAttributionAndGates:
+    """Money: who spent it, and whether anything asked first."""
+
+    def test_spend_rows_carry_the_seat_that_spent_them(self, root, monkeypatch):
+        from bgate_core import spend
+        monkeypatch.setenv("BGATE_SEAT", "art")
+        spend.record(root, 0.17, kind="image", detail="a sprite")
+        monkeypatch.setenv("BGATE_SEAT", "cinematic")
+        spend.record(root, 2.50, kind="video", detail="a shot")
+        by_seat = spend.totals(root)["by_seat"]
+        assert by_seat["art"]["usd"] == 0.17
+        assert by_seat["cinematic"]["usd"] == 2.5
+
+    def test_an_unattributed_row_is_grouped_not_dropped(self, root, monkeypatch):
+        from bgate_core import spend
+        monkeypatch.delenv("BGATE_SEAT", raising=False)
+        spend.record(root, 1.0, kind="image", detail="a human's own call")
+        totals = spend.totals(root)
+        # It must still sum: a by-seat view that silently loses rows is worse
+        # than no by-seat view.
+        assert totals["by_seat"]["(unattributed)"]["usd"] == 1.0
+        assert totals["project_usd"] == 1.0
+
+    def test_the_window_columns_exist_and_agree(self, root, monkeypatch):
+        from bgate_core import spend
+        monkeypatch.setenv("BGATE_SEAT", "art")
+        spend.record(root, 3.0, kind="image")
+        got = spend.totals(root)
+        assert got["today_usd"] == 3.0
+        assert got["week_usd"] == 3.0 and got["month_usd"] == 3.0
+        assert "agent_runs" in got
+
+    def test_every_paid_image_tool_asks_the_budget(self):
+        # The gate guarded ONE tool of twelve. This is the regression that
+        # notices if a paid path is added (or reverted) without one.
+        import ast
+        from pathlib import Path
+        src = Path("bgate_mcp/server.py").read_text(encoding="utf-8")
+        tree = ast.parse(src)
+        paid = {"image_generate", "image_edit", "item_generate", "item_variants",
+                "image_talkhead", "vfx_animate", "image_sprites", "voice_speak",
+                "kie_video_generate"}
+        ungated = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name in paid:
+                body = ast.get_source_segment(src, node) or ""
+                if "_spend_gate" not in body and "_gate_images" not in body:
+                    ungated.append(node.name)
+        assert ungated == [], f"paid tools that never ask the budget: {ungated}"

--- a/tests/test_hook.py
+++ b/tests/test_hook.py
@@ -674,3 +674,64 @@ class TestHarnessMetadataLane:
         manifest = next(r for r in brief["rules"] if r.startswith("WORK MANIFEST"))
         assert ".bgate/progress/" in manifest
         assert seats.can_write(root, "qa", ".bgate/progress/item-1.jsonl")["allowed"]
+
+
+class TestRefusalsRoute:
+    """A refusal that only names the wall teaches an agent to stop.
+
+    The observed pattern on a real board: a worker hit its lane, correctly
+    refused to trespass, wrote a LEFTOVERS block or a seat note, and closed —
+    and nothing was ever queued for the seat that owned the path. The refusal
+    is the one message guaranteed to arrive at that exact moment, so it now
+    carries the route: which seat owns the path, and the queue_add call that
+    hands the work over.
+    """
+
+    def test_a_lane_refusal_names_the_owning_seat_and_the_handoff(self, root):
+        # gameplay writing an asset: art's game/assets/** is the most specific
+        # owner and must be named ahead of tech's blanket game/**.
+        code, msg = hook.decide(payload("Write", str(root / "game/assets/rock.png")),
+                                "gameplay")
+        assert code == hook.BLOCK
+        assert "queue_add('art'" in msg
+        assert "depends_on" in msg
+        assert "Do NOT stop" in msg
+
+    def test_the_most_specific_lane_wins_over_a_blanket_one(self, root):
+        # audio's game/assets/audio/** beats art's game/assets/** and
+        # tech's game/**.
+        code, msg = hook.decide(
+            payload("Write", str(root / "game/assets/audio/hit.wav")), "gameplay")
+        assert code == hook.BLOCK
+        assert "queue_add('audio'" in msg
+
+    def test_an_unowned_path_names_the_layout_mismatch_not_a_dead_route(self, root):
+        # Routing this to the director was wrong: its lane is design/**, so the
+        # escalation target cannot write it either. An adopted repo (or one
+        # `bgate init` scaffolded into <root>) hits this for EVERY path.
+        code, msg = hook.decide(payload("Write", str(root / "orphan/nobody.txt")),
+                                "gameplay")
+        assert code == hook.BLOCK
+        assert "seat_configure" in msg
+        assert "layout" in msg
+        assert "queue_add('director'" not in msg
+
+    def test_a_lease_refusal_suggests_depending_on_the_holding_item(self, root):
+        target = root / "game" / "scripts" / "shared.gd"
+        data = {"tool_name": "Write", "cwd": str(root),
+                "tool_input": {"file_path": str(target)}}
+        assert hook.decide(data, "gameplay", "item-12")[0] == hook.ALLOW
+        code, msg = hook.decide(data, "tech", "item-13")
+        assert code == hook.BLOCK
+        assert "depends_on=12" in msg
+        assert "do not poll" in msg
+
+    def test_the_directors_refusal_is_unchanged(self, root):
+        # The director's tail predates this and is asserted elsewhere; this
+        # guards that the worker route did not replace it.
+        data = {"tool_name": "Write", "cwd": str(root), "session_id": "dddd-4444",
+                "tool_input": {"file_path": str(root / "game/scripts/x.gd")}}
+        code, msg = hook.decide(data, hook.DIRECTOR_SEAT,
+                                hook.session_owner(data), "block")
+        assert code == hook.BLOCK
+        assert "queue_add(seat, ...)" in msg

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -177,3 +177,53 @@ async def test_handoff_rejects_a_bad_kind_as_a_payload(wired):
     # act on, not a raised exception that reads as a broken server.
     got = await call("handoff_note", kind="vibes", text="x")
     assert got.get("error") and got.get("ok") is False
+
+
+@pytest.mark.anyio
+class TestQueueReopenCountsRounds:
+    """queue_reopen used to bypass queue.reopen, so ``attempts`` stayed 0
+    forever — and attempts is the round counter the QA gate's max-rounds cap
+    reads, so the fail/reopen loop the cap exists for could never trip it."""
+
+    async def test_reopen_increments_attempts_and_appends_the_reason(self, wired):
+        from bgate_core import queue as _q
+        item = _q.add(wired, "tech", "verify the door")
+        _q.set_status(wired, item["id"], "done", result="looked fine")
+        got = await call("queue_reopen", item_id=item["id"],
+                         reason="the hinge is backwards")
+        assert got["status"] == "queued"
+        assert int(got["attempts"]) == 1
+        assert "hinge is backwards" in got["brief"]
+
+    async def test_reopen_refuses_a_running_item(self, wired):
+        from bgate_core import queue as _q
+        item = _q.add(wired, "tech", "in flight")
+        _q.reserve(wired, item["id"])
+        got = await call("queue_reopen", item_id=item["id"], reason="too soon")
+        assert "error" in got and "dispatched" in got["error"]
+
+
+@pytest.mark.anyio
+class TestQueueClaimNext:
+    """The pickup loop, at the surface a worker actually calls."""
+
+    async def test_a_session_with_no_work_item_may_not_claim(self, wired, monkeypatch):
+        monkeypatch.delenv("BGATE_SEAT", raising=False)
+        monkeypatch.delenv("BGATE_WORK_ITEM", raising=False)
+        got = await call("queue_claim_next")
+        assert "error" in got and "pickup loop" in got["error"]
+
+    async def test_a_worker_claims_for_its_own_seat_with_its_run_identity(
+            self, wired, monkeypatch):
+        from bgate_core import queue as _q
+        monkeypatch.setenv("BGATE_SEAT", "art")
+        monkeypatch.setenv("BGATE_WORK_ITEM", "41")
+        _q.add(wired, "tech", "not art's problem to claim")
+        target = _q.add(wired, "art", "paint the next thing")
+        got = await call("queue_claim_next")
+        assert got.get("claimed") is True
+        assert got["id"] == target["id"]
+        assert got["actor"] == "agent:item-41"
+        # And the well runs dry honestly: nothing ready means finish the shift.
+        again = await call("queue_claim_next")
+        assert again.get("empty") is True

--- a/tests/test_music.py
+++ b/tests/test_music.py
@@ -19,6 +19,10 @@ WHAT IS ACTUALLY BEING PINNED, since most of this is one call deep:
 """
 from __future__ import annotations
 
+import contextlib
+import json
+from datetime import datetime, timedelta, timezone
+
 import pytest
 from fastapi.testclient import TestClient
 
@@ -263,6 +267,53 @@ class TestUnpricedSaysSo:
 
     def test_price_for_is_never_zero(self):
         assert kie.price_for() is None
+
+    def test_a_failed_run_says_the_cost_is_unknown_not_absent(self, root, fake,
+                                                               tmp_path):
+        # A failed run used to carry none of these keys, so a caller doing
+        # `result.get("credits_consumed", 0)` scored a charge that may well have
+        # happened as free — the same folding-to-zero estimate_usd refuses to do
+        # on the video side.
+        fake.status, fake.tracks = "SENSITIVE_WORD_ERROR", []
+        got = kie.generate_music("hum", str(tmp_path / "o"), root=root)
+        assert got["ok"] is False
+        assert got["estimated_usd"] is None
+        assert got["credits_consumed"] is None
+        assert got["credits_source"] == "unavailable"
+        assert got["accounted"] is False
+
+
+class TestTheTaskIdReachesTheCallerAtSubmit:
+    """generate_video has had this hook since it was written; generate_music
+    took no callback at all, so its callers could only learn the id from a
+    return value — which a killed process never produces."""
+
+    def test_on_submit_fires_before_the_poll(self, root, fake, tmp_path,
+                                              monkeypatch):
+        # BEFORE, not after: the poll is the minutes-long window in which dying
+        # costs money, so an id handed over on the far side of it is an id
+        # nobody ever gets.
+        order = []
+        polled = kie.poll_music
+
+        def watch(*args, **kwargs):
+            order.append("poll")
+            return polled(*args, **kwargs)
+
+        monkeypatch.setattr(kie, "poll_music", watch)
+        kie.generate_music("hum", str(tmp_path / "o"), root=root,
+                           on_submit=lambda task_id: order.append(task_id))
+        assert order == ["task-1", "poll"]
+
+    def test_a_broken_on_submit_does_not_lose_the_batch(self, root, fake,
+                                                         tmp_path):
+        # Bookkeeping must never lose the audio it was bookkeeping.
+        def boom(_task_id):
+            raise RuntimeError("the ledger is on fire")
+
+        got = kie.generate_music("hum", str(tmp_path / "o"), root=root,
+                                 on_submit=boom)
+        assert got["ok"] and got["count"] == 2
 
 
 # ---------------------------------------------------------------------------
@@ -551,6 +602,249 @@ class TestStatusReportsAndRecoverActs:
         fake.status, fake.tracks = "PENDING", []
         got = music.recover(root, "task-1")
         assert got["ok"] is False and "still running" in got["error"]
+
+
+# ---------------------------------------------------------------------------
+# Charged-and-lost: the window between the submit and the download
+# ---------------------------------------------------------------------------
+class Killed(RuntimeError):
+    """The process dying mid-poll, which is the whole point of the ticket.
+
+    Deliberately NOT a KieError: generate_music catches those and hands the task
+    id back on the result, which is the path that already worked. What had never
+    been survivable is the one where nothing gets returned at all.
+    """
+
+
+def _tickets(root):
+    """Every pending ticket on disk, decoded, oldest name first."""
+    directory = root / music.PENDING_DIR
+    if not directory.is_dir():
+        return []
+    return [json.loads(p.read_text(encoding="utf-8"))
+            for p in sorted(directory.glob("*.json"))]
+
+
+def _age_tickets(root, seconds):
+    """Backdate every ticket, so a sweep sees an hour-old generation without
+    the test sleeping for one."""
+    when = (datetime.now(timezone.utc)
+            - timedelta(seconds=seconds)).isoformat(timespec="seconds")
+    for path in (root / music.PENDING_DIR).glob("*.json"):
+        record = json.loads(path.read_text(encoding="utf-8"))
+        record["updated_at"] = when
+        path.write_text(json.dumps(record), encoding="utf-8")
+
+
+@contextlib.contextmanager
+def _killed_at(where):
+    """Kill the process at one point in the generation and put it back.
+
+    NOT monkeypatch: the `fake` fixture shares this test's monkeypatch instance,
+    so a mid-test ``undo()`` would also unstub kie's HTTP seam and every
+    assertion after it would be measuring a failed network call instead of the
+    thing under test — which is exactly what it did.
+    """
+    real = getattr(kie, where)
+
+    def boom(*_a, **_k):
+        raise Killed(f"the process died at {where}")
+
+    setattr(kie, where, boom)
+    try:
+        yield
+    finally:
+        setattr(kie, where, real)
+
+
+@contextlib.contextmanager
+def _ticket_never_closed():
+    """A crash between the download and the ticket being closed."""
+    real = music._close_ticket
+    music._close_ticket = lambda *_a, **_k: None
+    try:
+        yield
+    finally:
+        music._close_ticket = real
+
+
+class TestTheTaskIdSurvivesTheProcess:
+    """THE CHARGE LANDS AT SUBMIT AND THE POLL RUNS FOR MINUTES AFTERWARDS.
+
+    The task id used to reach durable storage only inside _absorb — that is,
+    after a download that had already succeeded — so the single window in which
+    dying costs money was the only window in which nothing had been written
+    down. recover() needs a task id; a killed process took the only copy with
+    it.
+    """
+
+    def test_the_task_id_is_on_disk_before_the_poll_begins(self, root, fake):
+        with _killed_at("poll_music"), pytest.raises(Killed):
+            music.generate(root, "night chase", name="chase")
+
+        ticket = _tickets(root)
+        assert len(ticket) == 1
+        assert ticket[0]["task_id"] == "task-1", \
+            "the batch was charged for and the handle died with the process"
+        assert ticket[0]["logical_name"] == "chase"
+
+    def test_a_crash_after_submit_is_recoverable(self, root, fake):
+        # The proof that the id is worth persisting: a fresh call collects the
+        # audio kie is already holding, and pays nothing for it.
+        with _killed_at("poll_music"), pytest.raises(Killed):
+            music.generate(root, "night chase", name="chase")
+
+        task_id = _tickets(root)[0]["task_id"]
+        got = music.recover(root, task_id)
+        assert got["ok"] and got["count"] == 2
+        assert got["estimated_usd"] is None      # charged at submit, not now
+        for candidate in got["candidates"]:
+            assert (root / candidate["path"]).is_file()
+
+    def test_the_recovery_lands_under_the_name_the_human_asked_for(self, root,
+                                                                    fake):
+        # No revision was ever registered, so the artifact scan has nothing to
+        # match — before the ticket carried the name, this came back called
+        # `night-run` (Suno's title) or twelve hex characters.
+        with _killed_at("poll_music"), pytest.raises(Killed):
+            music.generate(root, "night chase", name="Chase Theme")
+
+        assert music.recover(root, "task-1")["logical_name"] == "chase-theme"
+
+    def test_collecting_the_batch_closes_the_ticket(self, root, fake):
+        with _killed_at("poll_music"), pytest.raises(Killed):
+            music.generate(root, "night chase", name="chase")
+
+        music.recover(root, "task-1")
+        assert _tickets(root) == [], "a collected batch is owed nothing"
+
+    def test_a_finished_generation_leaves_nothing_pending(self, root, fake):
+        music.generate(root, "night chase", name="chase")
+        assert _tickets(root) == []
+
+    def test_a_prompt_kie_refused_is_not_reported_as_lost_money(self, root,
+                                                                 fake):
+        # Nothing was submitted, so nothing is owed. A sweep that cried wolf
+        # over every rejected prompt is a sweep nobody reads.
+        got = music.generate(root, "x" * 600, name="toolong")
+        assert got["ok"] is False and not got.get("task_id")
+        assert _tickets(root) == []
+
+    def test_a_cancel_after_the_submit_stays_pending(self, root, fake):
+        # kie hands the id back on the result here, but the batch is still paid
+        # for and uncollected — which is precisely what the sweep is for.
+        seen = []
+
+        def stop(_f, _w, _s):
+            seen.append(1)
+            if len(seen) > 1:
+                raise kie.MusicCancelled("the human pressed cancel")
+
+        got = music.generate(root, "night chase", name="chase",
+                             on_progress=stop)
+        assert got["ok"] is False and got["task_id"] == "task-1"
+        assert _tickets(root)[0]["task_id"] == "task-1"
+
+
+class TestStuckAndPaidFor:
+    """A dead poll loop used to be unrecoverable AND invisible. recover() has
+    always been able to collect a batch — what was missing is anything that
+    NOTICES, so recovery depended on a human remembering a task id they had
+    never been shown."""
+
+    def _stranded(self, root, *, age_s=3600, at_submit=False):
+        """One generation charged for and abandoned, aged into the sweep."""
+        where = "submit_music" if at_submit else "poll_music"
+        with _killed_at(where), pytest.raises(Killed):
+            music.generate(root, "night chase", name="chase")
+        _age_tickets(root, age_s)
+
+    def test_a_generation_inside_its_window_is_not_swept(self, root, fake,
+                                                          monkeypatch):
+        """A Suno batch renders in about three minutes. Calling one of those
+        stuck is how a human pays twice for work that is running fine."""
+        self._stranded(root, age_s=60)
+        assert music.stuck_tracks(root, poll=False)["stale"] == 0
+
+    def test_a_finished_batch_nobody_collected_is_found(self, root, fake,
+                                                         monkeypatch):
+        self._stranded(root)
+        got = music.stuck_tracks(root)
+        assert got["recoverable"] == 1
+        one = got["tracks"][0]
+        assert one["state"] == "recoverable" and one["task_id"] == "task-1"
+        assert one["logical_name"] == "chase"
+        assert "pays twice" in one["note"]
+
+    def test_the_cheap_half_asks_kie_nothing(self, root, fake, monkeypatch):
+        """It rides on every dashboard refresh, so it must cost no round trip."""
+        self._stranded(root)
+
+        def never(*_a, **_k):
+            raise AssertionError("poll=False must not reach the provider")
+
+        monkeypatch.setattr(music, "status", never)
+        got = music.stuck_tracks(root, poll=False)
+        assert got["tracks"][0]["state"] == "unpolled" and got["polled"] is False
+
+    def test_a_job_still_running_is_not_reported_as_money_to_collect(
+            self, root, fake, monkeypatch):
+        self._stranded(root)
+        fake.status, fake.tracks = "FIRST_SUCCESS", []
+        got = music.stuck_tracks(root)
+        assert got["tracks"][0]["state"] == "running" and got["recoverable"] == 0
+
+    def test_a_dead_generation_is_not_offered_for_recovery(self, root, fake,
+                                                            monkeypatch):
+        self._stranded(root)
+        fake.status, fake.tracks = "SENSITIVE_WORD_ERROR", []
+        got = music.stuck_tracks(root)
+        assert got["tracks"][0]["state"] == "failed" and got["recoverable"] == 0
+
+    def test_a_provider_that_cannot_be_asked_is_unknown_not_resolved(
+            self, root, fake, monkeypatch):
+        self._stranded(root)
+
+        def boom(*_a, **_k):
+            raise kie.KieError("could not reach kie")
+
+        monkeypatch.setattr(music, "status", boom)
+        got = music.stuck_tracks(root)
+        assert got["tracks"][0]["state"] == "unknown" and got["recoverable"] == 0
+
+    def test_a_generation_with_no_task_id_is_its_own_category(self, root, fake,
+                                                               monkeypatch):
+        """The worst one: the submit left and the handle did not come back."""
+        self._stranded(root, at_submit=True)
+        got = music.stuck_tracks(root, poll=False)
+        assert got["tracks"][0]["state"] == "lost"
+        assert "no handle" in got["tracks"][0]["note"]
+
+    def test_a_batch_already_filed_is_not_reported_as_money_to_spend_again(
+            self, root, fake, monkeypatch):
+        # A crash between the download and the ticket being closed leaves one of
+        # these behind. The takes ARE registered; reporting them as collectable
+        # is how a human pays for audio they already have.
+        with _ticket_never_closed():
+            music.generate(root, "night chase", name="chase")
+        _age_tickets(root, 3600)
+
+        got = music.stuck_tracks(root)
+        assert got["tracks"][0]["state"] == "collected"
+        assert got["recoverable"] == 0
+
+    def test_recovering_clears_it_from_the_sweep(self, root, fake, monkeypatch):
+        self._stranded(root)
+        assert music.stuck_tracks(root)["recoverable"] == 1
+        music.recover(root, "task-1")
+        assert music.stuck_tracks(root)["stale"] == 0
+
+    def test_the_sweep_says_the_deadline_it_is_racing(self, root, fake,
+                                                       monkeypatch):
+        # kie holds the audio for fourteen days; a recovery offered without its
+        # expiry reads as an errand that can wait.
+        self._stranded(root)
+        assert music.stuck_tracks(root, poll=False)["retention_days"] == 14
 
 
 class TestProgressIsReported:

--- a/tests/test_qa_runner.py
+++ b/tests/test_qa_runner.py
@@ -1,0 +1,209 @@
+"""godot_test_run — the QA seat's missing test runner.
+
+The seat's mission is "Own tests, repro, regression" and there was no MCP tool
+that ran a test: the only path was hand-rolling a godot_run per script and
+counting PASS lines by eye, which is not a thing a fail/reopen gate can be built
+on. The brief demands "tests at the known baseline, no new failures", so the
+result has to be structured enough to answer that in one call.
+
+The engine is faked here on purpose. What is under test is discovery (both
+project layouts), scoring (exit code is NOT enough — Godot prints SCRIPT ERROR
+and exits 0), and the no-tests case, none of which need a 170 MB binary. The
+real subprocess path is bgate_adapters/godot.py's, tested there.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from bgate_adapters import godot as _godot
+from bgate_mcp import server
+
+
+async def call(tool: str, /, **kwargs) -> dict:
+    result = await server.mcp.call_tool(tool, kwargs)
+    content = result[0] if isinstance(result, tuple) else result
+    block = content[0]
+    return json.loads(block.text) if hasattr(block, "text") else block
+
+
+@pytest.fixture()
+def wired(root, monkeypatch):
+    monkeypatch.setenv("BGATE_ROOT", str(root))
+    return root
+
+
+def _godot_project(root, layout: str = "game"):
+    """A project.godot in one of the two layouts the repo actually ships."""
+    base = (root / "game") if layout == "game" else root
+    base.mkdir(parents=True, exist_ok=True)
+    (base / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    return base
+
+
+def _fake_engine(monkeypatch, outputs: dict, seen: list | None = None):
+    """Stand in for a headless Godot: keyed on a marker in the script source."""
+    def run_script(script, project_dir=None, timeout=120):
+        if seen is not None:
+            seen.append({"script": script, "project_dir": project_dir,
+                         "timeout": timeout})
+        for marker, result in outputs.items():
+            if marker in script:
+                return {"stdout": "", "stderr": "", "exit_code": 0,
+                        "seconds": 0.1, "errors": [], "ok": True, **result}
+        return {"ok": True, "stdout": "", "stderr": "", "exit_code": 0,
+                "seconds": 0.1, "errors": []}
+
+    monkeypatch.setattr(_godot, "run_script", run_script)
+
+
+@pytest.mark.anyio
+class TestNoTests:
+    """"0 failures" out of nothing run is the most misleading answer available:
+    a regression gate that silently tests nothing looks exactly like a green one."""
+
+    async def test_a_project_with_no_godot_project_says_so(self, wired):
+        got = await call("godot_test_run")
+        assert got["ok"] is False and got["no_tests"] is True
+        assert "project.godot" in got["error"]
+
+    async def test_a_project_with_no_test_scripts_is_not_a_pass(self, wired):
+        _godot_project(wired)
+        got = await call("godot_test_run")
+        assert got["ok"] is False and got["no_tests"] is True
+        assert got["scripts_run"] == 0
+        # Where it looked, so the answer is actionable rather than a shrug.
+        assert "tests" in got["tests_dir"]
+        assert "no regression baseline" in got["error"]
+
+    async def test_a_named_script_that_does_not_exist_is_named_back(self, wired):
+        _godot_project(wired)
+        got = await call("godot_test_run", paths=["tests/ghost.gd"])
+        assert got["no_tests"] is True and got["missing"] == ["tests/ghost.gd"]
+
+
+@pytest.mark.anyio
+class TestDiscovery:
+    async def test_it_finds_tests_in_the_scaffold_layout(self, wired, monkeypatch):
+        base = _godot_project(wired, "game")
+        (base / "tests").mkdir()
+        (base / "tests" / "fight_test.gd").write_text("# MARK\nPASS\n",
+                                                      encoding="utf-8")
+        _fake_engine(monkeypatch, {"MARK": {"stdout": "PASS one\nPASS two\n"}})
+        got = await call("godot_test_run")
+        assert got["ok"] is True
+        assert [s["script"] for s in got["scripts"]] == ["tests/fight_test.gd"]
+
+    async def test_it_finds_tests_in_the_cli_layout_too(self, wired, monkeypatch):
+        # `bgate init` puts project.godot at the ROOT. Everything that hardcoded
+        # <root>/game silently did nothing for every CLI-created project.
+        base = _godot_project(wired, "root")
+        (base / "tests").mkdir()
+        (base / "tests" / "smoke_test.gd").write_text("# MARK\n", encoding="utf-8")
+        _fake_engine(monkeypatch, {"MARK": {"stdout": "PASS\n"}})
+        got = await call("godot_test_run")
+        assert got["scripts_run"] == 1
+        assert got["godot_project"] == str(base)
+
+    async def test_the_scripts_run_against_the_godot_project(self, wired,
+                                                             monkeypatch):
+        base = _godot_project(wired)
+        (base / "tests").mkdir()
+        (base / "tests" / "a_test.gd").write_text("# MARK\nbody\n",
+                                                  encoding="utf-8")
+        seen: list = []
+        _fake_engine(monkeypatch, {"MARK": {"stdout": "PASS\n"}}, seen)
+        await call("godot_test_run", timeout=42)
+        assert seen[0]["project_dir"] == str(base)
+        assert seen[0]["timeout"] == 42
+        # The script's OWN source is what runs — res:// loads inside it resolve
+        # because --path points at the project.
+        assert "body" in seen[0]["script"]
+
+
+@pytest.mark.anyio
+class TestScoring:
+    def _suite(self, root):
+        base = _godot_project(root)
+        (base / "tests").mkdir()
+        (base / "tests" / "green_test.gd").write_text("# GREEN\n", encoding="utf-8")
+        (base / "tests" / "red_test.gd").write_text("# RED\n", encoding="utf-8")
+        return base
+
+    async def test_per_script_verdicts_and_the_one_number_the_brief_wants(
+            self, wired, monkeypatch):
+        self._suite(wired)
+        _fake_engine(monkeypatch, {
+            "GREEN": {"stdout": "PASS door opens\nPASS door shuts\n"},
+            "RED": {"stdout": "PASS door opens\nFAIL door eats the player\n"},
+        })
+        got = await call("godot_test_run")
+
+        assert got["ok"] is False
+        assert got["scripts_run"] == 2 and got["scripts_failed"] == 1
+        assert got["failures"] == ["tests/red_test.gd"]
+        assert got["assertions_passed"] == 3 and got["assertions_failed"] == 1
+
+        by_name = {s["script"]: s for s in got["scripts"]}
+        assert by_name["tests/green_test.gd"]["ok"] is True
+        assert by_name["tests/red_test.gd"]["ok"] is False
+        # The failure carries its output; the pass does not — a green suite's
+        # stdout is engine boot chatter and returning it for every script is how
+        # a passing run stops fitting in a tool result.
+        assert "eats the player" in by_name["tests/red_test.gd"]["output"]
+        assert "output" not in by_name["tests/green_test.gd"]
+
+    async def test_a_clean_suite_reports_ok_with_no_error_string(self, wired,
+                                                                monkeypatch):
+        self._suite(wired)
+        _fake_engine(monkeypatch, {"GREEN": {"stdout": "PASS\n"},
+                                   "RED": {"stdout": "PASS\n"}})
+        got = await call("godot_test_run")
+        assert got["ok"] is True and not got["error"]
+        assert got["scripts_failed"] == 0
+
+    async def test_a_script_error_fails_the_script_even_at_exit_zero(
+            self, wired, monkeypatch):
+        # Godot prints SCRIPT ERROR and still exits 0. Scoring on the exit code
+        # alone would call a suite that never ran an assertion green.
+        self._suite(wired)
+        _fake_engine(monkeypatch, {
+            "GREEN": {"stdout": "PASS\n"},
+            "RED": {"stdout": "PASS\n", "exit_code": 0, "ok": False,
+                    "errors": ["SCRIPT ERROR: Invalid call on null instance"]},
+        })
+        got = await call("godot_test_run")
+        assert got["failures"] == ["tests/red_test.gd"]
+        red = [s for s in got["scripts"] if s["script"].endswith("red_test.gd")][0]
+        assert red["errors"] and red["ok"] is False
+
+    async def test_a_timeout_is_a_failure_that_names_itself(self, wired,
+                                                            monkeypatch):
+        self._suite(wired)
+        _fake_engine(monkeypatch, {
+            "GREEN": {"stdout": "PASS\n"},
+            "RED": {"ok": False, "error": "Godot timed out after 180s",
+                    "seconds": 180},
+        })
+        got = await call("godot_test_run")
+        red = [s for s in got["scripts"] if s["script"].endswith("red_test.gd")][0]
+        assert "timed out" in red["error"]
+
+    async def test_an_explicit_subset_runs_only_that(self, wired, monkeypatch):
+        self._suite(wired)
+        _fake_engine(monkeypatch, {"GREEN": {"stdout": "PASS\n"},
+                                   "RED": {"stdout": "FAIL\n"}})
+        got = await call("godot_test_run", paths=["tests/green_test.gd"])
+        assert got["ok"] is True and got["scripts_run"] == 1
+
+    async def test_the_engine_being_absent_comes_back_as_a_payload(self, wired,
+                                                                   monkeypatch):
+        self._suite(wired)
+
+        def boom(*_args, **_kwargs):
+            raise _godot.GodotNotFound("Godot not found.")
+
+        monkeypatch.setattr(_godot, "run_script", boom)
+        got = await call("godot_test_run")
+        assert got.get("ok") is False and "Godot not found" in got["error"]

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -297,3 +297,158 @@ class TestStaleBuildGuard:
         (web / "index.pck").write_bytes(b"fresh")  # written after the source
         got = client.get("/api/play/status").json()
         assert got["stale"] is False
+
+
+class TestReservation:
+    """The atomic queued->dispatched transition — two dispatchers, one winner.
+
+    dispatch._spawn and a worker's queue_claim_next live in different
+    processes; both used to read 'queued' and proceed, which is one item with
+    two agents. The UPDATE's WHERE clause is the guarantee under test.
+    """
+
+    def test_reserve_wins_exactly_once(self, root):
+        item = queue.add(root, "tech", "wire the door")
+        assert queue.reserve(root, item["id"]) is True
+        assert queue.reserve(root, item["id"]) is False
+        assert queue.get(root, item["id"])["status"] == "dispatched"
+
+    def test_release_undoes_reserve_without_touching_the_result(self, root):
+        item = queue.add(root, "tech", "wire the door")
+        queue.set_status(root, item["id"], "failed", result="round one notes")
+        queue.reopen(root, item["id"], "fix the hinge")
+        assert queue.reserve(root, item["id"]) is True
+        assert queue.release(root, item["id"]) is True
+        after = queue.get(root, item["id"])
+        assert after["status"] == "queued"
+        # The reopened note survives — release touches status alone. set_status
+        # would have blanked it, which is why release exists.
+        assert "reopened" in (after["result"] or "")
+
+    def test_release_of_a_non_dispatched_item_is_a_no_op(self, root):
+        item = queue.add(root, "tech", "wire the door")
+        assert queue.release(root, item["id"]) is False
+        assert queue.get(root, item["id"])["status"] == "queued"
+
+
+class TestClaimNext:
+    """The worker pickup loop: claim atomically, honour every hold."""
+
+    def test_claims_the_highest_priority_ready_item_and_stamps_the_actor(self, root):
+        queue.add(root, "art", "low", priority=0)
+        high = queue.add(root, "art", "high", priority=5)
+        got = queue.claim_next(root, "art", actor="agent:item-99")
+        assert got["id"] == high["id"]
+        assert got["status"] == "dispatched"
+        assert got["actor"] == "agent:item-99"
+
+    def test_never_claims_across_seats(self, root):
+        queue.add(root, "tech", "not yours")
+        assert queue.claim_next(root, "art", actor="agent:item-1") is None
+
+    def test_honours_dependencies(self, root):
+        first = queue.add(root, "art", "paint the anchor")
+        queue.add(root, "art", "derive the poses", depends_on=first["id"])
+        # Claim the ready one, then nothing: the dependent is not ready and the
+        # first is now dispatched.
+        assert queue.claim_next(root, "art", actor="agent:item-1")["id"] == first["id"]
+        assert queue.claim_next(root, "art", actor="agent:item-1") is None
+        queue.set_status(root, first["id"], "done", result="anchor landed")
+        follow = queue.claim_next(root, "art", actor="agent:item-1")
+        assert follow is not None and follow["title"] == "derive the poses"
+
+    def test_holds_what_autodeploy_holds(self, root):
+        queue.add(root, "director", "two agents disagreed",
+                  source="qa-gate-escalation")
+        queue.add(root, "director", "a chat turn", source="chat")
+        placeholder = queue.add(root, "director", "coming", brief="x")
+        with db.tx(root) as conn:
+            conn.execute("UPDATE work_item SET brief = '(preparing #7)' "
+                         "WHERE id = ?", (placeholder["id"],))
+        assert queue.claim_next(root, "director", actor="agent:item-1") is None
+
+    def test_requires_an_execution_identity(self, root):
+        queue.add(root, "art", "x")
+        with pytest.raises(ValueError, match="identity"):
+            queue.claim_next(root, "art", actor="  ")
+
+    def test_claimed_open_sees_only_this_actors_claims(self, root):
+        mine = queue.add(root, "art", "mine")
+        queue.add(root, "art", "ordinary")
+        queue.claim_next(root, "art", actor="agent:item-7")  # takes 'mine'
+        held = queue.claimed_open(root, "agent:item-7")
+        assert [h["id"] for h in held] == [mine["id"]]
+        assert queue.claimed_open(root, "agent:item-8") == []
+
+
+class TestEmitTerminal:
+    """The watchdog's kill path finally reaches the bus."""
+
+    def test_a_failed_item_emits_item_failed(self, root):
+        from bgate_core import events
+        item = queue.add(root, "tech", "doomed")
+        queue.set_status(root, item["id"], "failed", result="killed: ceiling")
+        before = events.head(root)
+        queue.emit_terminal(root, item["id"])
+        got = [e for e in events.since(root, before)["events"]
+               if e["kind"] == "item.failed"]
+        assert len(got) == 1
+        assert got[0]["payload"]["item"] == item["id"]
+
+    def test_a_non_terminal_status_emits_nothing(self, root):
+        from bgate_core import events
+        item = queue.add(root, "tech", "still going")
+        before = events.head(root)
+        queue.emit_terminal(root, item["id"])          # status is 'queued'
+        assert events.since(root, before)["events"] == []
+
+    def test_a_deleted_item_is_silently_skipped(self, root):
+        queue.emit_terminal(root, 424242)              # must not raise
+
+
+# The MCP-surface behaviour of queue_reopen and queue_claim_next (round
+# counting, worker-only claiming) is tested in test_mcp_server.py, through the
+# registered handlers the way a client hits them.
+
+
+class TestAutoCommitBreaksTheDeadlock:
+    """Nothing ever committed, and a dirty tree refuses every dispatch — so the
+    first agent to write a file blocked the whole board forever."""
+
+    def _repo(self, root):
+        import subprocess
+        for args in (["init"], ["config", "user.email", "t@t"],
+                     ["config", "user.name", "t"]):
+            subprocess.run(["git", *args], cwd=root, capture_output=True)
+        (root / "seed.txt").write_text("seed\n", encoding="utf-8")
+        subprocess.run(["git", "add", "-A"], cwd=root, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "seed"], cwd=root,
+                       capture_output=True)
+
+    def test_commit_paths_takes_only_what_it_is_given(self, root):
+        from bgate_core import gitwork
+        self._repo(root)
+        (root / "agent.txt").write_text("agent wrote this\n", encoding="utf-8")
+        (root / "human.txt").write_text("human wrote this\n", encoding="utf-8")
+
+        got = gitwork.commit_paths(root, ["agent.txt"], "bgate: item #1")
+        assert got["ok"] is True and got["committed"] == ["agent.txt"]
+        # The human's file is untouched — and still dirties the tree, which is
+        # the original rule working rather than being bypassed.
+        after = gitwork.dirty(root)
+        assert after["dirty"] is True
+        assert after["paths"] == ["human.txt"]
+
+    def test_a_clean_tree_after_the_agents_own_files_are_committed(self, root):
+        from bgate_core import gitwork
+        self._repo(root)
+        (root / "a.gd").write_text("1\n", encoding="utf-8")
+        (root / "b.gd").write_text("2\n", encoding="utf-8")
+        gitwork.commit_paths(root, ["a.gd", "b.gd"], "bgate: item #2")
+        assert gitwork.dirty(root)["dirty"] is False   # the next dispatch runs
+
+    def test_nothing_to_commit_is_reported_not_raised(self, root):
+        from bgate_core import gitwork
+        self._repo(root)
+        got = gitwork.commit_paths(root, [], "bgate: item #3")
+        assert got["ok"] is False and "nothing" in got["reason"]

--- a/tests/test_sfx.py
+++ b/tests/test_sfx.py
@@ -1,0 +1,253 @@
+"""Procedural SFX — determinism, and the recipe that has to rebuild the render.
+
+The audio house rule (dispatch.SEAT_RULES["audio"]) requires every synthesized
+asset to ship a ``<name>.synth.json`` another process can re-render identically
+from. That is a claim about BYTES, not about a file existing, so these tests
+compare bytes: same recipe twice, and a recipe carried away from its wav and
+rendered somewhere else entirely.
+
+The seed is the only non-arithmetic input, and it is the thing that used to be
+implicit. A module-level ``random`` would have made two identical recipes render
+two different explosions — which nothing would have caught, because both are
+plausible explosions.
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import wave
+from pathlib import Path
+
+import pytest
+
+from bgate_core import sfx
+from bgate_mcp import server
+
+
+async def call(tool: str, /, **kwargs) -> dict:
+    """Dispatch through FastMCP, the way a client hits it."""
+    result = await server.mcp.call_tool(tool, kwargs)
+    content = result[0] if isinstance(result, tuple) else result
+    block = content[0]
+    return json.loads(block.text) if hasattr(block, "text") else block
+
+
+@pytest.fixture()
+def wired(root, monkeypatch):
+    monkeypatch.setenv("BGATE_ROOT", str(root))
+    return root
+
+
+# ---------------------------------------------------------------------------
+# Kinds
+# ---------------------------------------------------------------------------
+class TestKinds:
+    def test_every_kind_the_seat_was_asked_for_exists(self):
+        names = {k["kind"] for k in sfx.kinds()}
+        # The gap this module closed: there was no way to make a game sound at
+        # all. These are the ones a 2D game asks for on day one.
+        assert {"blip", "pickup", "jump", "laser", "explosion", "hit",
+                "powerup"} <= names
+
+    def test_the_words_a_designer_writes_resolve(self):
+        assert sfx.resolve_kind("coin") == "pickup"
+        assert sfx.resolve_kind("shoot") == "laser"
+        assert sfx.resolve_kind("Thud") == "hit"
+        assert sfx.resolve_kind("level up") == "powerup"
+
+    def test_an_unknown_kind_names_the_options_instead_of_guessing(self):
+        with pytest.raises(sfx.SfxError) as exc:
+            sfx.resolve_kind("pew")
+        assert "laser" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# Determinism
+# ---------------------------------------------------------------------------
+class TestDeterminism:
+    def test_the_same_recipe_renders_the_same_bytes(self):
+        # explosion is the one that would expose a shared RNG: it is nothing but
+        # noise, so two renders of it differ everywhere or nowhere.
+        rec = sfx.recipe("explosion", name="boom")
+        assert sfx.render(rec) == sfx.render(rec)
+
+    def test_the_default_seed_comes_from_the_name_not_the_clock(self):
+        first = sfx.recipe("explosion", name="boom")
+        again = sfx.recipe("explosion", name="boom")
+        assert first == again
+        assert first["seed"] == sfx.default_seed("explosion", "boom")
+        # Regenerating tomorrow must be a no-op, not a diff nobody asked for.
+        assert sfx.render(first) == sfx.render(again)
+
+    def test_a_different_seed_is_a_different_roll(self):
+        one = sfx.render(sfx.recipe("explosion", name="boom", seed=1))
+        two = sfx.render(sfx.recipe("explosion", name="boom", seed=2))
+        assert one != two
+        assert len(one) == len(two)          # same shape, different noise
+
+    def test_two_names_do_not_collide_on_one_sound(self):
+        assert (sfx.render(sfx.recipe("hit", name="hit_wood"))
+                != sfx.render(sfx.recipe("hit", name="hit_stone")))
+
+    @pytest.mark.parametrize("kind", sfx.KINDS)
+    def test_every_kind_renders_a_16_bit_mono_wav_godot_can_import(self, kind,
+                                                                  tmp_path):
+        # AudioStreamWAV takes 8/16-bit PCM. A float WAV imports as silence with
+        # no error at all, which is the worst possible way to be wrong.
+        path = tmp_path / f"{kind}.wav"
+        path.write_bytes(sfx.render(sfx.recipe(kind, name=kind)))
+        with wave.open(str(path), "rb") as handle:
+            assert handle.getnchannels() == 1
+            assert handle.getsampwidth() == 2
+            assert handle.getframerate() == sfx.DEFAULT_RATE
+            assert 0.0 < handle.getnframes() / handle.getframerate() <= sfx.MAX_SECONDS
+
+    def test_the_render_ends_on_silence(self):
+        # A hard cut at a non-zero sample clicks, and a click on a sound that
+        # fires ten times a second is what makes a game sound cheap.
+        rec = sfx.recipe("laser", name="pew")
+        with wave.open(__import__("io").BytesIO(sfx.render(rec)), "rb") as handle:
+            frames = handle.readframes(handle.getnframes())
+        assert frames[-2:] == b"\x00\x00"
+
+
+# ---------------------------------------------------------------------------
+# The knobs
+# ---------------------------------------------------------------------------
+class TestScaling:
+    def test_base_hz_scales_every_pitch_in_the_preset(self):
+        low = sfx.recipe("laser", name="a", base_hz=400)
+        high = sfx.recipe("laser", name="a", base_hz=800)
+        assert (high["layers"][0]["freq_start"]
+                == pytest.approx(low["layers"][0]["freq_start"] * 2))
+        assert (high["layers"][0]["freq_end"]
+                == pytest.approx(low["layers"][0]["freq_end"] * 2))
+
+    def test_duration_scales_every_time_including_the_arpeggio_steps(self):
+        rec = sfx.recipe("powerup", name="up", duration_s=1.14)
+        assert rec["seconds"] == pytest.approx(1.14, abs=0.01)
+        starts = [l["start_s"] for l in rec["layers"]]
+        assert starts == sorted(starts) and starts[-1] > starts[0]
+
+    def test_a_recipe_past_the_cap_is_refused_as_music(self):
+        with pytest.raises(sfx.SfxError) as exc:
+            sfx.recipe("explosion", name="long", duration_s=60)
+        assert str(sfx.MAX_SECONDS) in str(exc.value)
+
+    def test_a_hand_edited_recipe_is_validated_not_trusted(self):
+        rec = sfx.recipe("blip", name="ui")
+        rec["layers"][0]["wave"] = "sawtooth"        # not one of WAVES
+        with pytest.raises(sfx.SfxError) as exc:
+            sfx.render(rec)
+        assert "layers[0].wave" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# The sidecar — the whole point of the house rule
+# ---------------------------------------------------------------------------
+class TestRecipeRoundTrip:
+    def test_generate_writes_the_wav_and_its_recipe_side_by_side(self, root):
+        got = sfx.generate(root, "coin", "pickup_coin")
+        wav, recipe_file = Path(got["path"]), Path(got["recipe_path"])
+        assert wav.is_file() and recipe_file.is_file()
+        assert recipe_file.name == "pickup_coin.synth.json"
+        # Inside the audio seat's own lane, resolved through the real layout.
+        assert got["rel_path"].endswith("assets/audio/sfx/pickup_coin.wav")
+
+    def test_the_recipe_carries_everything_needed_to_re_render(self, root):
+        got = sfx.generate(root, "explosion", "boom")
+        rec = json.loads(Path(got["recipe_path"]).read_text(encoding="utf-8"))
+        assert rec["version"] == sfx.RECIPE_VERSION
+        assert rec["seed"] and rec["sample_rate"] and rec["layers"]
+        layer = rec["layers"][0]
+        for knob in ("wave", "freq_start", "freq_end", "sweep", "attack_s",
+                     "decay_s", "sustain", "release_s", "lowpass_start_hz",
+                     "lowpass_end_hz", "noise_mix", "gain", "bits"):
+            assert knob in layer, knob
+
+    def test_rerender_reproduces_the_identical_file(self, root):
+        got = sfx.generate(root, "explosion", "boom")
+        before = Path(got["path"]).read_bytes()
+        again = sfx.rerender(got["recipe_path"])
+        assert again["identical"] is True
+        assert Path(got["path"]).read_bytes() == before
+
+    def test_the_recipe_alone_is_enough_far_from_its_wav(self, root, tmp_path):
+        """"Another process must be able to re-render the identical asset from
+        the recipe alone" — so carry the sidecar somewhere with no wav in it."""
+        got = sfx.generate(root, "laser", "shoot")
+        original = Path(got["path"]).read_bytes()
+
+        elsewhere = tmp_path / "someone_elses_machine"
+        elsewhere.mkdir()
+        shutil.copy2(got["recipe_path"], elsewhere / "shoot.synth.json")
+
+        rebuilt = sfx.rerender(elsewhere / "shoot.synth.json")
+        assert rebuilt["had_previous"] is False       # nothing to compare against
+        assert Path(rebuilt["path"]).read_bytes() == original
+
+    def test_a_recipe_that_renders_something_else_is_caught(self, root):
+        # The failure mode a sidecar has that no sidecar does not: it looks like
+        # provenance. `identical` is the field that keeps it honest.
+        got = sfx.generate(root, "blip", "select")
+        recipe_file = Path(got["recipe_path"])
+        rec = json.loads(recipe_file.read_text(encoding="utf-8"))
+        rec["layers"][0]["freq_start"] = 220.0
+        recipe_file.write_text(json.dumps(rec), encoding="utf-8")
+        assert sfx.rerender(recipe_file)["identical"] is False
+
+    def test_a_recipe_from_a_newer_build_refuses_rather_than_guesses(self, root,
+                                                                    tmp_path):
+        rec = sfx.recipe("blip", name="x")
+        rec["version"] = sfx.RECIPE_VERSION + 1
+        path = tmp_path / "x.synth.json"
+        path.write_text(json.dumps(rec), encoding="utf-8")
+        with pytest.raises(sfx.SfxError) as exc:
+            sfx.rerender(path)
+        assert "newer" in str(exc.value)
+
+    def test_a_name_cannot_escape_the_sfx_directory(self, root):
+        got = sfx.generate(root, "blip", "../../evil")
+        assert Path(got["path"]).parent == sfx.sfx_dir(root)
+
+
+class TestListing:
+    def test_a_wav_with_no_recipe_is_reported_not_hidden(self, root):
+        sfx.generate(root, "blip", "good")
+        orphan = sfx.sfx_dir(root) / "orphan.wav"
+        orphan.write_bytes(sfx.render(sfx.recipe("hit", name="orphan")))
+
+        found = {entry["name"]: entry for entry in sfx.list_sfx(root)}
+        assert found["good"]["has_recipe"] is True
+        assert found["orphan"]["has_recipe"] is False
+
+
+# ---------------------------------------------------------------------------
+# The MCP surface
+# ---------------------------------------------------------------------------
+@pytest.mark.anyio
+class TestMcpSurface:
+    async def test_the_audio_seat_can_now_make_a_sound(self, wired):
+        got = await call("sfx_generate", kind="coin", name="coin")
+        assert got.get("ok") is True and "error" not in got
+        assert Path(got["path"]).is_file()
+        assert Path(got["recipe_path"]).name == "coin.synth.json"
+
+    async def test_rerender_through_the_surface_reports_identical(self, wired):
+        made = await call("sfx_generate", kind="jump", name="hop")
+        again = await call("sfx_rerender", recipe_path=made["recipe_rel_path"])
+        assert again["identical"] is True
+
+    async def test_kinds_is_answerable_without_a_project(self):
+        got = await call("sfx_kinds")
+        assert {k["kind"] for k in got["kinds"]} >= {"laser", "explosion"}
+
+    async def test_a_bad_kind_comes_back_as_a_payload_not_an_exception(self, wired):
+        got = await call("sfx_generate", kind="pew", name="x")
+        assert got.get("ok") is False and got.get("error")
+
+    async def test_the_listing_names_what_lost_its_recipe(self, wired):
+        await call("sfx_generate", kind="hit", name="thump")
+        (sfx.sfx_dir(wired) / "thump.synth.json").unlink()
+        got = await call("sfx_list")
+        assert got["without_recipe"] == ["thump"]

--- a/tests/test_workflow_generate.py
+++ b/tests/test_workflow_generate.py
@@ -87,6 +87,21 @@ def client(root, monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def _no_spawn(monkeypatch):
+    """No test in this file may put a real Claude process on the machine.
+
+    Dispatch now means two things — "spawn agents" AND "you may spend on
+    providers" — so the scheduling tests below have to run with it ON, and a run
+    with dispatch on hands each agent step to bgate_ui.dispatch. The queue item
+    is still created and still walked by hand; only the process is stubbed.
+    """
+    from bgate_ui import dispatch as _dispatch
+
+    monkeypatch.setattr(_dispatch, "dispatch",
+                        lambda root, item_id, **kw: {"ok": True, "stub": True})
+
+
+@pytest.fixture(autouse=True)
 def _settle(root):
     """No worker may outlive its test — it would write into a deleted tmp dir.
 
@@ -103,6 +118,20 @@ def node(run: dict, node_id: str) -> dict:
 def finish(root, item_id: int, result: str = "done") -> None:
     queue.set_status(root, item_id, "dispatched")
     queue.set_status(root, item_id, "done", result)
+
+
+def start(root, graph: dict, **kw):
+    """Start a run the way the Run button does — dispatch ON.
+
+    A generate node calls an image provider, so `advance` only auto-starts one
+    when the run was started with dispatch on: the human's explicit "yes, do all
+    of this". Every test here is about what a REAL run does — do the three arms
+    overlap, does the cap hold, does the pick block — so they all need a run
+    that is allowed to schedule. What happens with dispatch off (nothing, until
+    a person presses ▶) is tests/test_workflow_guards.py's subject.
+    """
+    kw.setdefault("dispatch", True)
+    return workflows.start(root, graph, **kw)
 
 
 # ---------------------------------------------------------------------------
@@ -164,7 +193,7 @@ def serial_agents_graph() -> dict:
 
 class TestKinds:
     def test_kinds_are_rederived_from_the_type(self, root, provider):
-        run = workflows.start(root, fanout_graph())
+        run = start(root, fanout_graph())
         assert node(run, "a")["kind"] == "generate"
         assert node(run, "pick")["kind"] == "pick"
         assert node(run, "tech")["kind"] == "agent"
@@ -176,11 +205,11 @@ class TestKinds:
         for spec in graph["nodes"]:
             if spec["id"] == "pick":
                 spec["kind"] = "passive"
-        run = workflows.start(root, graph)
+        run = start(root, graph)
         assert node(run, "pick")["kind"] == "pick"
 
     def test_a_generate_node_makes_no_queue_item(self, root, provider):
-        run = workflows.start(root, fanout_graph())
+        run = start(root, fanout_graph())
         workflows.join(run["id"])
         assert queue.list_items(root) == []
 
@@ -191,7 +220,7 @@ class TestKinds:
 
 class TestParallelism:
     def test_sibling_generate_nodes_overlap(self, root, provider):
-        run = workflows.start(root, fanout_graph())
+        run = start(root, fanout_graph())
         # all three claimed on the first tick, none of them queued as work
         assert [node(run, n)["status"] for n in ("a", "b", "c")] == \
             ["running", "running", "running"]
@@ -208,7 +237,7 @@ class TestParallelism:
         assert len({c["model"] for c in provider.calls}) == 3
 
     def test_agent_steps_still_run_one_at_a_time(self, root, provider):
-        run = workflows.start(root, serial_agents_graph())
+        run = start(root, serial_agents_graph())
         live = [n for n in run["nodes"] if n["status"] == "queued"]
         assert len(live) == 1
         for _ in range(3):
@@ -222,7 +251,7 @@ class TestParallelism:
 
     def test_the_fan_out_respects_the_concurrency_cap(self, root, provider):
         spend.set_budget(root, max_concurrent=1)
-        run = workflows.start(root, fanout_graph())
+        run = start(root, fanout_graph())
         running = [n["node_id"] for n in run["nodes"] if n["status"] == "running"]
         assert len(running) == 1, "the budget's max_concurrent is the ceiling"
         workflows.join(run["id"])
@@ -233,7 +262,7 @@ class TestParallelism:
             ["passed", "passed", "passed"]
 
     def test_a_second_tick_does_not_generate_twice(self, root, provider):
-        run = workflows.start(root, fanout_graph())
+        run = start(root, fanout_graph())
         for _ in range(3):
             workflows.advance(root, run["id"])   # the dashboard polling
         workflows.join(run["id"])
@@ -275,7 +304,7 @@ def stepped_graph() -> dict:
 class TestRunOneNode:
     def _ready(self, root):
         """A run whose two generate nodes are ready but not yet ticked into."""
-        run = workflows.start(root, stepped_graph())
+        run = start(root, stepped_graph())
         queue.set_status(root, node(run, "writer")["work_item_id"], "dispatched")
         queue.set_status(root, node(run, "writer")["work_item_id"], "done",
                          "a weary paladin in dented plate")
@@ -299,7 +328,7 @@ class TestRunOneNode:
         assert node(workflows.get(root, run["id"]), "b")["status"] == "passed"
 
     def test_it_refuses_a_node_whose_inputs_are_not_satisfied(self, root, provider):
-        run = workflows.start(root, stepped_graph())
+        run = start(root, stepped_graph())
         with pytest.raises(ValueError) as caught:
             workflows.run_node(root, run["id"], "a")
         assert "'writer'" in str(caught.value)
@@ -311,14 +340,24 @@ class TestRunOneNode:
         # with nothing at all, so a slow tool looked like a dead button and got
         # clicked again. Widening it meant one wording had to cover both, and
         # "running" is the word the status column already uses.
+        #
+        # The widened branch was then DEAD for a commit: it raised the same
+        # sentence the status table below it already produces, so this test
+        # passed either way. It is gone, and the assertions below are what tell
+        # the two apart — the status table names the CARD and the way out.
         run = self._ready(root)
         workflows.run_node(root, run["id"], "a")
         with pytest.raises(ValueError) as caught:
             workflows.run_node(root, run["id"], "a")
-        assert "already running" in str(caught.value)
+        said = str(caught.value)
+        assert "already running" in said
+        assert "'A'" in said, "the refusal must name the card, not the node id"
+        assert "reconcile" in said, (
+            "a node whose worker died is also 'running'; the refusal has to "
+            "name the verb that ends that wait")
 
     def test_a_gate_is_resolved_not_run(self, root, provider):
-        run = workflows.start(root, fanout_graph())
+        run = start(root, fanout_graph())
         workflows.join(run["id"])
         run = workflows.advance(root, run["id"])
         with pytest.raises(ValueError) as caught:
@@ -326,7 +365,7 @@ class TestRunOneNode:
         assert "resolved by a human" in str(caught.value)
 
     def test_agent_steps_stay_single_file_even_when_pressed_by_hand(self, root, provider):
-        run = workflows.start(root, serial_agents_graph())
+        run = start(root, serial_agents_graph())
         waiting = next(n["node_id"] for n in run["nodes"] if n["status"] == "pending"
                        and n["kind"] == "agent")
         with pytest.raises(ValueError) as caught:
@@ -360,7 +399,7 @@ class TestRunOneNode:
 
 class TestPick:
     def _to_pick(self, root):
-        run = workflows.start(root, fanout_graph())
+        run = start(root, fanout_graph())
         workflows.join(run["id"])
         run = workflows.advance(root, run["id"])
         assert node(run, "pick")["status"] == "running"
@@ -438,7 +477,7 @@ class TestPick:
              "config": {"provider": "krea", "model": "krea-2-large",
                         "prompt": "turnaround of {input}"}})
         graph["edges"].append({"from": ["pick", "o"], "to": ["final", "i"]})
-        run = workflows.start(root, graph)
+        run = start(root, graph)
         workflows.join(run["id"])
         run = workflows.advance(root, run["id"])
         chosen = workflows.candidates(root, run["id"], "pick")[0]
@@ -463,7 +502,10 @@ class TestPick:
 
     def test_pick_over_http_refuses_an_agent_and_then_works(self, client, root,
                                                             provider, monkeypatch):
-        started = client.post("/api/workflows/runs", json=fanout_graph()).json()["data"]
+        # dispatch on: the models may not spend on a tick without it, and this
+        # test is about the pick surface, not about pressing three ▶ first.
+        started = client.post("/api/workflows/runs",
+                              json=dict(fanout_graph(), dispatch=True)).json()["data"]
         run_id = started["id"]
         workflows.join(run_id)
         run = client.post(f"/api/workflows/runs/{run_id}/advance").json()["data"]
@@ -517,7 +559,7 @@ class TestPromptOnAWire:
         }
 
     def test_an_upstream_text_output_becomes_the_prompt(self, root, provider):
-        run = workflows.start(root, self.prompt_graph())
+        run = start(root, self.prompt_graph())
         written = ("weary paladin in dented plate, clipboard in one hand, "
                    "16-bit pixel art, side view")
         finish(root, node(run, "writer")["work_item_id"], written)
@@ -529,14 +571,14 @@ class TestPromptOnAWire:
         assert provider.calls[-1]["prompt"] == written
 
     def test_a_template_composes_with_the_wire(self, root, provider):
-        run = workflows.start(root, self.prompt_graph("{input}, transparent background"))
+        run = start(root, self.prompt_graph("{input}, transparent background"))
         finish(root, node(run, "writer")["work_item_id"], "a weary paladin")
         run = workflows.advance(root, run["id"])
         workflows.join(run["id"])
         assert provider.calls[-1]["prompt"] == "a weary paladin, transparent background"
 
     def test_a_task_node_feeds_a_generate_node_directly(self, root, provider):
-        run = workflows.start(root, fanout_graph())
+        run = start(root, fanout_graph())
         workflows.join(run["id"])
         assert all(c["prompt"] == "the Project Manager Paladin, idle, 16-bit"
                    for c in provider.calls)
@@ -548,7 +590,7 @@ class TestPromptOnAWire:
                        "config": {"provider": "krea", "model": "z-image"}}],
             "edges": [],
         }
-        run = workflows.start(root, graph)
+        run = start(root, graph)
         workflows.join(run["id"])
         run = workflows.advance(root, run["id"])
         assert node(run, "img")["status"] == "failed"
@@ -563,7 +605,7 @@ class TestPromptOnAWire:
 class TestMoneyAndFailure:
     def test_the_budget_refuses_before_anything_is_generated(self, root, provider):
         spend.set_budget(root, per_day_usd=0.001, enforced=1)
-        run = workflows.start(root, fanout_graph())
+        run = start(root, fanout_graph())
         workflows.join(run["id"])
         run = workflows.advance(root, run["id"])
         assert node(run, "a")["status"] == "failed"
@@ -571,7 +613,7 @@ class TestMoneyAndFailure:
         assert provider.calls == [], "money was spent after the ceiling refused it"
 
     def test_spend_is_recorded_per_candidate(self, root, provider):
-        run = workflows.start(root, fanout_graph(count=2))
+        run = start(root, fanout_graph(count=2))
         workflows.join(run["id"])
         assert len(provider.calls) == 6
         totals = spend.totals(root)
@@ -580,7 +622,7 @@ class TestMoneyAndFailure:
     def test_a_provider_failure_fails_the_node_with_the_reason(self, root, monkeypatch):
         stub = Provider(fail="Krea has no API credit — top it up at krea.ai/settings")
         monkeypatch.setattr(generate, "call_provider", stub)
-        run = workflows.start(root, fanout_graph())
+        run = start(root, fanout_graph())
         workflows.join(run["id"])
         run = workflows.advance(root, run["id"])
         failed = node(run, "a")
@@ -594,7 +636,7 @@ class TestMoneyAndFailure:
         for spec in graph["nodes"]:
             if spec["id"] == "c":
                 spec["config"] = {"provider": "krea", "model": "krea-9-enormous"}
-        run = workflows.start(root, graph)
+        run = start(root, graph)
         workflows.join(run["id"])
         run = workflows.advance(root, run["id"])
         assert node(run, "c")["status"] == "failed"
@@ -606,7 +648,7 @@ class TestMoneyAndFailure:
         candidate under a single logical name, which made the comparison's arms
         indistinguishable in the registry; "which model made this" is the only
         question the node exists to answer."""
-        run = workflows.start(root, fanout_graph(count=3))
+        run = start(root, fanout_graph(count=3))
         workflows.join(run["id"])
         made = [r for r in artifacts.list_revisions(root, limit=100)
                 if r["producer"] == generate.PRODUCER]
@@ -625,7 +667,7 @@ class TestMoneyAndFailure:
         for spec in graph["nodes"]:
             if spec["id"] in ("a", "b"):
                 spec["label"] = "Image model"      # the palette's default
-        run = workflows.start(root, graph)
+        run = start(root, graph)
         workflows.join(run["id"])
         names = {r["logical_name"] for r in artifacts.list_revisions(root, limit=100)
                  if r["producer"] == generate.PRODUCER}

--- a/tests/test_workflow_guards.py
+++ b/tests/test_workflow_guards.py
@@ -1,0 +1,551 @@
+"""The guards on a workflow run: who may spend, what waits, and what gets out.
+
+`bgate_core.wfnodes` is the table that decides whether a node costs money and
+whether it may run beside another one, and it had no test at all — the two flags
+that gate a provider bill and a last-write-wins repo edit were asserted by
+nothing. Around them sat four holes that were each a way for the engine to spend
+or stall without a person involved:
+
+  * a paid node could be started by an AGENT, through the one route that took an
+    actor and then ignored it;
+  * a generate node started itself on every tick regardless of the dispatch
+    switch, so opening a run to press ▶ on one card fired every other one;
+  * a context or reference node that could not resolve went GREEN, and the
+    generation behind it billed for a prompt with no subject and no anchor;
+  * a node whose worker died with its process stayed 'running' for ever, with
+    nothing in the product able to move it.
+
+No network and no engine: `generate.call_provider` is the seam every provider
+call goes through, and `wfnodes.run` is the seam every tool call goes through.
+Both are stubbed, so a guard that leaks is visible as a RECORDED CALL rather
+than as a bill.
+"""
+from __future__ import annotations
+
+from concurrent.futures import Future
+
+import pytest
+from fastapi.testclient import TestClient
+
+from bgate_core import generate, queue, wfnodes, workflows
+from bgate_ui.app import app
+
+
+# ---------------------------------------------------------------------------
+# Stubs — the two seams
+# ---------------------------------------------------------------------------
+
+class Provider:
+    """A fake image provider that writes a byte and records the call."""
+
+    def __init__(self):
+        self.calls: list[dict] = []
+
+    def __call__(self, provider, model, prompt, out_path, **kw):
+        from pathlib import Path
+
+        self.calls.append({"provider": provider, "model": model,
+                           "prompt": prompt,
+                           "style_refs": list(kw.get("style_refs") or ())})
+        out = Path(out_path)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_bytes(b"\x89PNG-stub")
+        return {"ok": True, "path": str(out), "bytes": out.stat().st_size,
+                "provider": provider, "model": model, "seconds": 0.1,
+                "estimated_usd": 0.03}
+
+
+class Tool:
+    """A fake tool executor, in the envelope `wfnodes.run` really returns.
+
+    Replacing `wfnodes.run` rather than `wfnodes.call_tool` keeps the MCP server
+    — FastMCP, Blender, Godot, every provider adapter — out of the test process
+    entirely, which is the whole reason that import is lazy in the first place.
+    """
+
+    def __init__(self):
+        self.calls: list[dict] = []
+
+    def __call__(self, root, **kw):
+        self.calls.append(kw)
+        return {"ok": True, "error": "", "artifacts": [], "usd": 0.0,
+                "provider": "", "model": "", "logical_name": "",
+                "message": "the stub tool finished",
+                "output": {"tool": "stub", "paths": [], "artifacts": []}}
+
+
+@pytest.fixture()
+def provider(monkeypatch):
+    stub = Provider()
+    monkeypatch.setattr(generate, "call_provider", stub)
+    return stub
+
+
+@pytest.fixture()
+def tool(monkeypatch):
+    stub = Tool()
+    monkeypatch.setattr(wfnodes, "run", stub)
+    return stub
+
+
+@pytest.fixture(autouse=True)
+def _no_spawn(monkeypatch):
+    """Nothing here may put a real Claude process on the machine."""
+    from bgate_ui import dispatch as _dispatch
+
+    monkeypatch.setattr(_dispatch, "dispatch",
+                        lambda root, item_id, **kw: {"ok": True, "stub": True})
+
+
+@pytest.fixture(autouse=True)
+def _settle(root):
+    """No worker may outlive its test — it would write into a deleted tmp dir."""
+    yield
+    workflows.join(timeout=30)
+
+
+@pytest.fixture()
+def client(root, monkeypatch):
+    monkeypatch.setenv("BGATE_ROOT", str(root))
+    monkeypatch.setenv("BGATE_ACTOR", "marta@box")
+    return TestClient(app)
+
+
+def node(run: dict, node_id: str) -> dict:
+    return next(n for n in run["nodes"] if n["node_id"] == node_id)
+
+
+# ---------------------------------------------------------------------------
+# Graphs
+# ---------------------------------------------------------------------------
+
+def image_graph() -> dict:
+    """task -> one model card. The smallest graph that can spend money."""
+    return {
+        "workflow": {"id": "wf_guard", "name": "One model"},
+        "nodes": [
+            {"id": "task", "type": "input.task", "label": "Task",
+             "config": {"text": "a paladin who files tickets"}},
+            {"id": "gen", "type": "model.image", "label": "Image model",
+             "config": {"provider": "krea", "model": "krea-2-medium"}},
+        ],
+        "edges": [{"from": ["task", "o"], "to": ["gen", "i"]}],
+    }
+
+
+def paid_tool_graph() -> dict:
+    """task -> the raw image tool, which the registry marks paid."""
+    return {
+        "workflow": {"id": "wf_paid", "name": "Paid tool"},
+        "nodes": [
+            {"id": "task", "type": "input.task", "label": "Task",
+             "config": {"text": "a paladin"}},
+            {"id": "buy", "type": "tool.image.generate", "label": "Image tool",
+             "config": {"filename": "paladin.png"}},
+        ],
+        "edges": [{"from": ["task", "o"], "to": ["buy", "i"]}],
+    }
+
+
+def gated_graph() -> dict:
+    """art agent -> review gate. The two statuses reconcile must not touch."""
+    return {
+        "workflow": {"id": "wf_gate", "name": "Gate"},
+        "nodes": [
+            {"id": "art", "type": "agent.art", "label": "Art", "seat": "art",
+             "brief": "Redraw it."},
+            {"id": "gate", "type": "control.gate", "label": "Review gate"},
+        ],
+        "edges": [{"from": ["art", "o"], "to": ["gate", "i"]}],
+    }
+
+
+# ---------------------------------------------------------------------------
+# The table itself
+# ---------------------------------------------------------------------------
+
+# Every tool node that reaches a provider that bills. Written out rather than
+# derived, because deriving it from the same flag it is checking would assert
+# nothing: this list is the human answer to "which of these cost money", and a
+# new provider tool that arrives without paid=True has to fail here.
+PAID = {
+    "tool.cinematic.shot", "tool.image.generate", "tool.item.generate",
+    "tool.item.variants", "tool.music.generate", "tool.storyboard.auto",
+    "tool.storyboard.frame", "tool.voice.speak",
+}
+
+
+class TestRegistryFlags:
+    def test_exactly_the_billing_tools_are_marked_paid(self):
+        assert {t for t, spec in wfnodes.REGISTRY.items() if spec.paid} == PAID
+
+    def test_a_paid_node_never_takes_the_line(self):
+        """A paid tool writes only NEW files, so it fans out like a model card.
+
+        Marking one exclusive would serialise the one thing users run several of
+        at once (three shots, four variants) for no collision that exists."""
+        for node_type in PAID:
+            assert wfnodes.REGISTRY[node_type].exclusive is False, node_type
+
+    def test_engine_writes_are_exclusive_and_reads_are_not(self):
+        for node_type in ("tool.godot.run", "tool.godot.import",
+                          "tool.scene.wire", "tool.scene.set_property",
+                          "tool.blender.rig", "tool.level.generate"):
+            assert wfnodes.REGISTRY[node_type].exclusive is True, node_type
+        for node_type in ("tool.godot.status", "tool.scene.outline",
+                          "tool.image.status", "tool.level.plan"):
+            assert wfnodes.REGISTRY[node_type].exclusive is False, node_type
+
+    def test_the_palette_is_told_both_flags(self):
+        """The catalogue is what badges a card PAID before anyone presses it."""
+        cards = {c["type"]: c for c in wfnodes.catalogue()}
+        assert set(cards) == set(wfnodes.REGISTRY)
+        for node_type, spec in wfnodes.REGISTRY.items():
+            assert cards[node_type]["paid"] == spec.paid
+            assert cards[node_type]["exclusive"] == spec.exclusive
+
+    def test_the_flags_are_read_from_the_table_not_from_the_graph(self):
+        """A hand-POSTed node cannot declare its way out of either flag."""
+        lying = {"type": "tool.music.generate", "kind": "tool",
+                 "paid": False, "exclusive": False, "config": {}}
+        assert workflows._tool_paid(lying) is True
+        assert workflows._node_spends(lying) is True
+        writer = {"type": "tool.scene.wire", "kind": "tool", "exclusive": False}
+        assert workflows._tool_exclusive(writer) is True
+
+    def test_an_unknown_tool_type_takes_the_line(self):
+        """Absent from the table means unknown, and unknown must not fan out."""
+        assert workflows._tool_exclusive({"type": "tool.from.the.future"}) is True
+        assert workflows._tool_paid({"type": "tool.from.the.future"}) is False
+
+
+class TestNodeTypes:
+    def test_the_live_palette_type_generates(self):
+        assert workflows.kind_for({"type": "model.image"}) == "generate"
+
+    def test_the_legacy_names_still_generate(self):
+        """A run stores a SNAPSHOT of the graph, and workflows are saved JSON.
+
+        Dropping a name a saved graph still uses would make that node 'passive':
+        green, instant, and generating nothing."""
+        for legacy in ("model.generate", "llm.prompt"):
+            assert workflows.kind_for({"type": legacy}) == "generate"
+
+    def test_the_names_nothing_ever_emitted_are_gone(self):
+        """Neither appears in any palette, template, fixture or doc in this
+        repository — they guarded a graph that cannot exist."""
+        for dead in ("image.generate", "gen.image"):
+            assert workflows.kind_for({"type": dead}) != "generate"
+        # ...and the tool-node type whose NAME is nearly one of them is intact
+        assert workflows.kind_for({"type": "tool.image.generate"}) == "tool"
+
+
+# ---------------------------------------------------------------------------
+# Gap 1 — an agent may not spend
+# ---------------------------------------------------------------------------
+
+class TestOnlyAHumanSpends:
+    def test_an_agent_cannot_run_a_paid_tool_node(self, root, tool):
+        run = workflows.start(root, paid_tool_graph())
+        assert workflows.spends_money(root, run["id"], "buy") is True
+        with pytest.raises(PermissionError) as caught:
+            workflows.run_node(root, run["id"], "buy", actor="agent:item-7")
+        assert "spends money" in str(caught.value)
+        assert tool.calls == [], "an agent bought something"
+        assert node(workflows.get(root, run["id"]), "buy")["status"] == "pending"
+
+    def test_an_agent_cannot_run_a_model_card(self, root, provider):
+        run = workflows.start(root, image_graph())
+        with pytest.raises(PermissionError):
+            workflows.run_node(root, run["id"], "gen", actor="agent:item-7")
+        assert provider.calls == []
+
+    def test_a_free_node_is_not_gated_on_anybody(self, root, tool):
+        """The gate is on MONEY, not on the ▶. A free status node that needed a
+        human would be this guard growing past what it is for."""
+        graph = paid_tool_graph()
+        graph["nodes"][1] = {"id": "buy", "type": "tool.godot.status",
+                             "label": "Godot status", "config": {}}
+        run = workflows.start(root, graph, dispatch=False)
+        assert workflows.spends_money(root, run["id"], "buy") is False
+        workflows.join(run["id"])
+        # it ran on the tick, with no human anywhere near it
+        assert node(workflows.get(root, run["id"]), "buy")["status"] == "passed"
+        assert len(tool.calls) == 1
+
+    def test_a_human_runs_the_same_paid_node(self, root, tool):
+        run = workflows.start(root, paid_tool_graph())
+        workflows.run_node(root, run["id"], "buy", actor="marta@box")
+        workflows.join(run["id"])
+        assert node(workflows.get(root, run["id"]), "buy")["status"] == "passed"
+        assert len(tool.calls) == 1
+
+    def test_the_route_refuses_an_agent_and_then_serves_a_human(
+            self, client, root, tool, monkeypatch):
+        started = client.post("/api/workflows/runs",
+                              json=dict(paid_tool_graph(),
+                                        dispatch=False)).json()["data"]
+        run_id = started["id"]
+
+        monkeypatch.setenv("BGATE_ACTOR", "agent:item-3")
+        refused = client.post(f"/api/workflows/runs/{run_id}/nodes/buy/run")
+        assert refused.status_code == 403, refused.json()
+        assert refused.json()["error"]["code"] == "forbidden"
+        assert tool.calls == [], "the 403 was reported after the money was spent"
+
+        monkeypatch.setenv("BGATE_ACTOR", "marta@box")
+        ran = client.post(f"/api/workflows/runs/{run_id}/nodes/buy/run")
+        assert ran.status_code == 200, ran.json()
+        workflows.join(run_id)
+        assert len(tool.calls) == 1
+
+    def test_a_missing_node_is_still_a_404_not_a_403(self, client, root, tool):
+        """The money check runs first, so it has to fail the same way the run
+        it precedes does — otherwise a typo becomes a permissions mystery."""
+        started = client.post("/api/workflows/runs",
+                              json=paid_tool_graph()).json()["data"]
+        missing = client.post(
+            f"/api/workflows/runs/{started['id']}/nodes/nope/run")
+        assert missing.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Gap 2 — the dispatch switch is the money switch
+# ---------------------------------------------------------------------------
+
+class TestDispatchGatesSpending:
+    def test_a_model_card_waits_for_a_person_when_dispatch_is_off(
+            self, root, provider):
+        run = workflows.start(root, image_graph(), dispatch=False)
+        for _ in range(3):                       # the dashboard polling
+            run = workflows.advance(root, run["id"])
+        workflows.join(run["id"])
+        assert provider.calls == [], "a poll spent money nobody asked for"
+        held = node(run, "gen")
+        assert held["status"] == "pending"
+        assert "spends money" in held["detail"]
+        assert held["info"]["awaiting_human"] is True
+        assert run["status"] == "running", "the run is held, not finished"
+
+    def test_the_person_presses_run_and_it_goes(self, root, provider):
+        run = workflows.start(root, image_graph(), dispatch=False)
+        run = workflows.run_node(root, run["id"], "gen", actor="marta@box")
+        workflows.join(run["id"])
+        assert node(workflows.get(root, run["id"]), "gen")["status"] == "passed"
+        assert len(provider.calls) == 1
+
+    def test_run_workflow_is_the_yes_to_all_of_it(self, root, provider):
+        run = workflows.start(root, image_graph(), dispatch=True)
+        workflows.join(run["id"])
+        run = workflows.advance(root, run["id"])
+        assert node(run, "gen")["status"] == "passed"
+        assert len(provider.calls) == 1
+
+    def test_a_paid_tool_node_waits_on_the_same_switch(self, root, tool):
+        run = workflows.start(root, paid_tool_graph(), dispatch=False)
+        for _ in range(3):
+            run = workflows.advance(root, run["id"])
+        assert tool.calls == []
+        assert node(run, "buy")["status"] == "pending"
+        assert "spends money" in node(run, "buy")["detail"]
+
+    def test_a_free_tool_node_does_not_wait(self, root, tool):
+        """Only the bill is gated. A free node that needed a press would make
+        every graph a sequence of clicks."""
+        graph = paid_tool_graph()
+        graph["nodes"][1] = {"id": "buy", "type": "tool.godot.status",
+                             "label": "Godot status", "config": {}}
+        run = workflows.start(root, graph, dispatch=False)
+        workflows.join(run["id"])
+        assert len(tool.calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# Gap 3 — a context or reference node that failed is not a green node
+# ---------------------------------------------------------------------------
+
+def context_graph(node_spec: dict) -> dict:
+    """task + one context/reference node -> a model card that consumes both."""
+    return {
+        "workflow": {"id": "wf_ctx", "name": "Context"},
+        "nodes": [
+            {"id": "task", "type": "input.task", "label": "Task",
+             "config": {"text": "a paladin"}},
+            node_spec,
+            {"id": "gen", "type": "model.image", "label": "Image model",
+             "config": {"provider": "krea", "model": "krea-2-medium"}},
+        ],
+        "edges": [
+            {"from": ["task", "o"], "to": ["gen", "i"]},
+            {"from": [node_spec["id"], "o"], "to": ["gen", "i"]},
+        ],
+    }
+
+
+def held_context_graph(node_spec: dict) -> dict:
+    """The same context node, behind an agent step it takes input from.
+
+    A passive node is resolved by whatever tick reaches it, so the only way a
+    human can be standing at an UNRESOLVED one is with something unfinished in
+    front of it — which is the state the ▶ exists for.
+    """
+    graph = context_graph(node_spec)
+    graph["nodes"].insert(1, {"id": "art", "type": "agent.art", "label": "Art",
+                              "seat": "art", "brief": "Draw it."})
+    graph["edges"].append({"from": ["art", "o"], "to": [node_spec["id"], "i"]})
+    return graph
+
+
+BAD_BIBLE = {"id": "ctx", "type": "input.bible", "label": "Design bible",
+             "config": {"section_id": "9999"}}
+BAD_REF = {"id": "ctx", "type": "input.reference", "label": "Reference",
+           "config": {"ref": "no-such-anchor"}}
+
+
+class TestUnresolvedContextFails:
+    @pytest.mark.parametrize("spec,says", [
+        (BAD_BIBLE, "no bible section"),
+        (BAD_REF, "could not resolve reference"),
+    ])
+    def test_it_fails_the_node_instead_of_carrying_nothing_through(
+            self, root, provider, spec, says):
+        run = workflows.start(root, context_graph(spec), dispatch=True)
+        workflows.join(run["id"])
+        run = workflows.advance(root, run["id"])
+
+        failed = node(run, "ctx")
+        assert failed["status"] == "failed", (
+            "the node went green with an error in its output — the generation "
+            "behind it then billed for a prompt with no world and no anchor")
+        assert says in failed["detail"]
+        assert run["status"] == "failed"
+        assert node(run, "gen")["status"] == "skipped"
+        assert provider.calls == []
+
+    @pytest.mark.parametrize("spec,says", [
+        (BAD_BIBLE, "no bible section"),
+        (BAD_REF, "could not resolve reference"),
+    ])
+    def test_pressing_run_on_one_refuses_with_the_reason(self, root, provider,
+                                                         spec, says):
+        """Refused, not failed: the human is at the card and can fix the name."""
+        run = workflows.start(root, held_context_graph(spec), dispatch=False)
+        item = node(run, "art")["work_item_id"]
+        queue.set_status(root, item, "dispatched")
+        queue.set_status(root, item, "done", "drawn")
+        with pytest.raises(ValueError) as caught:
+            workflows.run_node(root, run["id"], "ctx", actor="marta@box")
+        assert says in str(caught.value)
+        assert node(workflows.get(root, run["id"]), "ctx")["status"] == "pending"
+
+    def test_a_resolvable_reference_still_passes(self, root, provider):
+        """The failure path must not have eaten the working one: a ref that
+        names a real file inside the project resolves and rides the wire."""
+        anchor = root / "game" / "assets" / "anchor.png"
+        anchor.parent.mkdir(parents=True, exist_ok=True)
+        anchor.write_bytes(b"\x89PNG")
+        spec = {"id": "ctx", "type": "input.reference", "label": "Reference",
+                "config": {"ref": "game/assets/anchor.png"}}
+        run = workflows.start(root, context_graph(spec), dispatch=True)
+        workflows.join(run["id"])
+        run = workflows.advance(root, run["id"])
+        assert node(run, "ctx")["status"] == "passed"
+        assert node(run, "gen")["status"] == "passed"
+        assert provider.calls[0]["style_refs"], "the anchor never reached the model"
+
+
+# ---------------------------------------------------------------------------
+# Gap 4 — the way out of 'running'
+# ---------------------------------------------------------------------------
+
+def _orphan(root, run_id: int, node_id: str) -> None:
+    """The row a killed process leaves behind: claimed, running, unowned.
+
+    Written directly because that is the only way to produce it without killing
+    a real worker mid-test — _INFLIGHT is per-process, so after a restart the
+    node is 'running' and the registry that would have finished it is empty.
+    """
+    workflows._set_node(root, run_id, node_id, "running",
+                        message="generating candidates…")
+
+
+class TestReconcile:
+    def test_it_releases_a_node_whose_worker_died(self, root, provider):
+        run = workflows.start(root, image_graph(), dispatch=False)
+        _orphan(root, run["id"], "gen")
+        # ...and the poll cannot move it: 'running' reads as work in flight
+        assert node(workflows.advance(root, run["id"]), "gen")["status"] == "running"
+
+        out = workflows.reconcile(root, run["id"])
+        assert [r["node_id"] for r in out["released"]] == ["gen"]
+        released = node(out["runs"][0], "gen")
+        assert released["status"] == "failed"
+        assert "can never arrive" in released["detail"]
+        assert released["info"]["reconciled"] is True
+        assert out["runs"][0]["status"] == "failed"
+
+    def test_it_leaves_a_gate_alone(self, root):
+        """A gate is 'running' BECAUSE it is waiting for a human. Releasing it
+        would turn every unattended approval into a failed run overnight."""
+        run = workflows.start(root, gated_graph())
+        item = node(run, "art")["work_item_id"]
+        queue.set_status(root, item, "dispatched")
+        queue.set_status(root, item, "done", "drawn")
+        run = workflows.advance(root, run["id"])
+        assert node(run, "gate")["status"] == "running"
+
+        assert workflows.reconcile(root, run["id"])["released"] == []
+        assert node(workflows.get(root, run["id"]), "gate")["status"] == "running"
+
+    def test_it_leaves_an_agent_step_alone(self, root):
+        """An agent step's status belongs to its queue item, which _sync_items
+        already reconciles against the queue."""
+        run = workflows.start(root, gated_graph())
+        queue.set_status(root, node(run, "art")["work_item_id"], "dispatched")
+        run = workflows.advance(root, run["id"])
+        assert node(run, "art")["status"] == "running"
+
+        assert workflows.reconcile(root, run["id"])["released"] == []
+        assert node(workflows.get(root, run["id"]), "art")["status"] == "running"
+
+    def test_it_leaves_a_worker_this_process_still_holds(self, root, provider):
+        run = workflows.start(root, image_graph(), dispatch=False)
+        _orphan(root, run["id"], "gen")
+        pending: Future = Future()
+        with workflows._INFLIGHT_LOCK:
+            workflows._INFLIGHT[(int(run["id"]), "gen")] = pending
+        try:
+            assert workflows.reconcile(root, run["id"])["released"] == []
+            assert node(workflows.get(root, run["id"]), "gen")["status"] == "running"
+        finally:
+            pending.set_result(None)
+            with workflows._INFLIGHT_LOCK:
+                workflows._INFLIGHT.pop((int(run["id"]), "gen"), None)
+
+    def test_the_sweep_covers_every_live_run(self, root, provider):
+        first = workflows.start(root, image_graph(), dispatch=False)
+        second = workflows.start(root, image_graph(), dispatch=False)
+        _orphan(root, first["id"], "gen")
+        _orphan(root, second["id"], "gen")
+
+        out = workflows.reconcile(root)
+        assert {r["run_id"] for r in out["released"]} == {first["id"], second["id"]}
+        assert all(r["status"] == "failed" for r in out["runs"])
+
+    def test_reconciling_twice_changes_nothing(self, root, provider):
+        run = workflows.start(root, image_graph(), dispatch=False)
+        _orphan(root, run["id"], "gen")
+        workflows.reconcile(root, run["id"])
+        assert workflows.reconcile(root, run["id"])["released"] == []
+
+    def test_over_http(self, client, root, provider):
+        started = client.post("/api/workflows/runs",
+                              json=dict(image_graph(), dispatch=False)).json()["data"]
+        _orphan(root, started["id"], "gen")
+
+        one = client.post(f"/api/workflows/runs/{started['id']}/reconcile")
+        assert one.status_code == 200, one.json()
+        assert [r["node_id"] for r in one.json()["data"]["released"]] == ["gen"]
+
+        assert client.post("/api/workflows/reconcile").json()["data"]["released"] == []
+        assert client.post("/api/workflows/runs/999/reconcile").status_code == 404


### PR DESCRIPTION
Four mechanics, all of which showed up as "the agents waste time".

THE DEADLOCK. Nothing in this system ever committed anything, and dispatch
refuses a dirty tree by default — so the first agent to write a file made the
tree dirty and every later dispatch was refused, forever, on a 20-second retry.
dirty_tree is a FLOOR refusal, so it stopped the whole board rather than one
item. Measured: an overnight queue of thirty items finished three. gitwork
gains commit_paths (the run's OWN paths, never `commit -a`, so a human's
uncommitted work is never swept in and still correctly blocks the next
dispatch), and dispatch.auto_commit — on by default — calls it when a run ends.

THE PICKUP LOOP. A finished worker's only move was to exit and let the board
pay a fresh agent's whole briefing for the next item. queue.claim_next lets it
claim the next ready item for its own seat and keep going, honouring the same
holds autodeploy respects. The claim is atomic against the dashboard
(queue.reserve/release), because there are two dispatchers now and both used to
read 'queued' and proceed. The watchdog keeps stdin open while a claim is live;
_reap and reconcile requeue whatever a dead run claimed.

DEPENDENCIES ARE A GRAPH. work_item.depends_on holds one parent, so a scene
that needs the sprite AND the sound AND the script could express one of three.
Migration 0033 adds work_item_dep alongside it (additive — every chain and
query that reads the column still works), blocker() reports every unsatisfied
parent, and cut_dependency is the repair verb for the board's one state with no
exit: a cancelled predecessor blocked its successors permanently.

SILENT FAILURES. _trip's ceiling kills wrote 'failed' through set_status, which
never emits, and _reap skipped complete() because the item was no longer
dispatched — so timeout, stall, cost and expired-OAuth kills produced no
item.failed at all: no bell, no webhook, no auto-reopen. Also: a runner that
fails instantly on every item (an expired login) burned a whole queue to
'failed' in ten minutes, because a dispatch that SPAWNS counts as a success and
never triggered a cooldown.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>