### PR TITLE
Agent seats refactor: seat = toolset + boundary, gates that redirect, single-sourced rules, provider gateway

### DIFF
--- a/bgate_cli/hook.py
+++ b/bgate_cli/hook.py
@@ -141,6 +141,40 @@ def director_mode() -> str:
 
 
 # ---------------------------------------------------------------------------
+# THE SEATED WORKER'S LANE - advisory by default since 2026-08-19.
+#
+# A seat is a TOOLSET plus a PROJECT BOUNDARY (aegis, which now defaults to
+# block). The lane table inside that boundary turned out to do more harm than
+# good as a hard gate: the default lanes assume the <root>/game + <root>/design
+# scaffold, so on an adopted repo every seat was refused on contact with the
+# real source tree, and the observed agent response to a refusal was not
+# routing but dying politely - "failed" with nothing done, cleared and
+# redispatched by a human. The refusal MESSAGE (which seat owns the path, the
+# queue_add call that hands work over) earned its keep; the exit code 2 did
+# not. So the message survives as a warning to the human and the write lands.
+#
+# Same ladder shape as DIRECTOR_MODES, different population. THE LADDER
+# ITSELF LIVES IN bgate_core.seats (LANE_MODES / lane_mode), single-sourced
+# for the same reason aegis's ladder is: two processes must answer alike.
+#
+#   collide  lanes waived silently; a collision with another live run still
+#            blocks and the lease is still taken.
+#   warn     DEFAULT. As collide, plus out-of-lane writes reported to the
+#            human on exit 1. The write lands; the agent is not interrupted.
+#   block    the old behaviour - out of lane is refused. For projects whose
+#            lane table is curated and trusted.
+def worker_lane_mode() -> str:
+    """How hard to enforce a SEATED worker's lane. Never raises.
+
+    Imported lazily like every bgate_core import here - the hook is a fresh
+    process on every tool call.
+    """
+    from bgate_core import seats
+
+    return seats.lane_mode()
+
+
+# ---------------------------------------------------------------------------
 # CONTAINMENT - the where-question, and its own ladder.
 #
 # Deliberately NOT folded into DIRECTOR_MODES even though it reads the same
@@ -157,12 +191,11 @@ def director_mode() -> str:
 # The names stay because callers and tests here use them.
 #
 #   off    the old behaviour: the boundary is not checked at all.
-#   warn   DEFAULT FOR THIS RELEASE. The call lands and the human is told on
-#          exit 1. This is not timidity: the gate's whole job right now is to
-#          produce the log that proves `block` would deny nothing legitimate.
-#          Turning it straight to block would have every false positive land as
-#          a dead agent in somebody's board, discovered hours later.
-#   block  a seated agent touching another tree is refused.
+#   warn   the call lands and the human is told on exit 1 - the
+#          evidence-gathering mode this gate shipped at.
+#   block  DEFAULT since 2026-08-19. A seated agent touching another tree is
+#          refused. The boundary hardened the same day the lane gate went
+#          advisory: a seat is a toolset plus THIS line.
 def aegis_mode() -> str:
     """How hard to enforce the project boundary. Never raises.
 
@@ -574,10 +607,11 @@ def decide(payload: dict, seat: str, owner: str = "",
            mode: str = "block") -> tuple[int, str]:
     """Pure decision, separated from stdio so tests can hit it directly.
 
-    `mode` is "block" for a dispatched seat worker - its lane is the whole point
-    of dispatching it - and one of DIRECTOR_MODES for a session that adopted no
-    seat. It only ever softens the LANE gate; a lock or lease collision is a
-    second live writer in the same file and is refused in every mode but "off".
+    `mode` is one of WORKER_LANE_MODES for a dispatched seat worker (default
+    "warn" - the lane is advisory, the project boundary is what a seat
+    enforces) and one of DIRECTOR_MODES for a session that adopted no seat.
+    It only ever softens the LANE gate; a lock or lease collision is a second
+    live writer in the same file and is refused in every mode but "off".
     """
     tool = payload.get("tool_name", "")
     tool_input = payload.get("tool_input") or {}
@@ -1278,7 +1312,10 @@ def main(argv: list[str] | None = None) -> int:
     try:
         seat = os.environ.get("BGATE_SEAT", "").strip()
         owner = os.environ.get("BGATE_LOCK_OWNER", "").strip()
-        mode = "block"
+        # A dispatched worker's lane is advisory by default (BGATE_LANES) -
+        # the project boundary (aegis) is what a seat enforces. See
+        # WORKER_LANE_MODES.
+        mode = worker_lane_mode()
         if not seat:
             # THIS LINE USED TO BE `return ALLOW`. It read as "no adopted
             # identity, nothing to enforce", and the first half was true - but a
@@ -1293,13 +1330,15 @@ def main(argv: list[str] | None = None) -> int:
         # hand-started session lives in the payload, not the environment.
         payload = json.loads(sys.stdin.read() or "{}")
         if mode != "block":
-            # Only the director path invents an owner, and only when it has to.
-            # A SEATED worker with no BGATE_LOCK_OWNER keeps the old semantics - # can_write treats an ownerless caller as unable to write over an
-            # owned lock, which is stricter than anything derived here, and
-            # loosening that to "no owner, no checks" would have quietly turned
-            # the gate off for exactly the agents it was written for.
+            # A dispatched worker already has BGATE_LOCK_OWNER=item-<id>;
+            # session_owner is the fallback for a hand-started session. A
+            # seated worker somehow lacking both keeps the old strict
+            # semantics via decide() - can_write treats an ownerless caller
+            # as unable to write over an owned lock - so only the DIRECTOR
+            # path may bail out on a missing identity.
             owner = owner or session_owner(payload)
-            if not owner:
+            if not owner and seat == DIRECTOR_SEAT \
+                    and not os.environ.get("BGATE_SEAT", "").strip():
                 # Nothing distinguishes this session from any other, so a lease
                 # would be meaningless and a collision unattributable. The
                 # director's lane is advisory anyway; do nothing rather than

--- a/bgate_core/aegis.py
+++ b/bgate_core/aegis.py
@@ -51,14 +51,14 @@ ALLOW, DENY, OUTSIDE = "allow", "deny", "outside"
 # callers.
 #
 #   off    the boundary is not checked at all.
-#   warn   DEFAULT FOR THIS RELEASE. The call lands and the crossing is logged.
-#          The gate's job right now is to produce the evidence that proves
-#          `block` would deny nothing legitimate; flipping straight to block
-#          would have every false positive land as a dead agent on somebody's
-#          board, discovered hours later.
-#   block  a seated agent touching another tree is refused.
+#   warn   the call lands and the crossing is logged - the evidence-gathering
+#          mode this gate shipped at while lanes were the hard boundary.
+#   block  DEFAULT. A seated agent touching another tree is refused. This
+#          became the default when the seat model was inverted (2026-08-19):
+#          a seat is a toolset plus THIS boundary, and lanes inside it are
+#          advisory. If the boundary only warns, a seat enforces nothing.
 MODES = ("off", "warn", "block")
-DEFAULT_MODE = "warn"
+DEFAULT_MODE = "block"
 
 # What marks a directory as a Builders Gate project. Deliberately NOT imported
 # from bgate_core.db: this module is loaded on the hook's hot path and by a

--- a/bgate_core/agentlog.py
+++ b/bgate_core/agentlog.py
@@ -1,0 +1,391 @@
+"""THE stream-json parser - one vocabulary for an agent's log, owned here.
+
+An agent run writes `.bgate/agents/item-<id>.log` in the CLI's stream-json
+(claude's bare event names, codex's dotted ones - one file may carry both,
+because a re-dispatch can switch runners under an existing log). Three
+separate readers had each grown their own copy of the folding rules: the
+dashboard's live feed (bgate_ui.dispatch), the history browser
+(bgate_ui.routes.history), and the MCP server's agent_activity. The forks
+were not theoretical - the first cut of this module misquoted STEER_MARKER,
+so the from-anywhere reader silently dropped every steer, which is exactly
+the class of bug a third copy of a constant produces.
+
+So the folding rules live HERE, in core, where every process can import
+them: what counts as a step, which payload key is a tool call's SUBJECT,
+how a re-dispatch resets the feed, what the final result event carries.
+The dashboard keeps its byte-cursor cache and Popen liveness on top;
+history keeps its byte-offset index and path mining; both fold events
+through this vocabulary or share its constants.
+
+Also here: :func:`tail`, the from-anywhere reader (disk + the agentreg
+registry, no server required) that backs the MCP `agent_activity` tool.
+
+Step shapes: {"kind": "say"|"tool"|"result"|"steer", ...} plus a "ts"
+stamp; the final result event lands in state["final"], not in the steps.
+"""
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Optional, Union
+
+# The dashboard rolls the log at 10MB; half of one is far more history than a
+# "what is it doing" question needs, and keeps the worst-case read bounded.
+MAX_TAIL_BYTES = 512 * 1024
+
+# The marker dispatch prepends to a mid-run steer turn. The PARSERS key on it,
+# the WRITER (dispatch's steer delivery) embeds it - one constant, or a reader
+# silently stops seeing steers (measured: see module docstring).
+STEER_MARKER = "STEER FROM THE DIRECTOR (act on this now): "
+
+# Matches runners.MCP_SERVER_NAME ("builders-gate"), spelled out because this
+# module is core and runners is UI; test_agentlog pins the agreement.
+MCP_TOOL_PREFIX = "mcp__builders-gate__"
+
+# codex items that are narration about thinking, not actions taken.
+CODEX_QUIET_ITEMS = {"reasoning", "todo_list"}
+
+
+def log_path(root, item_id: int) -> Path:
+    return Path(root) / ".bgate" / "agents" / f"item-{int(item_id)}.log"
+
+
+def blocks(ev: dict) -> list:
+    """Content blocks of a stream-json message. Some CLI builds send
+    ``content`` as a bare string; iterating that yields characters and
+    explodes on .get."""
+    content = (ev.get("message") or {}).get("content")
+    return [b for b in content if isinstance(b, dict)] \
+        if isinstance(content, list) else []
+
+
+def tool_subject(name: str, inp: dict) -> str:
+    """WHAT a call was about, not merely which tool it was.
+
+    The inspector drew a run as a row of verbs — Read, Grep, Grep, Read,
+    Bash — so a forty-step run was thirty-five interchangeable words. The
+    subject was always in the payload; this is the one place that decides
+    which key carries it, because the answer is per-tool: Grep's subject is
+    its PATTERN and the path is context, while Read's subject is the path
+    itself. The path still rides along on the end for the searches, because
+    phases.look() mines this string for the files a step touched.
+    """
+    def val(key: str) -> str:
+        got = inp.get(key)
+        return " ".join(str(got).split()) if isinstance(got, (str, int)) else ""
+
+    if name in ("Grep", "Glob"):
+        return " · ".join(x for x in (val("pattern"), val("path")) if x)
+    if name == "Bash":
+        return val("command")
+    if name in ("Read", "Write", "Edit", "MultiEdit"):
+        return val("file_path") or val("path")
+    if name == "NotebookEdit":
+        return val("notebook_path")
+    if name in ("WebFetch", "WebSearch"):
+        return val("url") or val("query")
+    if name in ("Task", "Agent"):
+        return val("description") or val("subagent_type")
+    if name == "TodoWrite":
+        # Its input is the whole list; any one item of it is a misleading label.
+        return ""
+    return (val("path") or val("file_path") or val("name") or val("title")
+            or val("role") or val("query") or val("pattern")
+            or val("description") or val("command") or val("prompt"))
+
+
+def add_step(state: dict, step: dict, max_steps: int = 0) -> None:
+    """Append one step; a positive ``max_steps`` bounds the ring.
+
+    What falls off the front is counted (``step_count``), not forgotten -
+    the dashboard's ``dropped``/``truncated`` fields are derived from the
+    difference. Every step is stamped with when it was PARSED - a few
+    milliseconds after the CLI wrote it and the only clock the log offers -
+    which is what lets a phase attribute artifacts to the part of the run
+    that produced them. Rounded to the second by the consumer that stores it.
+    """
+    step.setdefault("ts", time.time())
+    state["steps"].append(step)
+    state["step_count"] = int(state.get("step_count") or 0) + 1
+    if max_steps and len(state["steps"]) > max_steps:
+        del state["steps"][:len(state["steps"]) - max_steps]
+
+
+def _reset(state: dict) -> None:
+    """A re-dispatch. The log appends across runs and showing run 1's result
+    as run 2's current state was a real observed bug - everything before the
+    marker belongs to a run that is over, including its session id (resuming
+    run 1 while looking at run 2 would open an unrelated transcript)."""
+    state["steps"].clear()
+    state["step_count"] = 0
+    state["final"] = None
+    state["session_id"] = ""
+
+
+def fold_line(state: dict, raw: Union[bytes, str], max_steps: int = 0) -> None:
+    """Fold one raw log line into the feed. Tolerant of anything: a partial
+    or non-JSON line is a moment in a file two processes share, not an error."""
+    if isinstance(raw, bytes):
+        raw = raw.decode("utf-8", "replace")
+    line = raw.strip()
+    if not line:
+        return
+    try:
+        ev = json.loads(line)
+    except (ValueError, TypeError):
+        return
+    if isinstance(ev, dict):
+        fold_event(state, ev, max_steps)
+
+
+def fold_event(state: dict, ev: dict, max_steps: int = 0) -> None:
+    """Fold one parsed event - claude or codex shaped - into the feed.
+
+    ``state`` needs: steps (list), final, session_id, step_count. Extra keys
+    (a byte cursor, a cache stamp) are the caller's business and untouched.
+    """
+    # THE CLAUDE SESSION THIS RUN IS, which is what makes it resumable: the
+    # id is the handle for `claude --resume`. Taken from the first line that
+    # has one and then left alone (measured: one id per run across a log).
+    if not state.get("session_id"):
+        sid = ev.get("session_id")
+        if isinstance(sid, str) and sid:
+            state["session_id"] = sid
+
+    etype = ev.get("type")
+    if etype == "bgate_run_start":
+        _reset(state)
+    elif etype == "assistant":
+        for block in blocks(ev):
+            if block.get("type") == "text" \
+                    and str(block.get("text", "")).strip():
+                add_step(state, {"kind": "say",
+                                 "text": str(block["text"]).strip()[:1000]},
+                         max_steps)
+            elif block.get("type") == "tool_use":
+                name = str(block.get("name", "?"))
+                inp = block.get("input") \
+                    if isinstance(block.get("input"), dict) else {}
+                short = name.replace(MCP_TOOL_PREFIX, "")
+                # 200, not 120: a Bash hint is a command line, and the old
+                # cap cut most of them off inside the `cd "<long path>" &&`
+                # prefix every dispatched agent opens with.
+                add_step(state, {"kind": "tool", "name": short,
+                                 "hint": tool_subject(short, inp)[:200]},
+                         max_steps)
+    elif etype == "user":
+        for block in blocks(ev):
+            if block.get("type") == "tool_result":
+                c = block.get("content")
+                txt = c if isinstance(c, str) else (
+                    c[0].get("text", "") if isinstance(c, list) and c
+                    and isinstance(c[0], dict) else "")
+                txt = str(txt).strip()
+                if txt:
+                    add_step(state, {"kind": "result", "text": txt[:600],
+                                     "truncated": len(txt) > 600}, max_steps)
+            elif block.get("type") == "text":
+                # Replayed user turns - the FIRST is the dispatch prompt,
+                # which is plumbing, not activity. Only steers surface.
+                txt = str(block.get("text", ""))
+                if STEER_MARKER in txt:
+                    add_step(state, {"kind": "steer",
+                                     "text": txt.split(STEER_MARKER, 1)[1]
+                                     .strip()[:600]}, max_steps)
+    elif etype == "result":
+        # The agent's actual answer. NOT truncated to a preview length - it
+        # is the deliverable sentence; the cap only stops a runaway result
+        # from pinning memory.
+        state["final"] = {"subtype": ev.get("subtype"),
+                          "text": str(ev.get("result", ""))[:20000],
+                          "cost": ev.get("total_cost_usd"),
+                          "turns": ev.get("num_turns"),
+                          # The tokens, and which model spent them. `cost` on
+                          # a subscription is what this WOULD have cost on the
+                          # API; these are what the usage window meters.
+                          "model": final_model(ev),
+                          "tokens": final_tokens(ev)}
+    elif etype and etype.startswith(("thread.", "turn.", "item.")):
+        _fold_codex(state, str(etype), ev, max_steps)
+
+
+def final_tokens(ev: dict) -> dict:
+    """The run's token usage, in this vocabulary's four names. Read off
+    `usage` rather than summed from per-turn events: the CLI already totals
+    it there."""
+    usage = ev.get("usage")
+    if not isinstance(usage, dict):
+        return {}
+
+    def n(key: str) -> int:
+        try:
+            return max(0, int(usage.get(key) or 0))
+        except (TypeError, ValueError):
+            return 0
+    return {"input": n("input_tokens"), "output": n("output_tokens"),
+            "cache_read": n("cache_read_input_tokens"),
+            "cache_write": n("cache_creation_input_tokens")}
+
+
+def final_model(ev: dict) -> str:
+    """Which model actually ran, as the CLI names it - including the
+    context-window suffix, which is the distinction that meters differently.
+    Recorded because nothing else in the system knew."""
+    usage = ev.get("modelUsage")
+    if isinstance(usage, dict) and usage:
+        return max(usage, key=lambda k: (usage[k] or {})
+                   .get("cacheReadInputTokens", 0)
+                   if isinstance(usage[k], dict) else 0)
+    return str(ev.get("model") or "")
+
+
+# ---------------------------------------------------------------------------
+# The other vocabulary: `codex exec --json` speaks a smaller, dotted event
+# language. The two do not collide - dotted names against bare ones - so one
+# reader handles a log of either kind without being told which runner wrote
+# it. The mapping is deliberately lossy toward what the agent DID, not which
+# vendor's noun it used.
+# ---------------------------------------------------------------------------
+def _fold_codex(state: dict, etype: str, ev: dict, max_steps: int = 0) -> None:
+    if etype == "thread.started":
+        _reset(state)      # same job as bgate_run_start
+        return
+    if etype == "turn.completed":
+        # NO PRICE HERE, ON PURPOSE - see runners.Runner.cost_tracked. Tokens
+        # are recorded so the run is not a black box; nothing downstream may
+        # read them as dollars.
+        usage = ev.get("usage") if isinstance(ev.get("usage"), dict) else {}
+        state["usage"] = {
+            "input_tokens": usage.get("input_tokens"),
+            "cached_input_tokens": usage.get("cached_input_tokens"),
+            "output_tokens": usage.get("output_tokens"),
+            "reasoning_output_tokens": usage.get("reasoning_output_tokens"),
+        }
+        return
+    if etype != "item.completed":
+        # item.started is the same item arriving twice; taking only the
+        # completion keeps one step per action instead of a doubled feed.
+        return
+
+    item = ev.get("item") if isinstance(ev.get("item"), dict) else {}
+    kind = str(item.get("type") or "")
+    if kind in CODEX_QUIET_ITEMS:
+        return
+    if kind == "agent_message":
+        text = str(item.get("text") or "").strip()
+        if text:
+            add_step(state, {"kind": "say", "text": text[:1000]}, max_steps)
+            # The LAST message of the run is the deliverable; codex has no
+            # separate result event to carry it. Overwritten each time.
+            state["final"] = {"subtype": "success", "text": text[:20000],
+                              "cost": None, "turns": None}
+        return
+    if kind == "command_execution":
+        add_step(state, {"kind": "tool", "name": "Bash",
+                         "hint": str(item.get("command") or "")[:120]},
+                 max_steps)
+        output = str(item.get("aggregated_output") or "").strip()
+        code = item.get("exit_code")
+        if output or code:
+            add_step(state, {"kind": "result",
+                             "text": (f"exit {code}\n" if code else "")
+                             + output[:600],
+                             "truncated": len(output) > 600}, max_steps)
+        return
+    if kind in ("mcp_tool_call", "tool_call"):
+        name = str(item.get("tool") or item.get("name") or "?")
+        args = item.get("arguments") \
+            if isinstance(item.get("arguments"), dict) else {}
+        short = name.replace(MCP_TOOL_PREFIX, "")
+        add_step(state, {"kind": "tool", "name": short,
+                         "hint": (tool_subject(short, args)
+                                  or str(args.get("seat") or ""))[:200]},
+                 max_steps)
+        return
+    if kind in ("file_change", "patch_apply"):
+        changes = item.get("changes") \
+            if isinstance(item.get("changes"), list) else []
+        paths = ", ".join(str((c or {}).get("path") or "") for c in changes[:4])
+        add_step(state, {"kind": "tool", "name": "Edit",
+                         "hint": (paths or str(item.get("path") or ""))[:120]},
+                 max_steps)
+        return
+    # An item type this version has never seen still belongs in the feed -
+    # silence would make a new codex capability look like an agent doing
+    # nothing.
+    label = str(item.get("text") or item.get("command") or kind)
+    add_step(state, {"kind": "tool", "name": kind or "item",
+                     "hint": label[:120]}, max_steps)
+
+
+# ---------------------------------------------------------------------------
+# The from-anywhere reader (backs the MCP agent_activity tool)
+# ---------------------------------------------------------------------------
+def _liveness(root, item_id: int) -> dict:
+    """Is a process on this machine genuinely running this item, per the
+    on-disk registry? Best-effort: an unreadable registry reads as unknown."""
+    try:
+        from . import aegis, agentreg
+        for entry in agentreg.live():
+            if int(entry.get("item_id") or 0) != int(item_id):
+                continue
+            here = entry.get("root") or ""
+            if here and aegis.within(Path(here), Path(root)) \
+                    or aegis.within(Path(root), Path(here)):
+                return {"running": True, "pid": entry.get("pid"),
+                        "seat": entry.get("seat") or "",
+                        "started_at": entry.get("started_at")}
+        return {"running": False}
+    except Exception:
+        return {"running": None}
+
+
+def tail(root, item_id: int, limit: int = 30,
+         max_bytes: int = MAX_TAIL_BYTES) -> dict:
+    """The last ``limit`` steps of an item's agent log, plus liveness.
+
+    Cache-free and cursor-free on purpose: this serves an occasional MCP
+    call from ANY process (CLI, desktop, a second dashboard), so there is no
+    state to go stale between them; the dashboard's polling feed keeps its
+    own byte cursor and folds through the same functions above.
+
+    ``truncated`` says the window opened mid-run (the byte cap cut the head
+    off, or ``limit`` did) - a caller that needs everything reads the log
+    file the result names.
+    """
+    path = log_path(root, item_id)
+    out = {"item_id": int(item_id), "log": str(path),
+           **_liveness(root, item_id)}
+    try:
+        size = path.stat().st_size
+    except OSError:
+        return {**out, "steps": [], "final": None, "step_count": 0,
+                "truncated": False, "session_id": "",
+                "note": "no agent log for this item - it has never been "
+                        "dispatched here, or the log was cleaned up"}
+    clipped = size > max_bytes
+    try:
+        with open(path, "rb") as fh:
+            if clipped:
+                fh.seek(size - max_bytes)
+            data = fh.read(max_bytes)
+    except OSError:
+        return {**out, "steps": [], "final": None, "step_count": 0,
+                "truncated": False, "session_id": "",
+                "note": "the agent log exists but could not be read"}
+    lines = data.split(b"\n")
+    if clipped:
+        lines = lines[1:]  # the first line is almost certainly partial
+    state: dict = {"steps": [], "final": None, "session_id": "",
+                   "step_count": 0}
+    for raw in lines:
+        fold_line(state, raw)
+    steps = state["steps"]
+    window = steps[-limit:] if limit else steps
+    return {**out,
+            "steps": window,
+            "final": state["final"],
+            "step_count": state["step_count"],
+            "truncated": clipped or len(window) < len(steps),
+            "session_id": state["session_id"]}

--- a/bgate_core/agentlog.py
+++ b/bgate_core/agentlog.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 import json
 import time
 from pathlib import Path
-from typing import Optional, Union
+from typing import Union
 
 # The dashboard rolls the log at 10MB; half of one is far more history than a
 # "what is it doing" question needs, and keeps the worst-case read bounded.

--- a/bgate_core/gateway.py
+++ b/bgate_core/gateway.py
@@ -32,9 +32,10 @@ balance reads 0 is named as drained and skipped.
 """
 from __future__ import annotations
 
+import logging
 import threading
 import time
-from typing import Any, Optional
+from typing import Any
 
 # Which providers can serve which job. ORDER IS THE DOCTRINE, not a fallback
 # chain of equals: sprites/stills are minted with kie (nano-banana-2), motion
@@ -106,7 +107,19 @@ def _probe(provider: str, root) -> dict:
                 except Exception:
                     row["balance"] = None
     except Exception as exc:
-        row["reason"] = f"{type(exc).__name__}: {exc}"
+        # TYPE NAME ONLY in the row, deliberately. The rows this builds go out
+        # over HTTP (/api/providers/balances), and an exception's MESSAGE can
+        # carry filesystem paths or a provider response body - CodeQL flagged
+        # the flow, and it is right on hygiene even for a loopback-only
+        # surface. The adapters' own `reason` strings above are crafted
+        # sentences and stay; only the unexpected-failure catch is anonymised,
+        # with the full detail kept in the server's own log.
+        logging.getLogger(__name__).warning(
+            "provider probe %s failed: %s: %s", provider,
+            type(exc).__name__, exc)
+        row["reason"] = (f"the {provider} probe failed "
+                         f"({type(exc).__name__}) - the server log has the "
+                         "detail")
     return row
 
 

--- a/bgate_core/gateway.py
+++ b/bgate_core/gateway.py
@@ -1,0 +1,235 @@
+"""The provider gateway - which paid providers are LIVE, per capability.
+
+THE FAILURE THIS EXISTS TO END, observed repeatedly: an agent's first
+generation call hits the one provider it thought of, that provider answers
+402 (no credit) or has no key at all, and the agent concludes "no art today"
+and hand-rolls the asset - placeholder PNGs, procedural stand-ins, a 270-line
+workaround - while a second provider sat fully keyed and funded the whole
+time. One dead key must read as a ROUTING event, not a capability outage.
+
+So this module gives one answer to two questions, from any process:
+
+  status(root)            every hosted provider: keyed, reachable, and - where
+                          the provider exposes it - the remaining balance.
+  route_note(root, cap)   ONE SENTENCE for an error message: which provider to
+                          use instead, or the honest "nothing is funded, file
+                          the blocker". Appended to billing-shaped failures by
+                          the MCP server's _fail, so the redirect arrives in
+                          the same tool result as the refusal - the exact
+                          moment the agent is deciding to hand-roll.
+
+WHAT IT DELIBERATELY IS NOT. Not a key store (keys stay in .env; there is no
+set_api_key tool, same reasoning as bgate_core.settings) and not a spend
+gate (spend.check owns budgets). It reads; the one thing it writes is a
+short-lived in-process cache, because balance probes cost a network round
+trip and a billing failure can trigger several in one tick.
+
+BALANCE SEMANTICS: None is UNKNOWN, never zero. Only kie and Retro Diffusion
+expose a balance endpoint; openai exposes none and krea's API balance shows
+only through a 402 at call time. A provider with a key and an unknown
+balance is ROUTABLE - the call itself is the probe - while a provider whose
+balance reads 0 is named as drained and skipped.
+"""
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any, Optional
+
+# Which providers can serve which job. ORDER IS THE DOCTRINE, not a fallback
+# chain of equals: sprites/stills are minted with kie (nano-banana-2), motion
+# is Retro Diffusion, and that division is a hard project rule stated in the
+# art seat's house rules - this table must never quietly reorder it.
+CAPABILITIES: dict[str, tuple[str, ...]] = {
+    "image": ("kie", "krea", "openai"),
+    "animate": ("retrodiffusion",),
+    "three_d": ("krea",),
+    "music": ("kie",),
+    "video": ("kie",),
+}
+
+PROVIDERS = ("openai", "krea", "kie", "retrodiffusion")
+
+# Balance probes are network calls; a burst of billing failures must not turn
+# into a burst of probes. Per (root, provider), seconds.
+CACHE_S = 120.0
+_cache: dict[tuple[str, str], tuple[float, dict]] = {}
+_lock = threading.Lock()
+
+
+def _probe(provider: str, root) -> dict:
+    """One provider's row: {id, keyed, reason, balance, balance_unit}.
+
+    Never raises - a gateway that throws while explaining a failure eats the
+    original error. ``keyed`` is offline truth (the adapter's available());
+    ``balance`` is None wherever the provider will not say.
+    """
+    row: dict[str, Any] = {"id": provider, "keyed": False, "reason": "",
+                           "balance": None, "balance_unit": ""}
+    try:
+        if provider == "openai":
+            from bgate_adapters import imagegen
+            got = imagegen.available()
+            row["keyed"] = bool(got.get("available"))
+            row["reason"] = str(got.get("reason") or "")
+            # No balance API. The key is the whole offline answer.
+        elif provider == "krea":
+            from bgate_adapters import krea
+            got = krea.available(root)
+            row["keyed"] = bool(got.get("available"))
+            row["reason"] = str(got.get("reason") or "")
+            # The API balance surfaces only as a 402 at call time; billed
+            # separately from the workspace plan, which is the trap the
+            # reason string carries when that 402 arrives.
+        elif provider == "kie":
+            from bgate_adapters import kie
+            got = kie.available(root)
+            row["keyed"] = bool(got.get("available"))
+            row["reason"] = str(got.get("reason") or "")
+            if row["keyed"]:
+                row["balance"] = kie.credit_balance(root)
+                row["balance_unit"] = "credits"
+        elif provider == "retrodiffusion":
+            from bgate_adapters import retrodiffusion as rd
+            got = rd.available(root)
+            row["keyed"] = bool(got.get("available"))
+            row["reason"] = str(got.get("reason") or "")
+            if row["keyed"]:
+                try:
+                    bal = rd.balance(root)
+                    value = bal.get("credits")
+                    if value is None:
+                        value, row["balance_unit"] = bal.get("balance"), "usd"
+                    else:
+                        row["balance_unit"] = "credits"
+                    row["balance"] = float(value) if value is not None else None
+                except Exception:
+                    row["balance"] = None
+    except Exception as exc:
+        row["reason"] = f"{type(exc).__name__}: {exc}"
+    return row
+
+
+def status(root=None, *, fresh: bool = False) -> list[dict]:
+    """Every hosted provider's row, cached CACHE_S per (root, provider).
+
+    ``fresh=True`` bypasses the cache - the right call after the human says
+    they just topped an account up.
+    """
+    key_root = str(root or "")
+    now = time.monotonic()
+    rows = []
+    for provider in PROVIDERS:
+        cache_key = (key_root, provider)
+        with _lock:
+            hit = _cache.get(cache_key)
+        if hit and not fresh and now - hit[0] < CACHE_S:
+            rows.append(dict(hit[1]))
+            continue
+        row = _probe(provider, root)
+        with _lock:
+            _cache[cache_key] = (now, dict(row))
+        rows.append(row)
+    return rows
+
+
+def _drained(row: dict) -> bool:
+    balance = row.get("balance")
+    return balance is not None and float(balance) <= 0
+
+
+def pick(root, capability: str) -> dict:
+    """The provider a ``capability`` job should route to right now.
+
+    {"provider": id or None, "why": sentence, "alternatives": [ids]} -
+    doctrine order, keyed, not provably drained. None means genuinely nothing
+    is routable, and ``why`` says so per provider so the caller can file THE
+    blocker rather than A blocker.
+    """
+    order = CAPABILITIES.get(capability, ())
+    if not order:
+        return {"provider": None, "alternatives": [],
+                "why": f"unknown capability {capability!r}; known: "
+                       f"{sorted(CAPABILITIES)}"}
+    rows = {r["id"]: r for r in status(root)}
+    routable = [p for p in order
+                if rows.get(p, {}).get("keyed") and not _drained(rows[p])]
+    if routable:
+        chosen = routable[0]
+        note = _balance_phrase(rows[chosen])
+        return {"provider": chosen, "alternatives": routable[1:],
+                "why": f"{chosen} is keyed{note}"}
+    reasons = "; ".join(
+        f"{p}: " + ("drained (balance 0)" if p in rows and _drained(rows[p])
+                    else str(rows.get(p, {}).get("reason") or "no key"))
+        for p in order)
+    return {"provider": None, "alternatives": [],
+            "why": f"no {capability} provider is routable - {reasons}"}
+
+
+def _balance_phrase(row: dict) -> str:
+    balance = row.get("balance")
+    if balance is None:
+        return " (balance unknown - the call itself is the probe)"
+    return f" with {balance:g} {row.get('balance_unit') or 'credits'} left"
+
+
+def route_note(root, capability: str = "image") -> str:
+    """The sentence a billing failure carries so the agent re-routes.
+
+    Written for the agent that just read "no credit" and is about to decide
+    the pipeline is closed: it is not, unless every row here says so too.
+    """
+    routed = pick(root, capability)
+    if routed["provider"]:
+        return (f"THIS IS A ROUTING EVENT, NOT AN OUTAGE: {routed['why']} - "
+                f"re-run the SAME pipeline tool routed at "
+                f"{routed['provider']} (provider_status shows every row). "
+                "Do NOT hand-roll the asset because one account is empty.")
+    return (f"{routed['why']}. Nothing is funded for this, so do not improvise "
+            "a substitute asset: report the drained accounts in your result "
+            "note (provider_status has the rows) and file the top-up as the "
+            "blocker - a human decides which account gets money.")
+
+
+# Error text that means "the account, not the request" - the shapes the
+# adapters actually raise (kie 402 sentence, krea 402 sentence, RD/openai
+# billing phrasing). Deliberately narrow: a 422 must not read as a money
+# problem or the redirect trains agents to provider-hop around real bugs.
+_BILLING_SIGNS = ("no credit", "insufficient credit", "out of credit",
+                  "insufficient_quota", "exceeded your current quota",
+                  "billing", "402", "payment required", "top the account up",
+                  "top it up", "balance")
+
+
+def is_billing_error(text: str) -> bool:
+    lowered = str(text or "").lower()
+    return any(sign in lowered for sign in _BILLING_SIGNS)
+
+
+def billing_note(root=None) -> str:
+    """The capability-agnostic redirect appended to every billing-shaped tool
+    failure (bgate_mcp.server._fail). It cannot know which capability the
+    failed call served, so it reports the whole board and restates the
+    division of labour; the agent holds the context to pick the lane.
+    """
+    parts = []
+    for row in status(root):
+        if not row.get("keyed"):
+            parts.append(f"{row['id']}: no key")
+        elif _drained(row):
+            parts.append(f"{row['id']}: keyed but DRAINED (balance 0)")
+        else:
+            parts.append(f"{row['id']}: keyed{_balance_phrase(row)}")
+    live = [r for r in status(root) if r.get("keyed") and not _drained(r)]
+    tail = ("Re-run the SAME pipeline tool routed at a live provider where "
+            "the craft allows it (sprites/stills: kie > krea > openai; "
+            "motion: retrodiffusion only; music/video: kie only). Do NOT "
+            "hand-roll a substitute asset because one account is empty."
+            if live else
+            "Nothing is funded. Do not improvise a substitute asset: name "
+            "the drained accounts in your result note and file the top-up "
+            "as the blocker - a human decides which account gets money.")
+    return ("ONE ACCOUNT BEING EMPTY IS A ROUTING EVENT, NOT AN OUTAGE. "
+            "The board right now - " + "; ".join(parts) + ". " + tail +
+            " provider_status(fresh=true) re-probes after a top-up.")

--- a/bgate_core/modules.py
+++ b/bgate_core/modules.py
@@ -49,7 +49,7 @@ MODULES: dict[str, dict] = {
         "label": "Music",
         "blurb": "Suno music generation through kie.ai — candidates, "
                  "audition, keep/discard. Needs a KIE key.",
-        "tools": ("kie_music_", "music_"), "extras": (), "doctor": (),
+        "tools": ("music_",), "extras": (), "doctor": (),
     },
     "cinematic": {
         "label": "Cinematics",
@@ -167,7 +167,7 @@ def doctor_row_enabled(row_name: str, off: set[str]) -> bool:
 # Seat tool surfaces — which CRAFT a dispatched seat actually practises
 # ---------------------------------------------------------------------------
 # Modules trim the registry per PROJECT; crafts trim it per SEAT. A gameplay
-# agent carried every cinematic_, blender_ and kie_music_ schema in its
+# agent carried every cinematic_, blender_ and music_ schema in its
 # context on every turn — tools it has no lane, no brief step and no business
 # calling. Craft groups are the unambiguous generation/authoring surfaces;
 # everything outside them (queue, seats, bible, lore, godot, scene, assets,
@@ -180,7 +180,7 @@ CRAFTS: dict[str, tuple[str, ...]] = {
               "animation_generate", "sprite_contract_", "tileset_",
               "game_view_", "prop_generate"),
     "three_d": ("blender_", "character_generate", "godot_retarget_check"),
-    "music": ("kie_music_", "music_"),
+    "music": ("music_",),
     "cinematic": ("cinematic_", "storyboard_", "kie_video_"),
     "voice": ("voice_",),
     "sfx": ("sfx_",),

--- a/bgate_core/queue.py
+++ b/bgate_core/queue.py
@@ -39,11 +39,18 @@ SATISFIED = ("done",)
 # of them ends up grabbing an escalation a human was supposed to read.
 #   qa-gate-escalation — two agents could not agree and a human has to decide.
 #   chat — a message to the director; the console dispatches those itself.
-#   failure-escalation — an item failed past its automatic-retry cap. The whole
-#     point of the cap is that nothing else is spent on it until a person has
-#     read the failure, so an escalation an auto-dispatcher picked up would be
-#     the harness paying to rediscover the blocker it just stopped paying for.
-HELD_SOURCES = ("qa-gate-escalation", "chat", "failure-escalation")
+#
+# failure-escalation is NOT held any more (2026-08-19). It was, on the theory
+# that a failure past its retry cap needed a person — and the observed result
+# was the board's worst dead end: the escalation sat queued forever, the
+# failed item sat failed forever, and the human's actual job became clearing
+# and re-dispatching by hand. The console's director session still gets first
+# claim on a fresh escalation (followup._hand_to_director_session reserves
+# it); when no such session exists, autodeploy now spawns a director-seat
+# agent whose brief is to DIAGNOSE AND ACT — read the failure, fix the brief,
+# queue_reopen or route the real blocker. Spend is bounded the same way it
+# always was: ONE escalation per item, ever (followup.fail_escalated).
+HELD_SOURCES = ("qa-gate-escalation", "chat")
 
 # The source stamped on that escalation. Named here rather than in the router
 # that files them because the hold above and the filing must never drift apart:
@@ -1006,6 +1013,40 @@ def release(root: str | os.PathLike[str], item_id: int) -> bool:
     return undone
 
 
+def ready(root: str | os.PathLike[str], seat: str = "",
+          limit: int = 120) -> list[dict]:
+    """Queued items an auto-dispatcher may start, most deserving first.
+
+    THE ONE COPY OF THE READINESS RULE. Both dispatchers - the dashboard's
+    autodeploy loop and a worker's claim_next - used to carry their own SQL
+    for "queued, not held, brief real, parents landed", and the two copies
+    had already drifted once (autodeploy joined the single-column parent,
+    claim_next re-derived it) before this function existed. A candidate that
+    one dispatcher considers ready and the other does not is a race with a
+    personality; readiness is now a fact about the ROW, answered here, and
+    the dispatchers differ only in what they do with the list.
+
+    Multi-parent deps (work_item_dep) are checked via blocker() in Python -
+    the SQL join sees only the depends_on column - which is also why the
+    LIMIT matters: it bounds the per-call blocker() sweep. Items filtered
+    out here produce NO refusal by design; a blocked successor is the board
+    working as intended, and the row's own `waiting_on` (queue_list) is
+    where the reason surfaces.
+    """
+    marks = ", ".join("?" * len(HELD_SOURCES))
+    seat_clause = "AND i.seat = ? " if seat else ""
+    params = (*( (seat,) if seat else () ), *HELD_SOURCES, PLACEHOLDER_BRIEF)
+    candidates = rows(db.connect(root).execute(
+        f"SELECT i.* FROM work_item i "
+        f"LEFT JOIN work_item d ON d.id = i.depends_on "
+        f"WHERE i.status = 'queued' {seat_clause}"
+        f"AND i.source NOT IN ({marks}) AND i.brief NOT LIKE ? "
+        "AND (i.depends_on IS NULL OR d.id IS NULL OR d.status = 'done') "
+        f"ORDER BY i.priority DESC, i.id LIMIT {max(1, int(limit))}",
+        params))
+    return [c for c in candidates if blocker(root, int(c["id"])) is None]
+
+
 def claim_next(root: str | os.PathLike[str], seat: str,
                actor: str) -> Optional[dict]:
     """Atomically claim the next READY item for a seat — the worker pickup loop.
@@ -1029,18 +1070,7 @@ def claim_next(root: str | os.PathLike[str], seat: str,
         raise ValueError(f"unknown seat {seat!r}; seats are {tuple(_seats.DEFAULT_SEATS)}")
     if not str(actor or "").strip():
         raise ValueError("claim_next needs the claiming execution's identity")
-    marks = ", ".join("?" * len(HELD_SOURCES))
-    candidates = rows(db.connect(root).execute(
-        f"SELECT i.id FROM work_item i "
-        f"LEFT JOIN work_item d ON d.id = i.depends_on "
-        f"WHERE i.status = 'queued' AND i.seat = ? "
-        f"  AND i.source NOT IN ({marks}) AND i.brief NOT LIKE ? "
-        "  AND (i.depends_on IS NULL OR d.id IS NULL OR d.status = 'done') "
-        "ORDER BY i.priority DESC, i.id LIMIT 10",
-        (seat, *HELD_SOURCES, PLACEHOLDER_BRIEF)))
-    for row in candidates:
-        if blocker(root, int(row["id"])) is not None:
-            continue                      # an extra parent has not landed
+    for row in ready(root, seat=seat, limit=10):
         if not reserve(root, int(row["id"])):
             continue                      # lost the race — next candidate
         item = set_run_fields(root, int(row["id"]), actor=str(actor).strip())

--- a/bgate_core/seats.py
+++ b/bgate_core/seats.py
@@ -24,6 +24,36 @@ from . import assets, bible, db, lore
 from .util import rows
 
 # ---------------------------------------------------------------------------
+# HOW HARD A SEATED WORKER'S LANE IS ENFORCED. One dial, one default, read by
+# both enforcers (the PreToolUse hook and anything server-side that asks) —
+# the same single-source rule as aegis.MODES, and it lives here because this
+# module is the lane oracle.
+#
+# Advisory by default since 2026-08-19: a seat is a TOOLSET plus the aegis
+# project boundary (which defaults to block). The lane table inside that
+# boundary is guidance — as a hard gate it refused whole source trees on
+# adopted repos and turned refusals into dead agents instead of routed work.
+#
+#   collide  lanes waived silently; collisions with another live run still
+#            block, leases still taken.
+#   warn     DEFAULT. As collide, plus out-of-lane writes reported to the
+#            HUMAN (hook exit 1). The write lands; the agent keeps working.
+#   block    the old behaviour — out of lane is refused.
+LANE_MODES = ("collide", "warn", "block")
+DEFAULT_LANE_MODE = "warn"
+
+
+def lane_mode() -> str:
+    """How hard to enforce a seated worker's lane. Never raises.
+
+    Unrecognised values map to the default rather than erroring — BGATE_LANES
+    is set by hand and by dispatch, and a typo that silently hardened (or
+    disabled) the gate would be worse than either mode.
+    """
+    chosen = os.environ.get("BGATE_LANES", "").strip().lower()
+    return chosen if chosen in LANE_MODES else DEFAULT_LANE_MODE
+
+# ---------------------------------------------------------------------------
 # THE LAYERED 3D SEQUENCE — KIND-KEYED, NOT ALWAYS-ON.
 #
 # This used to be 669 words wedged into the art seat's always-on workflow, and
@@ -142,6 +172,294 @@ def _kind_note(role: str, dimension: str) -> str:
 
 
 # ---------------------------------------------------------------------------
+# DISPATCH RULES - seat-specific house rules injected UNCONDITIONALLY into the
+# dispatch prompt: the one channel every agent sees even if it skips
+# seat_brief (item 56 did: it hand-rolled 8 loose image_edit frames for an
+# animation task and never stitched a sheet).
+#
+# MOVED HERE FROM bgate_ui/dispatch.py (2026-08-19), where they lived next to
+# the spawner while every OTHER statement of what a seat is lived here. Two
+# modules each holding half the seat's instructions is how the art rules and
+# the art workflow contradicted each other on which tool default applies
+# (measured, 2026-08-11) - the drift is only visible when both halves share a
+# file. dispatch.py re-exports these names so its callers and tests are
+# unchanged; the CONTENT has exactly one home.
+#
+# Keep these short, imperative, and PROJECT-AGNOSTIC: this dict ships with the
+# tool and is read by every project on the machine, so anything naming a
+# specific game's assets, characters or test scenes belongs in that project's
+# own seat_rules.json (see :func:`dispatch_rules`), not here.
+_LEVEL_RULE = (
+    "LEVEL GENERATION HOUSE RULE - THE ART IS A DEPENDENCY, NOT A DETAIL:\n"
+    "THE ORDER IS: game_view_get -> (art seat: tileset_generate, "
+    "prop_generate) -> then BY VIEW: top_down/isometric take "
+    "level_plan -> level_generate; side_scroller takes "
+    "sidescroll_generate.\n"
+    "• game_view_get FIRST, always. It says whether this game is "
+    "top_down, side_scroller or isometric, which decides the tile "
+    "geometry, which prop mounts exist, and how playability is even "
+    "checked. A level built against the wrong view is not a level with a "
+    "style problem, it is the wrong geometry - and both generators "
+    "refuse the wrong view rather than drawing it. UNSET IS DECLARED, "
+    "NOT GUESSED: game_view_set is the declaration, and it is a project "
+    "decision - make it only when your brief or the bible states the "
+    "view; otherwise it is the director's call to make.\n"
+    "• SIDE-SCROLLERS: sidescroll_generate, and THE JUMP IS AN "
+    "INPUT. Pass player_scene=<the player's .tscn> and the tunables are "
+    "read from the scene itself, converted to cells by the tileset's "
+    "tile size, and the player is instanced at spawn - do NOT copy "
+    "run/jump_speed/gravity by hand, because a level built for one "
+    "jump and played with another is the failure this parameter "
+    "closes. It refuses an unplayable level (reachable, clearance, "
+    "softlock, stranded); a finding is a bug to report, not a "
+    "difficulty dial. It takes the same prop_manifest.\n"
+    "• You hold level_plan, level_generate and sidescroll_generate. "
+    "You do NOT hold the "
+    "generators: tilesets and prop sheets are the ART seat's craft. If "
+    "the tileset or prop atlas you need does not exist, QUEUE IT - do "
+    "not point level_generate at a placeholder and call the level done. "
+    "The art seat makes them with tileset_generate and prop_generate; "
+    "prop_generate writes a MANIFEST and level_generate takes it as "
+    "prop_manifest=<path>, so you never type an atlas coordinate. "
+    "A level wired to art that is not there loads clean and draws nothing.\n"
+    "• READ THE PROP CONTRACT, do not invent one. bgate_core.props "
+    "declares every type's mount, its size in cells, which room "
+    "purposes it belongs in, and whether it loops or has states. "
+    "prop_atlas maps TYPE to atlas cell - 'torch.e=0,0 torch.w=1,0' "
+    "when a wall mount needs one tile per facing, because the engine's "
+    "flip bit does not carry texture_origin.\n"
+    "• DECALS ARE THEIR OWN LAYER. A TileMapLayer holds ONE tile "
+    "per coordinate, so a crack in the floor and the barrel standing on "
+    "it can only coexist as two layers. level_generate emits them; do "
+    "not flatten them back together.\n"
+    "• THE CONNECTIVITY GATE IS NOT ADVISORY. Every solid prop is "
+    "checked by flood filling the walkable set. If still_connected comes "
+    "back false that is a BUG to report, not a density dial to turn "
+    "down - a level that has lost a room looks completely fine in a "
+    "screenshot.\n"
+    "• READ THE `skipped` COUNTS before deciding a level is "
+    "under-dressed. back_wall, corner, no_side and wrong_purpose are the "
+    "placer REFUSING on purpose. Dark north walls mean the type set has "
+    "no front-facing sprite - the fix is a sconce, not a looser rule.\n"
+    "• LOOK AT THE RESULT IN THE ENGINE: godot_check_project then "
+    "godot_screenshot. Every level defect found so far - protrusions, "
+    "black corridor cracks, gaps in the wall shadow, props floating in "
+    "stone - was invisible in the numbers and obvious in one frame."
+)
+
+DISPATCH_RULES = {
+    # gameplay and tech both hold the `level` craft, so both can run
+    # level_generate - and both can spend an afternoon on a level whose
+    # art does not exist yet. The rule is identical for each seat, so it
+    # is written once and shared.
+    "gameplay": _LEVEL_RULE,
+    "tech": _LEVEL_RULE,
+    "narrative": (
+        "NARRATIVE HOUSE RULE - NO FIRST-THOUGHT JOKES:\n"
+        "• Before landing ANY name/line/bark, generate 5 candidates and kill "
+        "every one that is the FIRST joke anyone would make on the premise "
+        "(the obvious pun, the meme format, the joke every parody of this "
+        "subject already made). Ship the one that surprises.\n"
+        "• Obey the project's OWN tone tests (read the tone guide / bible "
+        "before writing; if you wrote one this session, your content must "
+        "pass it - self-contradiction is an automatic fail). No winks, no "
+        "lampshading, no decade-old meme formats.\n"
+        "• Specificity beats snark: a line should only make sense in THIS "
+        "world. If it could be pasted into any generic parody of the genre, "
+        "cut it.\n"
+        "• Read every deliverable back OUT LOUD (to yourself) against the "
+        "tone tests before landing. Land fewer, better lines."
+    ),
+    "audio": (
+        "AUDIO HOUSE RULE - EVERY SYNTHESIZED ASSET SHIPS ITS RECIPE, AND THE "
+        "PIPELINE ALREADY DOES IT:\n"
+        "• SFX go through sfx_generate - it writes the .wav AND the "
+        "`<name>.synth.json` recipe sidecar in one call, and sfx_rerender "
+        "rebuilds the identical wav from the recipe alone. Do NOT hand-write "
+        "sidecars or keep loose synthesis scripts; a hand-rolled wav without "
+        "its recipe is a dead end, and sfx_list names any effect that has "
+        "lost one. sfx_kinds says what the synthesizer can make.\n"
+        "• MONEY ALREADY SPENT IS RECOVERABLE. A music generation that "
+        "crashed or was killed mid-download is not gone: music_stuck_tracks "
+        "lists paid tasks with no delivered file, and music_recover downloads "
+        "and registers them without paying again. Check it before "
+        "re-generating anything."
+    ),
+    "art": (
+        "ART HOUSE RULE - THE CONTRACT DECIDES THE SHEET, THE PIPELINE MAKES "
+        "IT, THE BATTERY REFEREES IT:\n"
+        "• WHICH GENERATOR DOES WHICH JOB - THEY ARE NOT "
+        "INTERCHANGEABLE. SPRITES AND STILLS ARE MINTED WITH KIE "
+        "(nano-banana-2); MOTION IS RETRO DIFFUSION, off a start frame "
+        "the sprite step produced. RD REDRAWS whatever it is handed, "
+        "which is exactly right for animating a frame you already own "
+        "and exactly wrong as a way to ORIGINATE a design: asked for a "
+        "prop cold it returns a different object every call and will not "
+        "hold a set's look. Never mint with RD, never animate with kie. "
+        "animation_generate already routes this correctly.\n"
+        "• FIRST, ALWAYS: sprite_contract_get(character, action) - the "
+        "declared view, direction set, cell size and frame counts. No "
+        "contract set = raise it with the director (sprite_contract_set has "
+        "presets), do NOT invent a layout. And palette_pin BEFORE any art if "
+        "none is pinned (>=32 colours, derived across SEVERAL sheets/refs - "
+        "a 24-colour single-sheet derivation silently recoloured a blouse).\n"
+        "• CHARACTER ANIMATION CYCLES = animation_generate. It reads the "
+        "contract, takes start frames from the character's OWN sheets, runs "
+        "the purpose-trained animation model per drawn direction (~$0.14), "
+        "conforms to the pinned palette, grades everything, and emits the "
+        "contract-shaped sheet + .tres + .aseprite master. Do NOT hand-build "
+        "cycles out of image_edit calls - that is the path that shipped ten "
+        "of twenty facings backwards.\n"
+        "• A MISSING or OFF-STYLE direction start frame is minted with a "
+        "TWO-REF edit (nano-banana-2): style authority = a good frame of the "
+        "character, angle authority = any frame at the wanted camera angle, "
+        "prompt names both jobs. One ref alone gives pure-N instead of "
+        "back-3/4. Filmstrip single-gen (whole cycle as ONE image, "
+        "from_painted_sheet to slice) remains the way to mint a NEW "
+        "character's first sheet - identity by construction.\n"
+        "• ACT ON THE FINDINGS. facing_flip / wrong_direction / height_split "
+        "/ yaw_drift / set_drift on a strip = re-roll THAT strip, do not "
+        "land it. The one eyeball override: pose-legitimate height (a raised "
+        "arm, a collapse taper) - look at the GIF preview and say so in the "
+        "seat note. LOOK at every animation preview before landing; motion "
+        "defects are obvious in two seconds of playback and invisible in a "
+        "grid.\n"
+        "• HAND FIXES go through the master: open the .aseprite, fix the "
+        "frame, aseprite_export - never pixel-edit the shipped PNG (the "
+        "export re-grades; a raw edit dodges every check).\n"
+        "• Before landing: consistency_check per frame AND clear alpha flags "
+        "(no white halo, no feathered fringe, no background bleed, no hollow "
+        "interior). Any alpha flag = do not land.\n"
+        "\n"
+        "• THE ORDER IS: game_view_get -> palette_pin -> "
+        "tileset_generate -> prop_generate -> hand the manifest to "
+        "whoever holds the level generator (level_generate top-down, "
+        "sidescroll_generate side-scroller).\n"
+        "• PROPS ARE prop_generate, ONE CALL. It reads the view for "
+        "the camera, art_spec for the canvas and ground anchor, draws "
+        "with kie, keys the background, fits the contract box, hardens "
+        "the alpha, conforms to the pinned palette, packs the atlas and "
+        "writes the manifest. Do NOT hand-roll that chain with "
+        "image_generate: the first prop set was made that way and it "
+        "silently skipped the conform and the defringe - 32px sprites "
+        "with 600 colours, two thirds off-palette, feathered edges. The "
+        "steps were not refused, they were forgotten.\n"
+        "LEVEL ART IS A CONTRACT AND A HANDOFF - YOU MAKE IT, GAMEPLAY "
+        "AND TECH SPEND IT:\n"
+        "• TILESETS: tileset_generate, and leave bits=8. A 16-mask "
+        "set cannot say 'floor north and east, void at the north-east "
+        "corner', so the shadow band along every wall BREAKS at each "
+        "step in a room's outline. The corner tiles are pure geometry, "
+        "so eight bits costs no extra call and no extra money. It draws "
+        "TWO MATERIALS with kie (prompt=floor, void_prompt=behind) and "
+        "carves every mask tile between them - same provider rule as "
+        "sprites: kie generates, RD only ever animates.\n"
+        "• PROPS: props.art_spec(type) IS the spec - exact canvas "
+        "in pixels, the ground anchor, how many DRAWINGS (a wall mount "
+        "needs one per facing; the engine mirrors a sprite but NOT its "
+        "texture_origin, measured), and whether the type LOOPS (a torch "
+        "flickers, a portal turns) or has STATES (a chest is shut, "
+        "opening, open). Loop and state are two different engine "
+        "mechanisms and a type declares one, never both. A prop drawn at "
+        "the wrong proportion is not a style difference, it is a sprite "
+        "hanging off its cell, and no placement rule fixes it.\n"
+        "• A WALL MOUNT IS THE OBJECT ONLY - no wall behind it, no "
+        "floor under it, no scene. A torch prompted 'flat against a "
+        "wall' comes back with a slab of masonry attached and pastes a "
+        "stone rectangle over the level. Same for a floor prop: no "
+        "ground, no cast shadow.\n"
+        "• DO NOT NAIVELY DOWNSCALE a 1024px generation into a "
+        "32px cell. It survives for a simple silhouette (a barrel) and "
+        "turns a detailed subject (a chest) into mush. Conform through "
+        "the palette and the Aseprite master, and re-roll whatever does "
+        "not read at 1x on a dark background - where you must LOOK.\n"
+        "\n"
+        "HUD / UI CHROME SHIPS AS SEPARATE LAYERED PARTS, NEVER ONE BAKED "
+        "COMPOSITE:\n"
+        "• A UI element with dynamic or independently-driven sub-parts - a meter = "
+        "frame + segmented FILL + icon + counter badge; a health bar = frame + "
+        "FILL; a card = frame + portrait + label plate - MUST ship as SEPARATE "
+        "transparent PNGs, one per layer, NOT fused into a single image. The "
+        "scene/designer stacks and drives each independently: the fill depletes in "
+        "code BEHIND a hollow frame, segments light one by one, the icon/badge are "
+        "their own nodes. Gening the whole element in one go leaves nothing the "
+        "designer can wire - it is not shippable.\n"
+        "• Frames are HOLLOW: a fully transparent window where the code-driven fill "
+        "shows through. NEVER bake a colored fill into a frame. For every frame, "
+        "post the exact fill-window rect (x,y,w,h) in your seat note.\n"
+        "• Keep the parts on a consistent pixel grid / shared registration so they "
+        "stack cleanly at the target rect. A single composed PREVIEW mock is fine "
+        "FOR REVIEW, but the SHIPPED assets are the separate layers.\n"
+        "• Match the pinned concept: crop the target element out of the concept "
+        "ref, condition generation on that crop, and build your own "
+        "concept-vs-output comparison - iterate until it matches, don't ship "
+        "isolated bare bars.\n"
+        "\n"
+        "WORLD / ENVIRONMENT ASSETS ARE INDIVIDUAL GENS, NEVER A SLICED SCENE:\n"
+        "• Concept mocks are COMPOSITES - inspiration, not assets. A shippable "
+        "world asset is generated ON ITS OWN: one prop (desk, plant, vending "
+        "machine, printer shrine), one tile, one unit sprite per gen, "
+        "transparent background, consistent scale against the project's grid "
+        "(e.g. a 32px-tile world: props sized in tile multiples, characters to "
+        "their tile footprint). NEVER generate a full scene and cut pieces out "
+        "of it - sliced fragments have baked lighting/overlap and never "
+        "composite cleanly.\n"
+        "• Tilesets: gen each tile type separately (or a strict uniform grid "
+        "sheet where every cell is one clean tile), then assemble the atlas "
+        "with code - cells must be seamlessly tileable with their neighbors.\n"
+        "• Scale/registration discipline: every asset in a batch states its "
+        "intended pixel size; verify against the grid before landing so the "
+        "engine drops it in without per-asset fudging.\n"
+        "• UNITS SHIP THE FULL FACING MATRIX THE SPRITE CONTRACT DECLARES: "
+        "drawn directions generated, mirrored directions flipped in-engine "
+        "(flip_h), never generated - the contract's drawn/mirror map is the "
+        "authority, per character and per action (sprite_contract_get). A "
+        "partial facing x anim matrix is an automatic fail.\n"
+        "• ISO PROPS DECLARE A ROTATION CLASS (see the project bible's "
+        "prop-rotation contract): SYMMETRIC = 1 gen reused; MIRRORABLE = 2 "
+        "gens + flip_h (NO text/logos/handedness); FULL = 4 gens (anything "
+        "with readable text/signage - mirrored text is an automatic fail). "
+        "All views of one prop conditioned on the SAME prop ref so it reads "
+        "as one object rotated; state the tile footprint per prop.\n"
+        "\n"
+        "DELIVERY FIDELITY - WHAT WAS APPROVED IS WHAT SHIPS:\n"
+        "• The engine-ready file you deliver must be a MECHANICAL derivation "
+        "of the approved artifact revision: trim, downscale, alpha-clean - "
+        "NOTHING ELSE. Never redraw, re-generate, or 'improve' an asset at "
+        "the delivery step; a delivered file whose content differs from its "
+        "approved source is an automatic reject (observed failure: floors "
+        "shipped with an invented X-bevel that existed in no approved rev).\n"
+        "• Name the source in your seat note per delivered file "
+        "(delivered X <- approved revision N) so the trail is auditable."
+    ),
+}
+
+
+DISPATCH_RULES_FILENAME = "seat_rules.json"
+
+
+def dispatch_rules(root: str | os.PathLike[str], seat: str) -> str:
+    """The house rules injected into THIS project's dispatch prompt for a seat.
+
+    ``<root>/.bgate/seat_rules.json`` ({"art": "...", "narrative": ""}) is the
+    project's override and wins outright - including an empty string, which is
+    how a project turns a built-in off. Rules are prompt text, not schema, so
+    they live in a file the project edits and diffs rather than in the seat
+    table. Absent an override, the shipped built-in applies.
+    """
+    from pathlib import Path
+
+    try:
+        data = json.loads((Path(root) / ".bgate" / DISPATCH_RULES_FILENAME)
+                          .read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        data = {}
+    if isinstance(data, dict) and seat in data:
+        return str(data[seat] or "").strip()
+    return DISPATCH_RULES.get(seat, "")
+
+
+# ---------------------------------------------------------------------------
 # The eight seats. Lanes assume the scaffold layout (<root>/game, <root>/design).
 # ---------------------------------------------------------------------------
 DEFAULT_SEATS: dict[str, dict] = {
@@ -241,17 +559,24 @@ DEFAULT_SEATS: dict[str, dict] = {
     "art": {
         "title": "Art",
         "mission": "Own models, textures, and look. Lock every binary before "
-                   "editing; export through blender_export_gltf and verify with "
-                   "godot_import_asset, because the engine's view is the truth. "
+                   "editing; export through blender_export_gltf and deliver with "
+                   "godot_deliver_asset, because the engine's view is the truth "
+                   "and deliver is import PLUS the lit stand-up photo that "
+                   "proves it landed. "
                    "CONSISTENCY IS ENFORCED, NEVER REQUESTED: pin the reference, "
                    "condition every frame on it, measure the result. A model asked "
                    "to stay on-model will not. LOOK at the frame before you call "
                    "it done.",
         "write_globs": ["game/assets/**", "blender/**", "art/**"],
         "workflow": (
-            "ANIMATIONS SHIP AS STITCHED SHEETS, NOT LOOSE FRAMES. For any "
-            "animation use image_sprites with poses named '<anim>/<idx>' "
-            "(stagger/0..stagger/5) and ref_image=the approved character. It "
+            "ANIMATIONS SHIP AS STITCHED SHEETS, NOT LOOSE FRAMES — AND WHICH "
+            "TOOL MAKES THE SHEET DEPENDS ON WHAT EXISTS. A character that "
+            "already has sheets gets its cycles from animation_generate: it "
+            "reads the sprite contract, starts from the character's OWN "
+            "frames, and emits the contract-shaped sheet + .tres + .aseprite "
+            "master. image_sprites is for MINTING: a NEW character's "
+            "first painted sheet, poses named '<anim>/<idx>' "
+            "(stagger/0..stagger/5), ref_image=the approved character - it "
             "stitches <name>_sheet.png + <name>_frames.tres (drop-in for "
             "AnimatedSprite2D). image_edit is a single-frame fix only; never "
             "hand-roll a multi-frame animation as separate PNGs. Clear every "
@@ -484,21 +809,24 @@ DEFAULT_SEATS: dict[str, dict] = {
             "note to inform; queue an item to get an answer. And prefer neither: "
             "state the assumption you made, build on it, and name the one line "
             "that would have to change if it was wrong.\n"
-            "0. BOARD IT BEFORE YOU PLAN IT. A shot list is cheap to write and "
-            "expensive to be wrong about, because the thing that proves it "
-            "wrong is a clip you have already paid for. storyboard_write_script "
-            "turns a premise into a script and a beat per frame for a fraction "
-            "of a cent; storyboard_frame_generate draws one beat as an IMAGE, "
-            "which is two orders of magnitude cheaper than the shot it stands "
-            "in for. Board the scene, look at it, throw half of it out, THEN "
-            "storyboard_promote — which writes the sequence with every approved "
-            "frame wired in as that shot's first_frame, so rules 2 and 3 below "
-            "are satisfied by construction rather than by discipline. Pass the "
-            "pinned cast as cast_refs: a board with no cast drifts exactly like "
-            "an unanchored sequence, only for less money. A frame a human drew "
-            "or dropped in counts as evidence the same way a generated one "
-            "does not — the board records which, and you should read it before "
-            "approving anything.\n"
+            "0. BOARD IT BEFORE YOU PLAN IT — WITH storyboard_auto, WHICH IS "
+            "RULE 0a's ONE CALL. A shot list is cheap to write and expensive "
+            "to be wrong about, because the thing that proves it wrong is a "
+            "clip you have already paid for; a board is two orders of "
+            "magnitude cheaper than the shots it stands in for. The PARTS "
+            "(storyboard_write_script, storyboard_frame_generate, "
+            "storyboard_promote) are for CHANGING ONE THING on a board that "
+            "exists — redraw one beat, rewrite one line — never for building "
+            "the board by hand; hand-running the chain is storyboard_auto "
+            "with five extra places to stop. Look at the board, throw half "
+            "of it out, then promote — the sequence gets every approved "
+            "frame wired in as that shot's first_frame, so rules 2 and 3 "
+            "below are satisfied by construction rather than by discipline. "
+            "Pass the pinned cast as cast_refs: a board with no cast drifts "
+            "exactly like an unanchored sequence, only for less money. A "
+            "frame a human drew or dropped in counts as evidence the same "
+            "way a generated one does not — the board records which, and you "
+            "should read it before approving anything.\n"
             "1. PLAN FIRST, IN ONE CALL. cinematic_plan(name, shots) writes the "
             "whole shot list and spends nothing. It survives your death — a "
             "successor reads the list and knows both what was bought and what "
@@ -649,12 +977,18 @@ DEFAULT_SEATS: dict[str, dict] = {
             "exists to end. Then let the baseline do the remembering: every run "
             "is diffed against the last one that actually drove the game, so "
             "'when did this start failing' has a date.\n"
-            "5. COMPARE AGAINST THE REFERENCE, ALWAYS. For anything visual, "
-            "render the ACTUAL in-game result (godot_screenshot at 640x360 — NOT "
-            "a mock, NOT the seat's own preview) and put it SIDE-BY-SIDE with "
-            "this project's pinned refs (ref_list gives you the names; the bible "
-            "gives you the constraints). If it doesn't match the ref, it FAILS. "
-            "Cite the specific mismatch.\n"
+            "5. COMPARE AGAINST THE REFERENCE, ALWAYS — WITH YOUR EYES ON A "
+            "RENDER. For anything visual, render the ACTUAL in-game result "
+            "(godot_screenshot at 640x360 — NOT a mock, NOT the seat's own "
+            "preview; for a produced image, OPEN it — the Read tool shows you "
+            "the picture) and put it SIDE-BY-SIDE with this project's pinned "
+            "refs (ref_list gives you the names; the bible gives you the "
+            "constraints). Geometry stats, node counts, connectivity checks "
+            "and file metadata are one check, never THE check: a level whose "
+            "walkability numbers are all green can still render with holes "
+            "where the doors should be, and a verdict written off numbers "
+            "about a picture you never opened is a false PASS. If it doesn't "
+            "match the ref, it FAILS. Cite the specific mismatch.\n"
             "6. THINGS THAT ARE AN AUTOMATIC FAIL (learned the hard way): wrong "
             "asset TYPE (a character sprite used where an ICON belongs); the same "
             "mechanic drawn as two different designs; bare fills / black boxes / "
@@ -784,12 +1118,30 @@ SEAT_IDENTITY = (
 # `--scope user`, so switching projects cannot drop it. Per-project CLAUDE.md
 # stamping never could make that promise.
 DIRECTOR_PROTOCOL = (
-    "DELEGATE BY DEFAULT. Substantial work goes on the board with "
-    "queue_add(seat, title, brief) and is executed by a spawned agent that holds "
-    "that seat's lanes, rules and lock discipline (seat_list for this project's "
-    "table). Doing seat work yourself is the anti-pattern — it is unlaned, "
-    "unlogged, unbudgeted, and it skips the QA gate, so nobody but you ever "
-    "checks it.\n"
+    "THE HUMAN'S INSTRUCTION OUTRANKS EVERYTHING BELOW. When the human tells "
+    "you to do something, do it — directly, now, without re-routing it to the "
+    "board unless they asked for that, and without arguing the pipeline's "
+    "case. Every rule in this protocol is a default for when you are choosing; "
+    "none of it is a reason to refuse, renegotiate, or slow-walk what you were "
+    "told. If an instruction genuinely conflicts with a hard constraint (spend "
+    "you cannot authorise, another live agent in the file), say so in one "
+    "sentence and offer the closest thing you CAN do — then do it.\n"
+    "\n"
+    "DO THE WORK OR DELEGATE IT — BOTH ARE LEGITIMATE. Delegation buys "
+    "parallelism, the QA gate, and a budget line; doing it yourself buys "
+    "immediacy and your own judgment. Reach for the board when the work is "
+    "parallel, long-running, or should be QA-gated: queue_add(seat, title, "
+    "brief) files it for a spawned agent holding that seat's toolset "
+    "(seat_list for the table). Do it yourself when the human asked you to, "
+    "when it is faster than writing the brief, or when a dispatched agent "
+    "already failed at it and you can see why.\n"
+    "\n"
+    "WHAT YOU DISPATCH, YOU WATCH. A dispatched item is your responsibility "
+    "until it lands: check board_digest / queue_list, read a running agent "
+    "with agent_activity(item_id), steer it with agent_steer, and when it "
+    "fails, read WHY from its result and either fix the brief and "
+    "queue_reopen it or do the work yourself — do not file it away as "
+    "somebody else's stall.\n"
     "\n"
     "queue_add FILES A ROW; THE DASHBOARD IS WHAT RUNS IT. Nothing dispatches "
     "unless `bgate serve` is up. Check before you delegate and say so if it is "
@@ -822,12 +1174,12 @@ DIRECTOR_PROTOCOL = (
     "which items are waiting is more useful than re-dispatching anything. Never "
     "flip the mode to unblock yourself.\n"
     "\n"
-    "WHAT YOU DO YOURSELF: decide and arbitrate; write the brief (a vague brief "
-    "is the main way a dispatch is wasted); read state (project_status, "
+    "ALWAYS YOURS REGARDLESS: decide and arbitrate; write the brief (a vague "
+    "brief is the main way a dispatch is wasted); read state (project_status, "
     "queue_list, iteration_status, bible_read, lore_*, seat_notes); steer a "
-    "running item with agent_steer; judge the result. Small reads, one-line "
-    "fixes and answering the human are fine to do directly. A multi-file change, "
-    "an asset, a system, a test suite — that is a seat's job.\n"
+    "running item with agent_steer; judge the result. When you DO seat work "
+    "directly, note it (handoff_note) so the board's record stays honest — "
+    "the point of the note is visibility, not permission.\n"
     "\n"
     "EVIDENCE, NOT ASSERTION. A claim about a game is cashed with the harness: "
     "godot_check_project for a build, godot_run for headless truth, "
@@ -1684,8 +2036,29 @@ def brief(root: str | os.PathLike[str], role: str, note_limit: int = 10) -> dict
         "traps": traps_for(role, dimension),
         "rules": [
             TOOLING_RULE,
-            "Write only inside your lanes; can_write is the oracle, not a suggestion.",
+            "Stay inside the project you were dispatched for - that boundary "
+            "is enforced. Your lanes inside it are the map of what is yours; "
+            "prefer them, route big cross-seat work with queue_add, and when "
+            "your item plainly needs a small write outside them, make it "
+            "rather than dying - the write is logged either way.",
             "Lock binaries before editing (asset_lock), release when done.",
+            # THE ROUTING RULE, shared because every paying seat has shipped
+            # the failure: one 402 read as "the pipeline is closed", followed
+            # by a hand-rolled substitute, while a funded provider sat idle.
+            "AN EMPTY ACCOUNT IS A ROUTING EVENT, NOT AN OUTAGE. When a "
+            "generation fails on credit or a key, the failure carries a "
+            "`route` field and provider_status shows every provider's key "
+            "and balance - re-run the same pipeline tool at a live provider "
+            "where the craft allows it. NEVER hand-roll a substitute asset "
+            "because one account was empty; if nothing is funded, that is a "
+            "blocker to file, not a downgrade to improvise around.",
+            # THE EYES RULE, in the shared list because every seat has shipped
+            # the failure: green geometry stats over a render with holes in it.
+            "IF IT IS VISIBLE, LOOK AT IT. Before claiming any visual "
+            "deliverable done: render it (godot_screenshot for a scene; for a "
+            "produced image, open the file - the Read tool shows you the "
+            "picture) and judge the PICTURE. Stats, tree dumps, byte checks "
+            "and passing tests are one check, never the full check.",
             "Narrative writes go through canon_check before they land.",
             # "Check scope_check(rank) before building anything new." was the
             # next line for a long time. The tool it named answered off a cut

--- a/bgate_core/settings.py
+++ b/bgate_core/settings.py
@@ -295,13 +295,17 @@ class Setting:
 SETTINGS: tuple[Setting, ...] = (
     # -- Dispatch -----------------------------------------------------------
     Setting(
-        key="autopilot.on", group="Dispatch", kind=BOOL, default=False,
+        key="autopilot.on", group="Dispatch", kind=BOOL, default=True,
         store=("workspace", "director", "autopilot", "on"),
         env_coerce=("BGATE_AUTODEPLOY", lambda raw: False if _falsey(raw) else None),
         env_note="BGATE_AUTODEPLOY=0 stops the loop from starting at all, so the "
                  "stored switch cannot take effect until the server restarts",
         help="Dispatch queued work automatically as slots free up, instead of "
-             "waiting for somebody to press deploy on each item."),
+             "waiting for somebody to press deploy on each item. ON by "
+             "default since 2026-08-19: shipped off, a filed chain looked "
+             "exactly like a running one and sat still until somebody found "
+             "the toggle - 'my chains never auto-deploy' was this default. "
+             "Turn it off for a board you want to hand-dispatch."),
     Setting(
         key="dispatch.allow_dirty", group="Dispatch", kind=BOOL, default=False,
         store=("registry", "dispatch.allow_dirty"), scope=MACHINE,
@@ -629,11 +633,13 @@ SETTINGS: tuple[Setting, ...] = (
              "breaks the promise the rest of the tool makes. https only, no "
              "private or link-local addresses, one attempt."),
     Setting(
-        key="notify.stall_hours", group="Notifications", kind=FLOAT, default=2.0,
+        key="notify.stall_hours", group="Notifications", kind=FLOAT, default=0.5,
         minimum=0.25, maximum=168.0, store=("registry", "notify.stall_hours"),
         help="How long a chain's head may sit in review or blocked before it "
              "is called stalled. The bus is transition-driven, so without this "
-             "the quiet failure — nothing happening — emits nothing."),
+             "the quiet failure — nothing happening — emits nothing. Half an "
+             "hour by default: at the old two hours, a chain parked behind a "
+             "dead predecessor was invisible for a whole working session."),
     Setting(
         key="notify.question_stale_h", group="Notifications", kind=FLOAT,
         default=12.0, minimum=0.25, maximum=168.0,

--- a/bgate_core/wfnodes.py
+++ b/bgate_core/wfnodes.py
@@ -422,14 +422,14 @@ _NODES: list[ToolNode] = [
 
     # ---- Music ------------------------------------------------------------
     ToolNode(
-        type="tool.music.options", tool="kie_music_options",
+        type="tool.music.options", tool="music_options",
         label="Music options", category="audio", glyph="♪",
         accent="var(--c-audio)", produces="data", exclusive=False,
         summary="Which music models and styles this build can reach. Free, "
                 "and the node that tells you whether the key is live.",
         args={}),
     ToolNode(
-        type="tool.music.generate", tool="kie_music_generate",
+        type="tool.music.generate", tool="music_generate",
         label="Generate music", category="audio", glyph="♪",
         accent="var(--c-audio)", produces="audio", paid=True, exclusive=False,
         summary="A track from a prompt. PAID - it calls a provider and the "

--- a/bgate_mcp/server.py
+++ b/bgate_mcp/server.py
@@ -276,9 +276,9 @@ _READ_ONLY_TOOLS = frozenset({
     "dialogue_list", "sfx_list", "brainstorm_list", "brainstorm_feed",
     "playtest_list", "playtest_brief", "art_tournament_standings",
     # long-running production pipelines, read side
-    "kie_music_options", "music_candidates", "cinematic_options",
+    "music_options", "music_candidates", "cinematic_options",
     "cinematic_styles", "cinematic_sequences", "cinematic_candidates",
-    "cinematic_shot_status", "cinematic_estimate", "kie_music_status",
+    "cinematic_shot_status", "cinematic_estimate", "music_status",
     "storyboard_boards", "storyboard_open",
 })
 
@@ -767,7 +767,20 @@ def _module_registers(tool_name: str) -> bool:
 def _fail(exc: Exception) -> dict:
     # ok=false alongside the message: one predicate for every failure in this
     # module, whatever the tool. See _normalize.
-    return {"ok": False, "error": f"{type(exc).__name__}: {exc}"}
+    out = {"ok": False, "error": f"{type(exc).__name__}: {exc}"}
+    # A BILLING-SHAPED FAILURE CARRIES ITS OWN REDIRECT. The observed agent
+    # response to "no credit" is to conclude the pipeline is closed and
+    # hand-roll the asset - while a second provider sits keyed and funded.
+    # Appending the gateway's board here, in the same tool result as the
+    # refusal, reaches the agent at the exact moment it is deciding that.
+    # Best-effort by the _fail rule: explaining a failure must never raise.
+    try:
+        from bgate_core import gateway as _gateway
+        if _gateway.is_billing_error(out["error"]):
+            out["route"] = _gateway.billing_note(_root_hint())
+    except Exception:
+        pass
+    return out
 
 
 _RUN_SEQ = itertools.count()
@@ -2707,6 +2720,53 @@ def blender_sprites(base_script: str, poses: list[dict], name: str = "sprite",
                             (f" ({len(result['failed'])} failed)" if result["failed"] else ""),
                  ref=result["sheet"])
         return result
+    except Exception as exc:
+        return _fail(exc)
+
+
+# ---------------------------------------------------------------------------
+# The provider gateway
+# ---------------------------------------------------------------------------
+@_tool
+def provider_status(capability: str = "", fresh: bool = False) -> dict:
+    """Which paid providers are LIVE - keyed, and funded where they will say.
+
+    READ THIS BEFORE CONCLUDING A PIPELINE IS CLOSED. One account answering
+    "no credit" is a routing event, not an outage: the same job usually has a
+    second keyed provider, and the observed failure is an agent that tried
+    one key, read $0, and hand-rolled the asset while another account sat
+    funded. Every billing-shaped tool failure also carries this board in its
+    `route` field, so you should rarely need to guess.
+
+    Per provider: `keyed` (offline truth), `balance` (a NUMBER only where the
+    provider exposes one - kie and Retro Diffusion do; openai never says, and
+    krea's API balance shows only as a 402 at call time - so None means
+    UNKNOWN and the provider is still routable), and the adapter's own
+    `reason` when unkeyed.
+
+    Pass `capability` ("image" | "animate" | "three_d" | "music" | "video")
+    to also get `pick`: the provider that job should route to right now,
+    honouring the craft division (sprites/stills mint with kie; motion is
+    Retro Diffusion; music/video are kie). `fresh=true` re-probes past the
+    2-minute cache - the right call after the human tops an account up.
+
+    Keys never appear here, and there is no tool that writes one - a human
+    sets keys (bgate key / the Generators panel), deliberately.
+    """
+    try:
+        from bgate_core import gateway as _gateway
+        try:
+            root = _root()
+        except LookupError:
+            root = None
+            _keys()
+        out = {"ok": True,
+               "providers": _gateway.status(root, fresh=bool(fresh)),
+               "capabilities": {k: list(v)
+                                for k, v in _gateway.CAPABILITIES.items()}}
+        if capability:
+            out["pick"] = _gateway.pick(root, str(capability))
+        return out
     except Exception as exc:
         return _fail(exc)
 
@@ -9938,7 +9998,7 @@ def voice_speak(text: str, out_path: str = "",
 # SFX - synthesized, not generated
 # ---------------------------------------------------------------------------
 # THE AUDIO SEAT COULD NOT MAKE A GAME SOUND. Its mission opens "Own SFX and
-# music hooks" and every tool it had was a paid, keyed provider - kie_music_*
+# music hooks" and every tool it had was a paid, keyed provider - music_*
 # for beds, voice_* for speech - so a project without a key produced no audio at
 # all, and even with one there was no path to a coin pickup or a laser. These
 # three tools need no key, no network and no budget: an SFX is four oscillator
@@ -10157,7 +10217,8 @@ def queue_list(status: Optional[str] = None, seat: Optional[str] = None,
     """
     try:
         from bgate_core import queue as _q
-        rows = _q.list_items(_root(), status=status, seat=seat)
+        root = _root()
+        rows = _q.list_items(root, status=status, seat=seat)
         cap = max(1, min(int(limit or 40), 200))
         shown = rows[:cap]
         items = []
@@ -10169,6 +10230,31 @@ def queue_list(status: Optional[str] = None, seat: Optional[str] = None,
                 item["brief"] = brief[:240]
                 item["brief_len"] = len(brief)
                 item["result"] = result[:240]
+            # WHY IS THIS NOT RUNNING - answered on the row, because a queued
+            # item that nothing will ever dispatch used to look exactly like
+            # one that is next in line, and the difference lived in three
+            # different modules. Best-effort: an unreadable blocker is not a
+            # reason to fail the whole listing.
+            if item.get("status") == "queued":
+                if str(item.get("source") or "") in _q.HELD_SOURCES:
+                    item["waiting_on"] = (
+                        f"held: source {item.get('source')!r} is never "
+                        "auto-dispatched - a human (or the director session) "
+                        "must take it")
+                else:
+                    try:
+                        blk = _q.blocker(root, int(item["id"]))
+                    except Exception:
+                        blk = None
+                    if blk is not None:
+                        item["waiting_on"] = (
+                            f"blocked: depends on #{blk['id']} which is "
+                            f"{blk['status']!r}"
+                            + ("" if blk["status"] in ("queued", "dispatched",
+                                                       "review")
+                               else " - that predecessor will never reach "
+                                    "'done' on its own; queue_reopen it or "
+                                    "queue_cut_dependency to release this"))
             items.append(item)
         return {
             "items": items,
@@ -10626,6 +10712,43 @@ def agent_steer(item_id: int, text: str) -> dict:
 
 
 @_tool
+def agent_activity(item_id: int, limit: int = 30) -> dict:
+    """Watch a dispatched agent work - its recent steps, result and liveness.
+
+    The read half of agent_steer: queue_add hands work out, agent_steer
+    corrects it mid-run, and this is how you SEE what the run is doing before
+    deciding either. Everything comes off disk (the item's stream-json log
+    plus the machine-wide agent registry), so it works from any session -
+    CLI, desktop, a second dashboard - whether or not `bgate serve` is up.
+
+    Returns the last ``limit`` steps ("say" / "tool" / "result" / "steer"),
+    the run's final result event if it has one, `running` (True/False, or
+    null when the host will not vouch for the pid), and the log path for
+    anyone who wants the whole transcript. `step_count`/`truncated` say
+    whether the window is the full story.
+
+    Read this BEFORE clearing or re-dispatching a failed item: the last few
+    steps almost always name the actual wall the agent hit, and a
+    queue_reopen whose reason quotes it beats one that guesses.
+    """
+    try:
+        from bgate_core import agentlog as _agentlog
+        root = _root()
+        out = _agentlog.tail(root, int(item_id), limit=int(limit))
+        try:
+            from bgate_core import queue as _q
+            item = _q.get(root, int(item_id))
+            out["status"] = item["status"]
+            out["seat"] = out.get("seat") or item.get("seat") or ""
+            out["title"] = item.get("title") or ""
+        except LookupError:
+            out["status"] = None
+        return {"ok": True, **out}
+    except Exception as exc:
+        return _fail(exc)
+
+
+@_tool
 def ask_human(question: str, refs: Optional[list] = None) -> dict:
     """Ask the human who owns this project ONE question - and keep working.
 
@@ -10940,7 +11063,7 @@ def kie_status() -> dict:
 
 
 @_tool
-def kie_music_options() -> dict:
+def music_options() -> dict:
     """What a music generation may ask for: models, per-mode character limits,
     which model takes a duration, and whether kie is reachable at all.
 
@@ -10957,7 +11080,7 @@ def kie_music_options() -> dict:
 
 
 @_tool
-def kie_music_generate(prompt: str, name: str = "", instrumental: bool = True,
+def music_generate(prompt: str, name: str = "", instrumental: bool = True,
                        model: str = "", custom: bool = False, style: str = "",
                        title: str = "", negative_tags: str = "",
                        vocal_gender: str = "", duration: Optional[int] = None,
@@ -10979,7 +11102,7 @@ def kie_music_generate(prompt: str, name: str = "", instrumental: bool = True,
     custom=False (simple mode) takes a 500-character DESCRIPTION and Suno writes
     everything. custom=True takes lyrics up to 3,000-5,000 characters depending
     on the model, plus `style` and `title` - which are refused in simple mode
-    rather than silently dropped. See kie_music_options for the exact ceilings.
+    rather than silently dropped. See music_options for the exact ceilings.
 
     duration is V5_5 ONLY (10-360s). Every other model would be charged for its
     default length while ignoring the request, so it is refused here.
@@ -11014,15 +11137,15 @@ def kie_music_generate(prompt: str, name: str = "", instrumental: bool = True,
 
 
 @_tool
-def kie_music_status(task_id: str) -> dict:
+def music_status(task_id: str) -> dict:
     """Where a Suno task got to, straight from kie. Costs nothing.
 
     Reports the eight documented statuses. CALLBACK_EXCEPTION is the subtle one:
     it means kie could not deliver its webhook, NOT that the music failed, so it
     is only a failure when the record also carries no audio.
 
-    This only LOOKS. When it says `recoverable`, kie_music_recover is what puts
-    the audio on disk - do not re-run kie_music_generate to get files for a task
+    This only LOOKS. When it says `recoverable`, music_recover is what puts
+    the audio on disk - do not re-run music_generate to get files for a task
     that already has them, that is paying twice.
     """
     try:
@@ -11045,7 +11168,7 @@ def music_stuck_tracks(older_than_s: int = 0, poll: bool = True) -> dict:
 
     Run it after any crash, kill or dashboard restart. `recoverable` is the list
     worth acting on: those are finished generations sitting on the provider that
-    kie_music_recover can still collect - but only inside the provider's
+    music_recover can still collect - but only inside the provider's
     retention window, which the result names. `poll=False` answers from local
     tickets alone and reaches no provider, which is the right call when you only
     want to know whether anything is outstanding.
@@ -11060,10 +11183,10 @@ def music_stuck_tracks(older_than_s: int = 0, poll: bool = True) -> dict:
 
 
 @_tool
-def kie_music_recover(task_id: str, name: str = "") -> dict:
+def music_recover(task_id: str, name: str = "") -> dict:
     """Download and register the tracks of a task ALREADY PAID FOR. Costs nothing.
 
-    kie_music_generate submits, waits, downloads and files in one blocking call,
+    music_generate submits, waits, downloads and files in one blocking call,
     so anything that goes wrong after the submit - a timeout, a dropped
     connection, a cancel, a CDN refusing the download - leaves a task id, a
     charge, and no files. kie holds the audio for FOURTEEN DAYS from generation.

--- a/bgate_ui/autodeploy.py
+++ b/bgate_ui/autodeploy.py
@@ -65,7 +65,7 @@ POLL_S = 4.0
 # automatic dispatcher in a second process and must hold the same items back;
 # two copies of this tuple is how one of them grabs an escalation. The names
 # stay importable from here — this module is where the policy is explained.
-from bgate_core.queue import HELD_SOURCES, PLACEHOLDER_BRIEF  # noqa: E402
+from bgate_core.queue import HELD_SOURCES, PLACEHOLDER_BRIEF  # noqa: E402,F401
 
 # A row created in two statements — INSERT with a placeholder, then UPDATE with
 # the real text — is briefly dispatchable with nothing in it. Both the console

--- a/bgate_ui/autodeploy.py
+++ b/bgate_ui/autodeploy.py
@@ -46,7 +46,7 @@ import threading
 import time
 from typing import Optional
 
-from bgate_core import activity, db, settings as _settings, workspace as _ws
+from bgate_core import activity, settings as _settings, workspace as _ws
 from bgate_ui.pump import Pump
 
 SEAT = "director"
@@ -215,21 +215,14 @@ def _candidates(root: str) -> list[dict]:
     working exactly as designed, the link is simply next rather than ready. The
     tick that follows its predecessor's completion picks it up on its own.
     """
-    marks = ", ".join("?" * len(HELD_SOURCES))
-    rows = db.connect(root).execute(
-        f"SELECT i.id, i.seat, i.title, i.source FROM work_item i "
-        f"LEFT JOIN work_item d ON d.id = i.depends_on "
-        f"WHERE i.status = 'queued' "
-        f"AND i.source NOT IN ({marks}) AND i.brief NOT LIKE ? "
-        "AND (i.depends_on IS NULL OR d.id IS NULL OR d.status = 'done') "
-        "ORDER BY i.priority DESC, i.id LIMIT 40",
-        (*HELD_SOURCES, PLACEHOLDER_BRIEF)).fetchall()
-    # The join sees only the single-column parent. An item with EXTRA parents
-    # (work_item_dep) is filtered here for the same reason the chained ones are:
-    # a refusal costs the item a cooldown and fills the "last refusal" slot with
-    # a non-event when the board is simply working as designed.
+    # THE READINESS RULE IS queue.ready(), shared verbatim with a worker's
+    # claim_next - two dispatchers, one definition of "may start". The limit
+    # is 120, raised from 40: chain links default to priority 0 and QA /
+    # escalation rows run 7-9, so on a busy board forty higher-priority rows
+    # pushed every chain successor past the window and the chain simply never
+    # advanced — starvation with no refusal recorded anywhere.
     from bgate_core import queue as _q
-    return [dict(r) for r in rows if _q.blocker(root, int(r["id"])) is None]
+    return _q.ready(root, limit=120)
 
 
 def tick(root: str | os.PathLike[str], *, force: bool = False) -> dict:

--- a/bgate_ui/dispatch.py
+++ b/bgate_ui/dispatch.py
@@ -28,11 +28,13 @@ from pathlib import Path
 from typing import Optional
 
 from bgate_core import aegis as _aegis
+from bgate_core import agentlog as _agentlog
 from bgate_core import agentreg as _agentreg
 from bgate_core import assets as _assets
 from bgate_core import gates as _gates
 from bgate_core import gitwork as _git
 from bgate_core import queue as _queue
+from bgate_core import seats as _seatmod
 from bgate_core import settings as _settings
 from bgate_core import spend as _spend
 from bgate_ui import runners as _runners
@@ -236,272 +238,14 @@ def _native_images(root: str, runner: "_runners.Runner") -> bool:
         return False
 
 
-# Seat-specific house rules injected UNCONDITIONALLY into the dispatch prompt - # the one channel every agent sees even if it skips seat_brief (item 56 did:
-# it hand-rolled 8 loose image_edit frames for an animation task and never
-# stitched a sheet). Keep these short, imperative, and PROJECT-AGNOSTIC: this
-# dict ships with the tool and is read by every project on the machine, so
-# anything naming a specific game's assets, characters or test scenes belongs
-# in that project's own seat_rules.json (see :func:`seat_rules`), not here.
-_LEVEL_RULE = (
-    "LEVEL GENERATION HOUSE RULE - THE ART IS A DEPENDENCY, NOT A DETAIL:\n"
-    "THE ORDER IS: game_view_get -> (art seat: tileset_generate, "
-    "prop_generate) -> then BY VIEW: top_down/isometric take "
-    "level_plan -> level_generate; side_scroller takes "
-    "sidescroll_generate.\n"
-    "\u2022 game_view_get FIRST, always. It says whether this game is "
-    "top_down, side_scroller or isometric, which decides the tile "
-    "geometry, which prop mounts exist, and how playability is even "
-    "checked. A level built against the wrong view is not a level with a "
-    "style problem, it is the wrong geometry - and both generators "
-    "refuse the wrong view rather than drawing it.\n"
-    "\u2022 SIDE-SCROLLERS: sidescroll_generate, and THE JUMP IS AN "
-    "INPUT. Pass player_scene=<the player's .tscn> and the tunables are "
-    "read from the scene itself, converted to cells by the tileset's "
-    "tile size, and the player is instanced at spawn - do NOT copy "
-    "run/jump_speed/gravity by hand, because a level built for one "
-    "jump and played with another is the failure this parameter "
-    "closes. It refuses an unplayable level (reachable, clearance, "
-    "softlock, stranded); a finding is a bug to report, not a "
-    "difficulty dial. It takes the same prop_manifest.\n"
-    "\u2022 You hold level_plan, level_generate and sidescroll_generate. "
-    "You do NOT hold the "
-    "generators: tilesets and prop sheets are the ART seat's craft. If "
-    "the tileset or prop atlas you need does not exist, QUEUE IT - do "
-    "not point level_generate at a placeholder and call the level done. "
-    "The art seat makes them with tileset_generate and prop_generate; "
-    "prop_generate writes a MANIFEST and level_generate takes it as "
-    "prop_manifest=<path>, so you never type an atlas coordinate. "
-    "A level wired to art that is not there loads clean and draws nothing.\n"
-    "\u2022 READ THE PROP CONTRACT, do not invent one. bgate_core.props "
-    "declares every type's mount, its size in cells, which room "
-    "purposes it belongs in, and whether it loops or has states. "
-    "prop_atlas maps TYPE to atlas cell - 'torch.e=0,0 torch.w=1,0' "
-    "when a wall mount needs one tile per facing, because the engine's "
-    "flip bit does not carry texture_origin.\n"
-    "\u2022 DECALS ARE THEIR OWN LAYER. A TileMapLayer holds ONE tile "
-    "per coordinate, so a crack in the floor and the barrel standing on "
-    "it can only coexist as two layers. level_generate emits them; do "
-    "not flatten them back together.\n"
-    "\u2022 THE CONNECTIVITY GATE IS NOT ADVISORY. Every solid prop is "
-    "checked by flood filling the walkable set. If still_connected comes "
-    "back false that is a BUG to report, not a density dial to turn "
-    "down - a level that has lost a room looks completely fine in a "
-    "screenshot.\n"
-    "\u2022 READ THE `skipped` COUNTS before deciding a level is "
-    "under-dressed. back_wall, corner, no_side and wrong_purpose are the "
-    "placer REFUSING on purpose. Dark north walls mean the type set has "
-    "no front-facing sprite - the fix is a sconce, not a looser rule.\n"
-    "\u2022 LOOK AT THE RESULT IN THE ENGINE: godot_check_project then "
-    "godot_screenshot. Every level defect found so far - protrusions, "
-    "black corridor cracks, gaps in the wall shadow, props floating in "
-    "stone - was invisible in the numbers and obvious in one frame."
-)
-
-SEAT_RULES = {
-    # gameplay and tech both hold the `level` craft, so both can run
-    # level_generate - and both can spend an afternoon on a level whose
-    # art does not exist yet. The rule is identical for each seat, so it
-    # is written once and shared.
-    "gameplay": _LEVEL_RULE,
-    "tech": _LEVEL_RULE,
-    "narrative": (
-        "NARRATIVE HOUSE RULE - NO FIRST-THOUGHT JOKES:\n"
-        "• Before landing ANY name/line/bark, generate 5 candidates and kill "
-        "every one that is the FIRST joke anyone would make on the premise "
-        "(the obvious pun, the meme format, the joke every parody of this "
-        "subject already made). Ship the one that surprises.\n"
-        "• Obey the project's OWN tone tests (read the tone guide / bible "
-        "before writing; if you wrote one this session, your content must "
-        "pass it - self-contradiction is an automatic fail). No winks, no "
-        "lampshading, no decade-old meme formats.\n"
-        "• Specificity beats snark: a line should only make sense in THIS "
-        "world. If it could be pasted into any generic parody of the genre, "
-        "cut it.\n"
-        "• Read every deliverable back OUT LOUD (to yourself) against the "
-        "tone tests before landing. Land fewer, better lines."
-    ),
-    "audio": (
-        "AUDIO HOUSE RULE - EVERY SYNTHESIZED ASSET SHIPS ITS RECIPE:\n"
-        "• Alongside each .wav/.ogg you synthesize, write a `<name>.synth.json` "
-        "sidecar capturing the FULL parametric recipe: wave type(s), ADSR, "
-        "pitch/glide, noise mix, filter, duration, sample rate - and for music "
-        "beds the complete note/step pattern per channel + tempo/key. Another "
-        "process must be able to re-render the identical asset from the recipe "
-        "alone (the upcoming Audio Studio edits these knobs and re-renders - "
-        "a .wav without its recipe is a dead end).\n"
-        "• Keep the synthesis code you used in the project's .bgate/ scratch "
-        "so the recipe->render path is reproducible."
-    ),
-    "art": (
-        "ART HOUSE RULE - THE CONTRACT DECIDES THE SHEET, THE PIPELINE MAKES "
-        "IT, THE BATTERY REFEREES IT:\n"
-        "\u2022 WHICH GENERATOR DOES WHICH JOB - THEY ARE NOT "
-        "INTERCHANGEABLE. SPRITES AND STILLS ARE MINTED WITH KIE "
-        "(nano-banana-2); MOTION IS RETRO DIFFUSION, off a start frame "
-        "the sprite step produced. RD REDRAWS whatever it is handed, "
-        "which is exactly right for animating a frame you already own "
-        "and exactly wrong as a way to ORIGINATE a design: asked for a "
-        "prop cold it returns a different object every call and will not "
-        "hold a set's look. Never mint with RD, never animate with kie. "
-        "animation_generate already routes this correctly.\n"
-        "• FIRST, ALWAYS: sprite_contract_get(character, action) - the "
-        "declared view, direction set, cell size and frame counts. No "
-        "contract set = raise it with the director (sprite_contract_set has "
-        "presets), do NOT invent a layout. And palette_pin BEFORE any art if "
-        "none is pinned (>=32 colours, derived across SEVERAL sheets/refs - "
-        "a 24-colour single-sheet derivation silently recoloured a blouse).\n"
-        "• CHARACTER ANIMATION CYCLES = animation_generate. It reads the "
-        "contract, takes start frames from the character's OWN sheets, runs "
-        "the purpose-trained animation model per drawn direction (~$0.14), "
-        "conforms to the pinned palette, grades everything, and emits the "
-        "contract-shaped sheet + .tres + .aseprite master. Do NOT hand-build "
-        "cycles out of image_edit calls - that is the path that shipped ten "
-        "of twenty facings backwards.\n"
-        "• A MISSING or OFF-STYLE direction start frame is minted with a "
-        "TWO-REF edit (nano-banana-2): style authority = a good frame of the "
-        "character, angle authority = any frame at the wanted camera angle, "
-        "prompt names both jobs. One ref alone gives pure-N instead of "
-        "back-3/4. Filmstrip single-gen (whole cycle as ONE image, "
-        "from_painted_sheet to slice) remains the way to mint a NEW "
-        "character's first sheet - identity by construction.\n"
-        "• ACT ON THE FINDINGS. facing_flip / wrong_direction / height_split "
-        "/ yaw_drift / set_drift on a strip = re-roll THAT strip, do not "
-        "land it. The one eyeball override: pose-legitimate height (a raised "
-        "arm, a collapse taper) - look at the GIF preview and say so in the "
-        "seat note. LOOK at every animation preview before landing; motion "
-        "defects are obvious in two seconds of playback and invisible in a "
-        "grid.\n"
-        "• HAND FIXES go through the master: open the .aseprite, fix the "
-        "frame, aseprite_export - never pixel-edit the shipped PNG (the "
-        "export re-grades; a raw edit dodges every check).\n"
-        "• Before landing: consistency_check per frame AND clear alpha flags "
-        "(no white halo, no feathered fringe, no background bleed, no hollow "
-        "interior). Any alpha flag = do not land.\n"
-        "\n"
-        "\u2022 THE ORDER IS: game_view_get -> palette_pin -> "
-        "tileset_generate -> prop_generate -> hand the manifest to "
-        "whoever holds the level generator (level_generate top-down, "
-        "sidescroll_generate side-scroller).\n"
-        "\u2022 PROPS ARE prop_generate, ONE CALL. It reads the view for "
-        "the camera, art_spec for the canvas and ground anchor, draws "
-        "with kie, keys the background, fits the contract box, hardens "
-        "the alpha, conforms to the pinned palette, packs the atlas and "
-        "writes the manifest. Do NOT hand-roll that chain with "
-        "image_generate: the first prop set was made that way and it "
-        "silently skipped the conform and the defringe - 32px sprites "
-        "with 600 colours, two thirds off-palette, feathered edges. The "
-        "steps were not refused, they were forgotten.\n"
-        "LEVEL ART IS A CONTRACT AND A HANDOFF - YOU MAKE IT, GAMEPLAY "
-        "AND TECH SPEND IT:\n"
-        "\u2022 TILESETS: tileset_generate, and leave bits=8. A 16-mask "
-        "set cannot say 'floor north and east, void at the north-east "
-        "corner', so the shadow band along every wall BREAKS at each "
-        "step in a room's outline. The corner tiles are pure geometry, "
-        "so eight bits costs no extra call and no extra money. It draws "
-        "TWO MATERIALS with kie (prompt=floor, void_prompt=behind) and "
-        "carves every mask tile between them - same provider rule as "
-        "sprites: kie generates, RD only ever animates.\n"
-        "\u2022 PROPS: props.art_spec(type) IS the spec - exact canvas "
-        "in pixels, the ground anchor, how many DRAWINGS (a wall mount "
-        "needs one per facing; the engine mirrors a sprite but NOT its "
-        "texture_origin, measured), and whether the type LOOPS (a torch "
-        "flickers, a portal turns) or has STATES (a chest is shut, "
-        "opening, open). Loop and state are two different engine "
-        "mechanisms and a type declares one, never both. A prop drawn at "
-        "the wrong proportion is not a style difference, it is a sprite "
-        "hanging off its cell, and no placement rule fixes it.\n"
-        "\u2022 A WALL MOUNT IS THE OBJECT ONLY - no wall behind it, no "
-        "floor under it, no scene. A torch prompted 'flat against a "
-        "wall' comes back with a slab of masonry attached and pastes a "
-        "stone rectangle over the level. Same for a floor prop: no "
-        "ground, no cast shadow.\n"
-        "\u2022 DO NOT NAIVELY DOWNSCALE a 1024px generation into a "
-        "32px cell. It survives for a simple silhouette (a barrel) and "
-        "turns a detailed subject (a chest) into mush. Conform through "
-        "the palette and the Aseprite master, and re-roll whatever does "
-        "not read at 1x on a dark background - where you must LOOK.\n"
-        "\n"
-        "HUD / UI CHROME SHIPS AS SEPARATE LAYERED PARTS, NEVER ONE BAKED "
-        "COMPOSITE:\n"
-        "• A UI element with dynamic or independently-driven sub-parts - a meter = "
-        "frame + segmented FILL + icon + counter badge; a health bar = frame + "
-        "FILL; a card = frame + portrait + label plate - MUST ship as SEPARATE "
-        "transparent PNGs, one per layer, NOT fused into a single image. The "
-        "scene/designer stacks and drives each independently: the fill depletes in "
-        "code BEHIND a hollow frame, segments light one by one, the icon/badge are "
-        "their own nodes. Gening the whole element in one go leaves nothing the "
-        "designer can wire - it is not shippable.\n"
-        "• Frames are HOLLOW: a fully transparent window where the code-driven fill "
-        "shows through. NEVER bake a colored fill into a frame. For every frame, "
-        "post the exact fill-window rect (x,y,w,h) in your seat note.\n"
-        "• Keep the parts on a consistent pixel grid / shared registration so they "
-        "stack cleanly at the target rect. A single composed PREVIEW mock is fine "
-        "FOR REVIEW, but the SHIPPED assets are the separate layers.\n"
-        "• Match the pinned concept: crop the target element out of the concept "
-        "ref, condition generation on that crop, and build your own "
-        "concept-vs-output comparison - iterate until it matches, don't ship "
-        "isolated bare bars.\n"
-        "\n"
-        "WORLD / ENVIRONMENT ASSETS ARE INDIVIDUAL GENS, NEVER A SLICED SCENE:\n"
-        "• Concept mocks are COMPOSITES - inspiration, not assets. A shippable "
-        "world asset is generated ON ITS OWN: one prop (desk, plant, vending "
-        "machine, printer shrine), one tile, one unit sprite per gen, "
-        "transparent background, consistent scale against the project's grid "
-        "(e.g. a 32px-tile world: props sized in tile multiples, characters to "
-        "their tile footprint). NEVER generate a full scene and cut pieces out "
-        "of it - sliced fragments have baked lighting/overlap and never "
-        "composite cleanly.\n"
-        "• Tilesets: gen each tile type separately (or a strict uniform grid "
-        "sheet where every cell is one clean tile), then assemble the atlas "
-        "with code - cells must be seamlessly tileable with their neighbors.\n"
-        "• Scale/registration discipline: every asset in a batch states its "
-        "intended pixel size; verify against the grid before landing so the "
-        "engine drops it in without per-asset fudging.\n"
-        "• UNITS SHIP THE FULL FACING MATRIX THE SPRITE CONTRACT DECLARES: "
-        "drawn directions generated, mirrored directions flipped in-engine "
-        "(flip_h), never generated - the contract's drawn/mirror map is the "
-        "authority, per character and per action (sprite_contract_get). A "
-        "partial facing x anim matrix is an automatic fail.\n"
-        "• ISO PROPS DECLARE A ROTATION CLASS (see the project bible's "
-        "prop-rotation contract): SYMMETRIC = 1 gen reused; MIRRORABLE = 2 "
-        "gens + flip_h (NO text/logos/handedness); FULL = 4 gens (anything "
-        "with readable text/signage - mirrored text is an automatic fail). "
-        "All views of one prop conditioned on the SAME prop ref so it reads "
-        "as one object rotated; state the tile footprint per prop.\n"
-        "\n"
-        "DELIVERY FIDELITY - WHAT WAS APPROVED IS WHAT SHIPS:\n"
-        "• The engine-ready file you deliver must be a MECHANICAL derivation "
-        "of the approved artifact revision: trim, downscale, alpha-clean - "
-        "NOTHING ELSE. Never redraw, re-generate, or 'improve' an asset at "
-        "the delivery step; a delivered file whose content differs from its "
-        "approved source is an automatic reject (observed failure: floors "
-        "shipped with an invented X-bevel that existed in no approved rev).\n"
-        "• Name the source in your seat note per delivered file "
-        "(delivered X <- approved revision N) so the trail is auditable."
-    ),
-}
-
-
-SEAT_RULES_FILENAME = "seat_rules.json"
-
-
-def seat_rules(root: str, seat: str) -> str:
-    """The house rules injected into THIS project's prompt for this seat.
-
-    ``<root>/.bgate/seat_rules.json`` ({"art": "...", "narrative": ""}) is the
-    project's override and wins outright - including an empty string, which is
-    how a project turns a built-in off. Rules are prompt text, not schema, so
-    they live in a file the project edits and diffs rather than in the seat
-    table. Absent an override, the shipped built-in applies.
-    """
-    try:
-        data = json.loads((Path(root) / ".bgate" / SEAT_RULES_FILENAME)
-                          .read_text(encoding="utf-8"))
-    except (OSError, ValueError):
-        data = {}
-    if isinstance(data, dict) and seat in data:
-        return str(data[seat] or "").strip()
-    return SEAT_RULES.get(seat, "")
+# SEAT HOUSE RULES LIVE IN bgate_core.seats (DISPATCH_RULES / dispatch_rules)
+# as of 2026-08-19 - every statement of what a seat is told has ONE home, so
+# the dispatch rules and the seat workflows cannot drift apart unseen (they
+# did: the art rules and the art workflow disagreed about the sheet default).
+# Re-exported here because callers and tests address them through this module.
+SEAT_RULES = _seatmod.DISPATCH_RULES
+SEAT_RULES_FILENAME = _seatmod.DISPATCH_RULES_FILENAME
+seat_rules = _seatmod.dispatch_rules
 
 
 def _verify_rule(root: str) -> str:
@@ -522,11 +266,24 @@ def _verify_rule(root: str) -> str:
     except Exception:
         pass
     godot = engine == "godot" or (root_path / "game" / "project.godot").is_file()
+    # THE EYES RULE, verbatim in both branches because it is the check agents
+    # skip. Observed on a real board: an agent measured a level's geometry
+    # (walkable cells, connectivity, flood-fill - all green), declared the
+    # doorways fine, and the render had black holes where the doors should
+    # be. Every number was true and the scene was broken. Stats, tree dumps,
+    # byte inspection and passing checks are ONE check; for anything a player
+    # sees, the check that counts is a RENDER IN FRONT OF YOUR EYES.
+    eyes = ("IF THE DELIVERABLE IS VISIBLE, LOOK AT IT: render it "
+            "(godot_screenshot for a scene, the produced image file for art - "
+            "the Read tool shows you images) and judge the PICTURE, before "
+            "you claim done. Geometry stats, node counts, file sizes and "
+            "green checks are supporting evidence, never the verdict; an "
+            "agent that reports numbers about an image it never opened is "
+            "the single most common way broken work gets marked done")
     if not godot:
         return ("run the narrowest real check that proves the change does "
                 "what the item asked - a build, the affected script, opening "
-                "the produced file - and LOOK at what you produce before you "
-                "land it.")
+                f"the produced file. {eyes}.")
     parts = ["godot_check_project after structural changes"]
     try:
         tests = sorted(p for p in (root_path / "game" / "tests").glob("*.gd"))
@@ -537,8 +294,7 @@ def _verify_rule(root: str) -> str:
         parts.append("run this project's own test scripts via godot_run when the "
                      f"code they cover moved ({named}) - fail=0 or report exactly "
                      "why")
-    parts.append("godot_screenshot when the change is visible")
-    parts.append("LOOK at what you produce")
+    parts.append(eyes)
     return "; ".join(parts) + "."
 
 
@@ -703,18 +459,21 @@ def _prompt_for(root: str, item: dict, native_images: bool = False) -> str:
         "for or working on right now. Read the board before touching a file a "
         "dispatched peer owns or duplicating queued work; a second brief call "
         "returns the same payload and costs what the first one did.\n"
-        "2. Do the work inside your lanes. The PreToolUse hook enforces them, "
-        "so write and let it refuse - seat_can_write is for when you need to "
-        "know BEFORE a long generation, not a checkpoint before every edit. "
-        "Lock binaries before editing.\n"
-        "   OUT-OF-LANE WORK IS ROUTED, NEVER DROPPED. If this task needs a "
-        "write another seat owns, queue_add(<that seat>, title, brief) files "
-        "it for an agent that CAN write it - pass depends_on="
+        "2. Do the work. Your hard boundary is the PROJECT you were "
+        "dispatched for - writes outside it are refused. Inside it, your "
+        "lanes are the map of what is yours, not a wall: prefer them, and "
+        "when this item plainly needs a write outside them, make it (it is "
+        "logged and reviewed like everything else). Lock binaries before "
+        "editing.\n"
+        "   FINISHING THE ITEM OUTRANKS STAYING IN LANE. A 'failed' result "
+        "because a path was not yours is the worst outcome available - "
+        "worse than the cross-lane write, which a human can see and undo. "
+        "Route SUBSTANTIAL cross-seat work instead of doing it badly: "
+        "queue_add(<that seat>, title, brief) files it for an agent with "
+        "the right toolset - pass depends_on="
         f"{item['id']} when it needs this item's output - then keep working "
         "on what is yours. A seat note, a LEFTOVERS block or a 'blocked' "
-        "result dispatches NOBODY; only a queue row does. Handing work on IS "
-        "part of finishing yours, and a result paragraph that names the items "
-        "you filed is a finished handoff.\n"
+        "result dispatches NOBODY; only a queue row does.\n"
         "   ROUTE ONLY WHAT THIS ITEM NEEDS. The test for filing work is "
         "'does my item need this done to be finished' - not 'did I notice "
         "something'. An improvement you merely noticed is one line in your "
@@ -1172,6 +931,10 @@ def _spawn(root: str, item_id: int, *, permission_mode: str = "acceptEdits",
         # server enforces another. aegis.mode() maps anything unrecognised to
         # the default, and it maps it the same way for everybody here.
         "BGATE_AEGIS": _aegis.mode(),
+        # The lane dial, normalised for the same reason as BGATE_AEGIS above:
+        # one policy for hook and server. Default is "warn" - a seat is a
+        # toolset plus the aegis boundary; its lane table is advisory.
+        "BGATE_LANES": _seatmod.lane_mode(),
         "BGATE_WORK_ITEM": str(item_id),
         "BGATE_LOCK_OWNER": f"item-{item_id}",
         # Who this session is, for anything that asks whether a human is
@@ -2383,7 +2146,7 @@ def steer(root: str, item_id: int, text: str) -> dict:
         if entry.get("stdin_closed"):
             return {"ok": False, "error": "agent is finishing; steer channel closed"}
         try:
-            entry["stdin"].write(_user_msg(f"STEER FROM THE DIRECTOR (act on this now): {text}").encode("utf-8"))
+            entry["stdin"].write(_user_msg(f"{STEER_MARKER}{text}").encode("utf-8"))
             entry["stdin"].flush()
         except OSError as exc:
             return {"ok": False, "error": f"agent not accepting input: {exc}"}
@@ -2648,298 +2411,25 @@ def status(root: str) -> list[dict]:
     return out
 
 
-STEER_MARKER = "STEER FROM THE DIRECTOR (act on this now): "
+# THE PARSER LIVES IN bgate_core.agentlog NOW (2026-08-19). Three readers of
+# the same stream-json - this feed, routes/history, and the MCP server's
+# agent_activity - each carried their own folding rules, and the third copy
+# shipped with a misquoted STEER_MARKER that silently dropped every steer.
+# One vocabulary, one home; this module keeps only what is genuinely its own:
+# the byte-cursor cache, the Popen liveness, and the per-run retention.
+STEER_MARKER = _agentlog.STEER_MARKER
+_tool_subject = _agentlog.tool_subject
+_final_tokens = _agentlog.final_tokens
+_final_model = _agentlog.final_model
 
 
 def _add_step(state: dict, step: dict) -> None:
-    """Append one step to the ring. What falls off the front is counted, not
-    forgotten - see the ``dropped``/``truncated`` fields read_activity returns.
-
-    Every step is stamped with when it was PARSED. That is a few milliseconds
-    after the CLI wrote it and is the only clock the log offers, but it is what
-    lets a phase say which renders and which sound files came out of it: an
-    artifact row carries created_at, a step did not carry anything to compare it
-    to, so the work an agent produced could not be attributed to the part of the
-    run that produced it. Rounded to the second, which is the resolution the
-    artifact table stores anyway.
-    """
-    step.setdefault("ts", time.time())
-    state["steps"].append(step)
-    state["step_count"] += 1
-    if len(state["steps"]) > MAX_STEPS:
-        del state["steps"][:len(state["steps"]) - MAX_STEPS]
-
-
-def _tool_subject(name: str, inp: dict) -> str:
-    """WHAT a call was about, not merely which tool it was.
-
-    The inspector drew a run as a row of verbs — Read, Grep, Grep, Read, Bash —
-    so a forty-step run was thirty-five interchangeable words. The subject was
-    always in the payload; this is the one place that decides which key carries
-    it, because the answer is per-tool: Grep's subject is its PATTERN and the
-    path is context, while Read's subject is the path itself.
-
-    Pattern-first for the searches is the specific fix. ``path`` came first in
-    the old flat or-chain, so every Grep in a run that searched one file printed
-    that same path and said nothing about what was being looked for — and Glob,
-    which has no ``path`` and no ``query``, printed nothing at all. The path
-    still rides along on the end, because phases.look() mines this string for
-    the files a step touched and dropping it would empty the file rail.
-    """
-    def val(key: str) -> str:
-        got = inp.get(key)
-        return " ".join(str(got).split()) if isinstance(got, (str, int)) else ""
-
-    if name in ("Grep", "Glob"):
-        return " · ".join(x for x in (val("pattern"), val("path")) if x)
-    if name == "Bash":
-        return val("command")
-    if name in ("Read", "Write", "Edit", "MultiEdit"):
-        return val("file_path") or val("path")
-    if name == "NotebookEdit":
-        return val("notebook_path")
-    if name in ("WebFetch", "WebSearch"):
-        return val("url") or val("query")
-    if name in ("Task", "Agent"):
-        return val("description") or val("subagent_type")
-    if name == "TodoWrite":
-        # Its input is the whole list; any one item of it is a misleading label.
-        return ""
-    return (val("path") or val("file_path") or val("name") or val("title")
-            or val("role") or val("query") or val("pattern")
-            or val("description") or val("command") or val("prompt"))
-
-
-def _blocks(ev: dict) -> list:
-    """Content blocks of a stream-json message. Some CLI builds send ``content``
-    as a bare string; iterating that yields characters and explodes on .get."""
-    content = (ev.get("message") or {}).get("content")
-    return [b for b in content if isinstance(b, dict)] if isinstance(content, list) else []
+    _agentlog.add_step(state, step, MAX_STEPS)
 
 
 def _absorb(state: dict, raw: bytes) -> None:
-    """Fold one log line into the parsed feed."""
-    line = raw.strip()
-    if not line:
-        return
-    try:
-        ev = json.loads(line)
-    except (ValueError, TypeError):
-        return
-    if not isinstance(ev, dict):
-        return
-    # THE CLAUDE SESSION THIS RUN IS, which is what makes it resumable.
-    #
-    # Every line the CLI writes carries the same `session_id`, and Claude Code
-    # keeps that session's transcript under ~/.claude/projects - so the id is
-    # the handle for `claude --resume`, and somebody who would rather read a run
-    # in a terminal than in this dashboard can pick it up exactly where the
-    # agent left it, with its whole context.
-    #
-    # TAKEN FROM THE FIRST LINE THAT HAS ONE AND THEN LEFT ALONE. Measured: one
-    # id per run across a whole log. A later line overwriting it would matter if
-    # that ever stopped being true, and the first is the one that names the
-    # session that was started.
-    if not state.get("session_id"):
-        sid = ev.get("session_id")
-        if isinstance(sid, str) and sid:
-            state["session_id"] = sid
-
-    etype = ev.get("type")
-    if etype == "bgate_run_start":
-        # A RE-DISPATCH. The log appends across runs and showing run 1's result
-        # as run 2's current state was a real observed bug - everything before
-        # this marker belongs to a run that is over.
-        state["steps"].clear()
-        state["step_count"] = 0
-        state["final"] = None
-        # A re-dispatch is a DIFFERENT Claude session, so the old id must go
-        # with the old steps. Resuming run 1 while looking at run 2 would open
-        # a transcript that has nothing to do with what is on screen.
-        state["session_id"] = ""
-    elif etype == "assistant":
-        for block in _blocks(ev):
-            if block.get("type") == "text" and str(block.get("text", "")).strip():
-                _add_step(state, {"kind": "say",
-                                  "text": str(block["text"]).strip()[:1000]})
-            elif block.get("type") == "tool_use":
-                name = str(block.get("name", "?"))
-                inp = block.get("input") if isinstance(block.get("input"), dict) else {}
-                short = name.replace("mcp__builders-gate__", "")
-                # 200, not 120: a Bash hint is a command line, and the old cap
-                # cut most of them off inside the `cd "<long path>" &&` prefix
-                # every dispatched agent opens with — the chip said what
-                # directory it was standing in and never what it ran there.
-                _add_step(state, {"kind": "tool", "name": short,
-                                  "hint": _tool_subject(short, inp)[:200]})
-    elif etype == "user":
-        for block in _blocks(ev):
-            if block.get("type") == "tool_result":
-                c = block.get("content")
-                txt = c if isinstance(c, str) else (
-                    c[0].get("text", "") if isinstance(c, list) and c
-                    and isinstance(c[0], dict) else "")
-                txt = str(txt).strip()
-                if txt:
-                    _add_step(state, {"kind": "result", "text": txt[:600],
-                                      "truncated": len(txt) > 600})
-            elif block.get("type") == "text":
-                # Replayed user turns - and the FIRST of them is the dispatch
-                # prompt, which carries the seat-identity preamble and the whole
-                # house-rules block. That is internal plumbing, not something to
-                # show a human reading their agent's activity: only turns
-                # carrying the director marker (live steers) are surfaced.
-                txt = str(block.get("text", ""))
-                if STEER_MARKER in txt:
-                    _add_step(state, {"kind": "steer",
-                                      "text": txt.split(STEER_MARKER, 1)[1].strip()[:600]})
-    elif etype == "result":
-        # The agent's actual answer. NOT truncated to a preview length - this is
-        # the deliverable sentence the user opened the panel to read; the cap is
-        # only here so a runaway result cannot pin the process's memory.
-        state["final"] = {"subtype": ev.get("subtype"),
-                          "text": str(ev.get("result", ""))[:20000],
-                          "cost": ev.get("total_cost_usd"),
-                          "turns": ev.get("num_turns"),
-                          # The tokens, and which model spent them. `cost` on a
-                          # subscription is what this WOULD have cost on the
-                          # API; these are what the rolling usage window
-                          # actually meters, and cache_read dominates them by
-                          # four orders of magnitude over output.
-                          "model": _final_model(ev),
-                          "tokens": _final_tokens(ev)}
-    elif etype and etype.startswith(("thread.", "turn.", "item.")):
-        _absorb_codex(state, etype, ev)
-
-
-def _final_tokens(ev: dict) -> dict:
-    """The run's token usage, in this module's four names.
-
-    Read off `usage` rather than summed from the per-turn assistant events:
-    the CLI already totals it there, and re-adding 8,000 assistant messages to
-    reach a number the result event carries is the kind of work this feed's
-    byte cursor exists to avoid.
-    """
-    usage = ev.get("usage")
-    if not isinstance(usage, dict):
-        return {}
-    def n(key: str) -> int:
-        try:
-            return max(0, int(usage.get(key) or 0))
-        except (TypeError, ValueError):
-            return 0
-    return {"input": n("input_tokens"), "output": n("output_tokens"),
-            "cache_read": n("cache_read_input_tokens"),
-            "cache_write": n("cache_creation_input_tokens")}
-
-
-def _final_model(ev: dict) -> str:
-    """Which model actually ran, as the CLI names it.
-
-    Recorded because nothing else in this system knew. Every dispatch left
-    --model unset, so the answer was whatever the CLI defaulted to that day - unlogged, unqueryable, and discovered only by reading a raw session log
-    after the bill looked wrong. `modelUsage` is keyed by the resolved name
-    including its context-window suffix, which is the distinction that matters:
-    an opus-5[1m] run and an opus-5 run meter differently.
-    """
-    usage = ev.get("modelUsage")
-    if isinstance(usage, dict) and usage:
-        return max(usage, key=lambda k: (usage[k] or {}).get("cacheReadInputTokens", 0)
-                   if isinstance(usage[k], dict) else 0)
-    return str(ev.get("model") or "")
-
-
-# ---------------------------------------------------------------------------
-# The other vocabulary
-# ---------------------------------------------------------------------------
-# `codex exec --json` speaks a different, smaller event language than claude's
-# stream-json. The two do not collide - dotted names against bare ones - so one
-# reader handles a log of either kind without being told which runner wrote it,
-# which matters because the log is per ITEM and a re-dispatch may switch runners
-# under an existing file.
-#
-# The mapping is deliberately lossy in one direction: codex reports a shell
-# command and its whole aggregated output, where claude reports a tool name and
-# a structured result. Both land as the same {kind: tool} / {kind: result} steps
-# the feed already renders, because the person reading the panel wants to know
-# what the agent DID, not which vendor's noun it used.
-_CODEX_QUIET_ITEMS = {"reasoning", "todo_list"}
-
-
-def _absorb_codex(state: dict, etype: str, ev: dict) -> None:
-    if etype == "thread.started":
-        # Same job as bgate_run_start: a resumed or re-dispatched thread must
-        # not show the previous run's steps as current.
-        state["steps"].clear()
-        state["step_count"] = 0
-        state["final"] = None
-        # A re-dispatch is a DIFFERENT Claude session, so the old id must go
-        # with the old steps. Resuming run 1 while looking at run 2 would open
-        # a transcript that has nothing to do with what is on screen.
-        state["session_id"] = ""
-        return
-    if etype == "turn.completed":
-        # NO PRICE HERE, ON PURPOSE - see runners.Runner.cost_tracked. Tokens
-        # are recorded so the run is not a black box, but nothing downstream may
-        # read them as dollars.
-        usage = ev.get("usage") if isinstance(ev.get("usage"), dict) else {}
-        state["usage"] = {
-            "input_tokens": usage.get("input_tokens"),
-            "cached_input_tokens": usage.get("cached_input_tokens"),
-            "output_tokens": usage.get("output_tokens"),
-            "reasoning_output_tokens": usage.get("reasoning_output_tokens"),
-        }
-        return
-    if etype != "item.completed":
-        # item.started is the same item arriving twice; taking only the
-        # completion keeps one step per action instead of a doubled feed.
-        return
-
-    item = ev.get("item") if isinstance(ev.get("item"), dict) else {}
-    kind = str(item.get("type") or "")
-    if kind in _CODEX_QUIET_ITEMS:
-        return
-    if kind == "agent_message":
-        text = str(item.get("text") or "").strip()
-        if text:
-            _add_step(state, {"kind": "say", "text": text[:1000]})
-            # The LAST message of the run is the deliverable, and codex has no
-            # separate result event to carry it. Overwritten each time, so
-            # whatever it said last stands.
-            state["final"] = {"subtype": "success", "text": text[:20000],
-                              "cost": None, "turns": None}
-        return
-    if kind == "command_execution":
-        command = str(item.get("command") or "")
-        _add_step(state, {"kind": "tool", "name": "Bash",
-                          "hint": command[:120]})
-        output = str(item.get("aggregated_output") or "").strip()
-        code = item.get("exit_code")
-        if output or code:
-            _add_step(state, {"kind": "result",
-                              "text": (f"exit {code}\n" if code else "")
-                                      + output[:600],
-                              "truncated": len(output) > 600})
-        return
-    if kind in ("mcp_tool_call", "tool_call"):
-        name = str(item.get("tool") or item.get("name") or "?")
-        args = item.get("arguments") if isinstance(item.get("arguments"), dict) else {}
-        short = name.replace(f"mcp__{_runners.MCP_SERVER_NAME}__", "")
-        # Same subject rules as the claude path — a codex run drawn as a column
-        # of bare verbs is exactly as unreadable.
-        _add_step(state, {"kind": "tool", "name": short,
-                          "hint": (_tool_subject(short, args)
-                                   or str(args.get("seat") or ""))[:200]})
-        return
-    if kind in ("file_change", "patch_apply"):
-        changes = item.get("changes") if isinstance(item.get("changes"), list) else []
-        paths = ", ".join(str((c or {}).get("path") or "") for c in changes[:4])
-        _add_step(state, {"kind": "tool", "name": "Edit",
-                          "hint": (paths or str(item.get("path") or ""))[:120]})
-        return
-    # An item type this version has never seen still belongs in the feed - # silence would make a new codex capability look like an agent doing nothing.
-    label = str(item.get("text") or item.get("command") or kind)
-    _add_step(state, {"kind": "tool", "name": kind or "item", "hint": label[:120]})
+    """Fold one log line into the parsed feed. The rules are agentlog's."""
+    _agentlog.fold_line(state, raw, MAX_STEPS)
 
 
 def _is_running(item_id: int) -> bool:

--- a/bgate_ui/followup.py
+++ b/bgate_ui/followup.py
@@ -1147,17 +1147,18 @@ def _do_reopen(root, action: dict) -> dict:
 
 
 def _do_fail_escalate(root, action: dict) -> dict:
-    """File ONE director item about a failure nobody is going to retry.
+    """File ONE director item about a failure the harness stopped retrying.
 
-    QUEUED, NEVER AUTO-DISPATCHED — the same shape as ``qa_gate._escalate``
-    and for a stronger reason. The cap that produced this escalation exists
-    because more agent time on this item is expected to be wasted; buying a
-    WORKER agent to announce that would spend the money the cap just refused.
-    ``queue.HELD_SOURCES`` carries the other half of that promise: no
-    auto-dispatcher may pick this row up either. What CAN take it is the
-    console's director session — a decider, not a worker; see
-    :func:`_hand_to_director_session` — and when no such session exists the
-    row is held for the dashboard exactly as shipped.
+    DISPATCHABLE since 2026-08-19. This used to be queued-never-dispatched
+    (queue.HELD_SOURCES), on the theory that a decision needed a person — and
+    the observed result was the board's deepest dead end: with no console
+    director session open, every escalation sat queued forever and the human's
+    job became clearing and re-dispatching by hand. The console's director
+    session still gets FIRST claim (:func:`_hand_to_director_session` reserves
+    the row); failing that, autodeploy spawns a director-seat agent whose
+    brief is to diagnose and ACT — file the real blocker, fix the brief and
+    reopen, ask the human, or cut it. Spend stays bounded where it always
+    was: one escalation per item, ever (``fail_escalated``).
 
     The guard is re-run here, not trusted from the snapshot, because the batch
     that decided it can be replayed and because the same item can fail twice
@@ -1417,11 +1418,13 @@ def failure_escalation_brief(root: str | os.PathLike[str], item: dict,
         "Nothing further has been dispatched against it, and nothing will be "
         "until you decide.\n")
     lines.append(
-        "You hold the director seat. Read the failure, then take exactly ONE of "
-        "the moves at the bottom and close THIS item saying which and why. Do "
-        "not do the failed item's work yourself: that is seat work, and doing "
-        "it here is unlaned, unlogged, unbudgeted and ungated — and it walks "
-        "straight around the retry cap that filed this.\n")
+        "You hold the director seat. INVESTIGATE FOR REAL — the failed item's "
+        "result note, agent_activity(%d) for its last steps, the files it "
+        "touched — then take exactly ONE of the moves at the bottom and close "
+        "THIS item saying which and why. A small, obvious fix that unblocks "
+        "the reopen (a wrong path in the brief, a missing one-liner) is yours "
+        "to make; redoing the failed item's whole deliverable here is not — "
+        "that walks around the retry cap that filed this.\n" % item_id)
 
     lines.append("WHAT FAILED")
     lines.append(f"  #{item_id} [{seat}] \"{str(item.get('title') or '')[:120]}\"")

--- a/bgate_ui/qa_gate.py
+++ b/bgate_ui/qa_gate.py
@@ -154,10 +154,31 @@ def _open_gate_exists(root: str, ref: str) -> bool:
 
 
 def _latest_gate_created(root: str, ref: str) -> str:
+    """When the last CONCLUDED review round for this item was filed.
+
+    Concluded means the reviewer actually delivered: status 'done' AND a
+    VERDICT marker in the result. It used to be max(created_at) over every
+    gate row, which made a DEAD reviewer count as a review — a QA agent that
+    crashed (reaped 'failed', or banked 'done' off a bare exit with no
+    verdict text) closed the round, the original item's updated_at was then
+    <= that timestamp, and the item passed the gate WITHOUT ANYONE EVER
+    LOOKING AT IT. Silence is the one verdict a gate must not accept: a
+    round with no verdict now simply does not count, so the sweep files a
+    fresh reviewer (bounded below — see _scan_once's runaway guard)."""
     row = db.connect(root).execute(
         "SELECT max(created_at) AS c FROM work_item "
-        "WHERE source = 'qa-gate' AND source_ref = ?", (ref,)).fetchone()
+        "WHERE source = 'qa-gate' AND source_ref = ? AND status = 'done' "
+        "AND (result LIKE '%VERDICT: PASS%' OR result LIKE '%VERDICT: FAIL%')",
+        (ref,)).fetchone()
     return (row["c"] if row and row["c"] else "")
+
+
+def _gate_rows_filed(root: str, ref: str) -> int:
+    """Every QA round ever filed for this item, delivered or not."""
+    row = db.connect(root).execute(
+        "SELECT count(*) AS n FROM work_item "
+        "WHERE source = 'qa-gate' AND source_ref = ?", (ref,)).fetchone()
+    return int(row["n"] if row else 0)
 
 
 def escalated(root: str | os.PathLike[str], ref: str) -> bool:
@@ -289,6 +310,15 @@ def _scan_once(root: str, cutoff_utc: str) -> None:
         rounds = int(item.get("attempts") or 0) + 1
         if rounds > cap:
             _escalate(root, item, ref, rounds - 1)
+            continue
+        # RUNAWAY GUARD for the no-verdict re-review path. A round whose
+        # reviewer died no longer counts as a review (_latest_gate_created),
+        # which means this sweep will file another - and a reviewer that dies
+        # EVERY time (broken CLI, poisoned brief) must not buy an agent per
+        # sweep forever. Twice the round cap in total filings is generous for
+        # honest crashes and cheap as a ceiling; past it, a human decides.
+        if _gate_rows_filed(root, ref) >= cap * 2:
+            _escalate(root, item, ref, rounds)
             continue
         # A closed gate exists and the original hasn't moved since -> already
         # reviewed this round. (updated_at bumps on the re-done fix round.)

--- a/bgate_ui/routes/console.py
+++ b/bgate_ui/routes/console.py
@@ -181,29 +181,62 @@ def _phases_for(root, item_id: int, feed: dict, all_steps: list,
 
 
 def _chain_state(conn, items: list[dict]) -> None:
-    """Stamp readiness onto the cards, in ONE query for the whole board.
+    """Stamp readiness onto the cards, in TWO queries for the whole board.
 
-    A chained item that is not ready is indistinguishable from a plain queued one
-    on the wire, so the console offered a deploy button whose only possible
-    outcome was a refusal. Resolved here rather than per row because the console
-    payload is already the expensive call on this page.
+    A chained item that is not ready is indistinguishable from a plain queued
+    one on the wire, so the console offered a deploy button whose only possible
+    outcome was a refusal. Resolved here rather than per row because the
+    console payload is already the expensive call on this page.
+
+    THREE TRUTHS THE FIRST VERSION MISSED, each of which drew a dispatchable-
+    looking card over an item nothing was ever going to run:
+      * EXTRA PARENTS. Fan-in deps live in work_item_dep, and reading only the
+        depends_on column rendered those cards `ready` with a deploy button
+        whose one outcome was `blocked_on_dependency`.
+      * `held`. A queued row whose source is in HELD_SOURCES (qa-gate
+        escalations, chat) is skipped by every auto-dispatcher on purpose - a
+        human takes it. On the wire it looked like any queued item.
+      * `stuck`. A predecessor in `failed`/`cancelled` will never reach 'done'
+        on its own, so the successor is not "waiting", it is parked until
+        someone reopens the predecessor or cuts the dependency - and the card
+        should say which act frees it.
     """
+    from bgate_core.queue import HELD_SOURCES, SATISFIED
+
+    ids = [int(it["id"]) for it in items]
+    extra: dict[int, list[int]] = {}
+    if ids:
+        marks = ", ".join("?" * len(ids))
+        for row in conn.execute(
+                f"SELECT item_id, depends_on FROM work_item_dep "
+                f"WHERE cut_at IS NULL AND item_id IN ({marks})",
+                tuple(ids)):
+            extra.setdefault(int(row["item_id"]), []).append(
+                int(row["depends_on"]))
     need = {int(it["depends_on"]) for it in items if it.get("depends_on")}
-    if not need:
-        for it in items:
-            it["ready"] = True
-        return
-    marks = ", ".join("?" * len(need))
-    deps = {int(row["id"]): dict(row) for row in conn.execute(
-        f"SELECT id, seat, title, status FROM work_item WHERE id IN ({marks})",
-        tuple(sorted(need)))}
+    need.update(d for deps in extra.values() for d in deps)
+    deps: dict[int, dict] = {}
+    if need:
+        marks = ", ".join("?" * len(need))
+        deps = {int(row["id"]): dict(row) for row in conn.execute(
+            f"SELECT id, seat, title, status FROM work_item "
+            f"WHERE id IN ({marks})", tuple(sorted(need)))}
     for it in items:
-        dep = deps.get(int(it["depends_on"] or 0))
-        # A missing predecessor (deleted) unblocks rather than strands: an item
-        # nobody can release is worse than one that ran a step early.
-        it["ready"] = not dep or dep["status"] == "done"
-        if not it["ready"]:
-            it["waiting_on"] = dep
+        parents = ([int(it["depends_on"])] if it.get("depends_on") else []) \
+            + extra.get(int(it["id"]), [])
+        # A missing predecessor (deleted) unblocks rather than strands: an
+        # item nobody can release is worse than one that ran a step early.
+        unsatisfied = [deps[p] for p in parents
+                       if p in deps and deps[p]["status"] not in SATISFIED]
+        it["ready"] = not unsatisfied
+        it["held"] = (it.get("status") == "queued"
+                      and str(it.get("source") or "") in HELD_SOURCES)
+        if unsatisfied:
+            it["waiting_on"] = unsatisfied[0]
+            if len(unsatisfied) > 1:
+                it["waiting_count"] = len(unsatisfied)
+            it["stuck"] = any(d["status"] in ("failed", "cancelled")
+                              for d in unsatisfied)
 
 
 def _turn_brief(text: str) -> str:
@@ -408,20 +441,29 @@ def _gates(root_dir, conn, active: set[int]) -> list[dict]:
         # behaviour that shipped before the setting existed.
         mode = _gatemode.DEFAULT
     out: list[dict] = []
+    # failure-escalation rows are in this list since 2026-08-19 - before
+    # that they appeared on NO rail at all: held from every dispatcher AND
+    # absent from the one view that lists what waits on a person, so a
+    # failed-past-its-cap item simply vanished until somebody went digging.
+    # They are auto-dispatchable now (a director agent may take one), so a
+    # QUEUED one is awaiting a ruling and a DISPATCHED one is being handled -
+    # `blocking` says which, and only 'qa-gate' rows are never a human's.
     for row in conn.execute(
             "SELECT id, seat, title, status, source, source_ref, created_at "
-            "FROM work_item WHERE source IN ('qa-gate', 'qa-gate-escalation') "
+            "FROM work_item WHERE source IN ('qa-gate', 'qa-gate-escalation', "
+            "'failure-escalation') "
             "AND status IN ('queued', 'dispatched') ORDER BY id DESC LIMIT 20"):
         ref = (row["source_ref"] or "").strip()
         out.append({
-            "kind": "escalation" if row["source"] == "qa-gate-escalation" else "qa",
+            "kind": "qa" if row["source"] == "qa-gate" else "escalation",
             "id": f"gate_item_{row['id']}",
             "item_id": int(row["id"]),
             "over_item_id": int(ref) if ref.isdigit() else None,
             "title": row["title"],
             "seat": row["seat"],
             "status": row["status"],
-            "blocking": row["source"] == "qa-gate-escalation",
+            "blocking": (row["source"] != "qa-gate"
+                         and row["status"] == "queued"),
             "created_at": row["created_at"],
         })
     # Sign-off: an agent says a thing is done, and until a human agrees it is

--- a/bgate_ui/routes/history.py
+++ b/bgate_ui/routes/history.py
@@ -54,6 +54,7 @@ from typing import Optional
 
 from fastapi import APIRouter, HTTPException, Query
 
+from bgate_core import agentlog as _agentlog
 from bgate_core import db
 from bgate_ui.deps import root
 
@@ -386,7 +387,10 @@ TEXT_CAP = 1200
 _QUIET_SYSTEM = {"thinking_tokens", "hook_started", "hook_response",
                  "task_started", "task_notification", "task_updated",
                  "background_tasks_changed"}
-_STEER_MARKER = "STEER FROM THE DIRECTOR (act on this now): "
+# Shared with every other reader of this format - see bgate_core.agentlog,
+# which owns the stream-json vocabulary. A private copy of the marker is
+# how a reader silently stops seeing steers.
+_STEER_MARKER = _agentlog.STEER_MARKER
 
 # Tools that PRODUCE, and tools that merely LOOK. An agent reads an order of
 # magnitude more than it writes, and a list that conflates the two is noise —
@@ -411,10 +415,7 @@ _MAX_IMAGE_PATHS = 300
 _RESULT_SCAN = 4000
 
 
-def _blocks(event: dict) -> list:
-    message = event.get("message")
-    content = message.get("content") if isinstance(message, dict) else None
-    return [b for b in (content or []) if isinstance(b, dict)]
+_blocks = _agentlog.blocks
 
 
 def _step(steps: list, run: int, offset: int, kind: str, **rest) -> None:
@@ -481,7 +482,7 @@ def _parse(path: Path) -> dict:
                         inp = block.get("input")
                         inp = inp if isinstance(inp, dict) else {}
                         raw_name = str(block.get("name", "?"))
-                        name = raw_name.replace("mcp__builders-gate__", "")
+                        name = raw_name.replace(_agentlog.MCP_TOOL_PREFIX, "")
                         hint = (inp.get("path") or inp.get("file_path")
                                 or inp.get("command") or inp.get("title")
                                 or inp.get("query") or inp.get("pattern")

--- a/bgate_ui/routes/providers.py
+++ b/bgate_ui/routes/providers.py
@@ -93,6 +93,26 @@ def providers_view() -> dict:
     return api.ok(_payload(_providers.status(root())))
 
 
+@router.get("/api/providers/balances")
+def providers_balances(fresh: bool = False) -> dict:
+    """Keyed-and-funded per provider, from the gateway - the panel's money row.
+
+    A SEPARATE ROUTE from /api/providers on the same reasoning kie keeps
+    credits() out of available(): the status view must answer offline, and a
+    balance probe is a network call per provider. This one is fetched when
+    the panel is actually open, cached ~2 minutes in the gateway, and
+    ``?fresh=1`` re-probes - the button a human presses after topping an
+    account up. `balance` null means the provider will not say (openai never
+    does; krea's API balance only surfaces as a 402 at call time), which the
+    panel must render as unknown, never as zero.
+    """
+    from bgate_core import gateway as _gateway
+
+    return api.ok({"providers": _gateway.status(root(), fresh=bool(fresh)),
+                   "capabilities": {k: list(v)
+                                    for k, v in _gateway.CAPABILITIES.items()}})
+
+
 @router.post("/api/providers/{provider_id}/key")
 def provider_set_key(provider_id: str, request: Request, payload: dict) -> dict:
     """Store one provider's key in the project's .env.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -23,10 +23,13 @@ identity, not a process: a session declares `BGATE_SEAT=art` and inherits art's
 mission, writable paths and brief (`bgate_core/seats.py`).
 
 **Lane**
-The file paths a seat may write, as glob patterns. Art's are `game/assets/**`,
-`blender/**`, `art/**`; gameplay's are `game/scripts/**`, `game/scenes/**`.
-`seat_can_write(role, path)` is the oracle and it fails **closed**: an unknown
-seat, a disabled seat, or a path matching nothing gets refused.
+The file paths a seat normally writes, as glob patterns. Art's are
+`game/assets/**`, `blender/**`, `art/**`; gameplay's are `game/scripts/**`,
+`game/scenes/**`. `seat_can_write(role, path)` is the oracle. Advisory by
+default (`BGATE_LANES`): an out-of-lane write lands and the
+human is warned; `block` restores hard refusal. The enforced boundary is the
+**project** — a dispatched agent may not touch files outside the game it was
+dispatched for (`BGATE_AEGIS`, default `block`).
 
 **Lock**
 A claim on one binary file, held by one seat, recorded in the database.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -6,9 +6,11 @@ made, and [gotchas.md](gotchas.md) covers what went wrong on the way.
 
 Verified against the source on 2026-08-12.
 
-Three gates run throughout: a spend budget refuses an over-ceiling agent, a seat
-lane refuses an out-of-lane write, and watchdogs kill a wedged run. Approval is
-human-only. An agent records a verdict, it does not sign off.
+Three gates run throughout: a spend budget refuses an over-ceiling agent, the
+project boundary refuses a write into any other tree (lanes inside it are
+advisory by default — an out-of-lane write lands and is reported), and
+watchdogs kill a wedged run. Approval is human-only. An agent records a
+verdict, it does not sign off.
 
 ## The dashboard
 
@@ -538,7 +540,7 @@ the causal history.
 
 ## Tool index
 
-196 MCP tools are registered. The families, so you know what to look for:
+226 MCP tools are registered (the count is easy to let rot; tests/test_seat_briefs.py reads the real surface off the source). The families, so you know what to look for:
 
 | Family | Prefix | Covers |
 |---|---|---|
@@ -550,7 +552,7 @@ the causal history.
 | Scene | `scene_*`, `level_plan`, `level_generate` | Node surgery and level layout |
 | Images | `image_*`, `sprite_*`, `item_*`, `vfx_animate`, `ref_*`, `profile_*`, `consistency_check`, `art_qa_verdict`, `art_tournament_*` | Generation, sprite sheets, items, references, consistency, art review |
 | Cutout | `cutout_*` | 2D part-on-skeleton characters |
-| Audio | `voice_*`, `sfx_*`, `kie_music_*`, `music_*`, `dialogue_*` | Speech, sound effects, music generation and selection, dialogue trees |
+| Audio | `voice_*`, `sfx_*`, `music_*`, `dialogue_*` | Speech, sound effects, music generation and selection, dialogue trees |
 | Cinematic | `cinematic_*`, `storyboard_*`, `kie_video_generate` | Shot planning, generation, assembly, delivery, boards |
 | Assets | `asset_*`, `pending_decisions` | Locks, tracking, integrity audit |
 | Playtest | `playtest_*`, `iteration_*`, `causal_*` | Recording, briefs, promotion, iteration snapshots |
@@ -565,7 +567,7 @@ bgate_cli/        the `bgate` console script: init, adopt, use, projects, serve,
                   hook-status, un-adopt
 bgate_core/       db, project, bible, lore, canon, scope, spend, queue,
                   workflows, artifacts, playtest, iterations, git, search
-bgate_mcp/        FastMCP server (stdio), 196 registered tools
+bgate_mcp/        FastMCP server (stdio), 226 registered tools
 bgate_adapters/   blender, godot, imagegen, krea, kie, localgen, sprites,
                   recorder, transcribe
 bgate_ui/         dashboard backend + routes/, and static/, which is the built

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -36,7 +36,7 @@ This is more machinery than a small project needs.
 | Term | Meaning |
 |---|---|
 | **Seat** | A fixed job title an agent adopts for a session. Eight of them: director, narrative, gameplay, tech, art, audio, cinematic, qa. A seat is an identity, not a process: a session sets `BGATE_SEAT=art` and inherits art's mission and writable paths. |
-| **Lane** | The glob patterns a seat may write. Art's are `game/assets/**`, `blender/**`, `art/**`; gameplay's are `game/scripts/**`, `game/scenes/**`. Writes outside your lane are refused, and unknown seats fail closed. |
+| **Lane** | The glob patterns a seat normally writes. Art's are `game/assets/**`, `blender/**`, `art/**`; gameplay's are `game/scripts/**`, `game/scenes/**`. Advisory by default: an out-of-lane write lands and is reported to you rather than refused (`BGATE_LANES=block` restores hard enforcement). The hard boundary is the project itself — a dispatched agent cannot touch files outside the game it was dispatched for. |
 | **Lock** | A claim on one binary file. Text merges, a `.blend` does not. `asset_lock` before editing, `asset_release` after. A held lock errors instead of queueing, so the second agent goes and does something else. |
 | **Work item** | One unit of queued work: seat, title, brief, status. A database row. Filing one costs nothing and starts nothing. |
 | **Dispatch** | Turning a queued item into a running agent. This is where money gets spent and where the refusals live. |
@@ -121,8 +121,9 @@ channel that leaves the machine.
 
 Settings holds every switch, each row saying whether its value is the default,
 something you stored, or an environment variable overriding both. Two of them
-decide how much runs without you: `autopilot` (does work start without you) and
-the approval gate (does it finish without you).
+decide how much runs without you: `autopilot` (does work start without you —
+ON by default, so a filed chain runs as soon as `bgate serve` is up) and the
+approval gate (does it finish without you).
 
 ### 3. Register the server and install the hook
 
@@ -142,11 +143,13 @@ fine. This is the most common failure on Windows.
 not pick up a newly registered server. Confirm by asking Claude to call
 `project_status`; if that tool is not in its list, the server is not connected.
 
-`hook-install` writes a PreToolUse hook into `.claude/settings.json` that calls
-`seat_can_write` before every Bash, Write or Edit and blocks out-of-lane or
-lock-violating writes. It is inert unless a session sets `BGATE_SEAT`, and it
-fails open on anything unexpected. `hook-status` proves enforcement is live and
-exits 1 if it is not.
+`hook-install` writes a PreToolUse hook into `.claude/settings.json` that
+checks every Bash, Write or Edit: writes outside the dispatched project are
+refused, writes over another run's lock are refused, and out-of-lane writes
+land with a warning to you (advisory by default; `BGATE_LANES=block` hardens
+them). It is inert unless a session sets `BGATE_SEAT`, and it fails open on
+anything unexpected. `hook-status` proves enforcement is live and exits 1 if
+it is not.
 
 ### 4. Write the bible before you build anything
 

--- a/frontend/public/audio/floor/README.md
+++ b/frontend/public/audio/floor/README.md
@@ -15,7 +15,7 @@ soundtrack, and the radio in the lounge stays scenery rather than becoming a
 switch that does nothing.
 
 **These are harness UI audio, not game assets.** That is why they live here
-beside the floor's sprites rather than going through `kie_music_generate` ->
+beside the floor's sprites rather than going through `music_generate` ->
 `music_keep` -> `music_install`, which files takes as artifact revisions and
 installs the kept one into the **engine project's** music library. A game
 shipping the dashboard's background music in its own audio folder is the bug

--- a/frontend/public/providerkeys.js
+++ b/frontend/public/providerkeys.js
@@ -106,6 +106,8 @@
       ".pv-sech{display:flex;align-items:baseline;gap:9px;font-family:var(--mono);font-size:10px;letter-spacing:.18em;text-transform:uppercase;color:var(--text-3);margin-bottom:9px;padding-bottom:6px;border-bottom:1px solid var(--line)}",
       ".pv-sech .n{color:var(--text-2)}",
       ".pv-none{font-size:12px;color:var(--text-3);padding:10px 0}",
+      ".pv-drained{color:var(--red,#e5534b);font-weight:600}",
+      ".pv-balbtn{margin-left:auto;cursor:pointer}",
     ].join("");
     document.head.appendChild(s);
   }
@@ -154,10 +156,25 @@ when you are not in a project at all. A project's own key still wins over it.">
       <div class="pv-foot">
         <span>${esc(row.env)}</span>
         ${fp}${src ? `<span>· ${src}</span>` : ""}
+        ${balanceHtml(row)}
         <a class="pv-link" href="${esc(row.key_url)}" target="_blank"
            rel="noopener noreferrer">get a key ↗</a>
       </div>
     </div>`;
+  }
+
+  /* What is LEFT on the account, where the provider will say. null balance is
+     UNKNOWN (openai never says; krea's API balance only surfaces as a 402 at
+     call time) and must never render as zero — an agent already made that
+     exact mistake and hand-rolled a sprite over it. */
+  function balanceHtml(row) {
+    const bal = PK.balances && PK.balances[row.id];
+    if (!bal || !bal.keyed) return "";
+    if (bal.balance == null) return `<span>· balance: provider won't say</span>`;
+    const amount = `${bal.balance} ${esc(bal.balance_unit || "credits")}`;
+    return Number(bal.balance) <= 0
+      ? `<span class="pv-drained">· DRAINED — 0 ${esc(bal.balance_unit || "credits")} left</span>`
+      : `<span>· ${amount} left</span>`;
   }
 
   /* Where the key goes, said once and said plainly. This paragraph is the
@@ -194,6 +211,7 @@ when you are not in a project at all. A project's own key still wins over it.">
 
   const PK = {
     data: null, _read: 0, _busy: "", _reading: false,
+    balances: null, _balBusy: false,
     hosts: {},           // where: element
 
     async load(force) {
@@ -211,6 +229,27 @@ when you are not in a project at all. A project's own key still wins over it.">
       return this.data;
     },
 
+    /* THE MONEY ROW. Separate fetch from load() because it probes the
+       network per provider (the gateway caches ~2 minutes server-side);
+       the key panel must paint offline-fast and the balances arrive as a
+       second coat. fresh=true is the button a human presses after topping
+       an account up. */
+    async loadBalances(fresh) {
+      if (this._balBusy) return;
+      this._balBusy = true;
+      try {
+        const d = await window.readJSON(
+          "/api/providers/balances" + (fresh ? "?fresh=1" : ""), {});
+        if (d && !d.__error && d.providers) {
+          this.balances = {};
+          d.providers.forEach(r => { this.balances[r.id] = r; });
+        }
+      } finally {
+        this._balBusy = false;
+      }
+      Object.keys(this.hosts).forEach(w => this.paint(w));
+    },
+
     mount(where, host) {
       if (!host) return false;
       injectStyle();
@@ -223,6 +262,7 @@ when you are not in a project at all. A project's own key still wins over it.">
           const id = hit.dataset.pvId;
           if (hit.dataset.pvAct === "save") this.save(id, where, hit);
           if (hit.dataset.pvAct === "clear") this.clear(id, where, hit);
+          if (hit.dataset.pvAct === "balances") this.loadBalances(true);
         });
         /* Enter saves. Without it the only way to commit is the button, and
            "I pasted it and pressed enter" is the most common way to believe a
@@ -245,6 +285,7 @@ when you are not in a project at all. A project's own key still wins over it.">
       el.innerHTML = `<div class="pv-wrap"><div class="pv-none">loading providers…</div></div>`;
       await this.load(true);
       this.paint("settings");
+      this.loadBalances(false);   // second coat; repaints when it lands
       return true;
     },
 
@@ -254,6 +295,7 @@ when you are not in a project at all. A project's own key still wins over it.">
       host.innerHTML = `<div class="pv-wrap"><div class="pv-none">loading generators…</div></div>`;
       await this.load(true);
       this.paint("studio");
+      this.loadBalances(false);   // second coat; repaints when it lands
       return true;
     },
 
@@ -276,6 +318,9 @@ when you are not in a project at all. A project's own key still wins over it.">
         <div class="pv-head">
           <span class="pv-eyebrow">Credentials</span>
           <h3>Art providers</h3>
+          <a class="pv-link pv-balbtn" data-pv-act="balances"
+             title="Balances are cached for ~2 minutes — press after topping an account up.">
+             re-check balances</a>
         </div>
         ${storageNote(d)}
         <div class="pv-grid">${rows.map(r => card(r, "settings")).join("")}</div>

--- a/frontend/src/shell/agents/Agents.tsx
+++ b/frontend/src/shell/agents/Agents.tsx
@@ -624,10 +624,13 @@ function BoardPane({ state, open, onRefresh, tab, setTab, queueView }: {
      into twenty toasts — so this is sequential, stops at the first real
      failure, and reports how far it got. */
   async function deployAll() {
-    const ready = queued.filter((i) => i.ready !== false);
+    /* Held rows (escalations, chat) are one-at-a-time human acts — a bulk
+       deploy firing one is exactly the auto-dispatch they are held from. */
+    const ready = queued.filter((i) => i.ready !== false && !i.held);
     const held = queued.length - ready.length;
     if (!ready.length) {
-      toast(held ? `${held} item(s) are waiting on earlier links` : "nothing to deploy");
+      toast(held ? `${held} item(s) are waiting on earlier links or held for you`
+                 : "nothing to deploy");
       return;
     }
     setBusy(true);
@@ -737,9 +740,28 @@ function BoardPane({ state, open, onRefresh, tab, setTab, queueView }: {
 
 function QueueCard({ item, items }: { item: Item; items: Item[] }) {
   const c = SEAT_COLOR[item.seat] || "var(--text-3)";
-  const blocker = item.depends_on
+  /* THE SERVER'S VERDICT WINS. _chain_state stamps ready/waiting_on across
+     BOTH dependency stores; the local depends_on lookup survives only as the
+     fallback for a payload from an older server, because it cannot see
+     fan-in parents and its blocker may sit outside the board window. */
+  const localBlocker = item.depends_on
     ? items.find((x) => x.id === item.depends_on) : undefined;
-  const waiting = !!blocker && !CLOSED.has(blocker.status);
+  const blocker = item.waiting_on
+    ?? (localBlocker && !CLOSED.has(localBlocker.status)
+        ? localBlocker : undefined);
+  const waiting = item.ready === false || (item.ready == null && !!blocker);
+  /* A dead predecessor is not "waiting" — nothing will ever free it. Name
+     the two acts that do, or the card reads as patience when it is a stall. */
+  const stuck = !!item.stuck
+    || (!!blocker && (blocker.status === "failed" || blocker.status === "cancelled"));
+  const more = (item.waiting_count || 0) > 1 ? ` +${item.waiting_count! - 1}` : "";
+  const line = item.held
+    ? "held for you — no auto-dispatcher takes this"
+    : stuck && blocker
+      ? `stuck: #${blocker.id} is ${blocker.status} — reopen it or cut the dependency`
+      : waiting && blocker
+        ? `blocked until #${blocker.id}${more} closes`
+        : item.seat;
   return (
     <Paper p="xs" withBorder className="bg4-sidecard"
            onClick={() => setSelection({ key: `i${item.id}`, kind: "item",
@@ -752,11 +774,14 @@ function QueueCard({ item, items }: { item: Item; items: Item[] }) {
           <Text size="xs" fw={500} lineClamp={2}>{item.title}</Text>
           <Text size="xs" c="dimmed" ff="var(--mono)" lineClamp={1}>
             {item.chain_pos != null ? `lane ${item.chain_pos} · ` : ""}
-            {waiting ? `blocked until #${blocker!.id} closes` : item.seat}
+            {line}
           </Text>
         </div>
-        <Badge size="xs" variant="default" color={waiting ? "yellow" : undefined}>
-          {waiting ? "waiting" : item.status}
+        <Badge size="xs" variant="default"
+               color={stuck ? "red" : item.held ? "grape"
+                      : waiting ? "yellow" : undefined}>
+          {stuck ? "stuck" : item.held ? "held"
+           : waiting ? "waiting" : item.status}
         </Badge>
       </Group>
     </Paper>

--- a/frontend/src/shell/agents/api.ts
+++ b/frontend/src/shell/agents/api.ts
@@ -24,12 +24,25 @@ export type Item = {
    *  it is blocked behind. */
   chain_id?: number | null; chain_pos?: number | null; depends_on?: number | null;
   /** False when an earlier link has not landed. deploy-all skips these rather
-   *  than aborting on the refusal they would return. */
+   *  than aborting on the refusal they would return. Covers BOTH the
+   *  depends_on column and the fan-in parents in work_item_dep — deriving
+   *  this client-side from depends_on alone is how a card with an unmet
+   *  extra parent got a deploy button whose one outcome was a refusal. */
   ready?: boolean;
   /** The link this one is blocked behind, when it is blocked. _chain_state
    *  sends the predecessor's own row so a card can name WHO it is waiting on
    *  rather than printing a bare id at somebody. */
   waiting_on?: { id: number; seat?: string; title?: string; status?: string } | null;
+  /** How many parents are unmet when it is more than the one in waiting_on. */
+  waiting_count?: number;
+  /** A blocking predecessor is failed/cancelled: it will NEVER reach done on
+   *  its own, so this is not "waiting", it is parked until a human reopens
+   *  the predecessor or cuts the dependency. The card copy must say so —
+   *  "waiting" on a dead link is how chains sat still for days. */
+  stuck?: boolean;
+  /** Queued, but no auto-dispatcher will ever take it (escalations, chat):
+   *  a human acts on it. Without the flag it looked like any queued item. */
+  held?: boolean;
 };
 export type Question = { id: number; seat?: string; text?: string; asked_at?: string };
 /** `blocking` IS THE FIELD THAT DECIDES WHETHER A HUMAN IS NEEDED, and it was

--- a/frontend/src/shell/agents/floorMusic.ts
+++ b/frontend/src/shell/agents/floorMusic.ts
@@ -3,7 +3,7 @@
  *
  * WHERE THE TRACKS LIVE, WHICH THE PLAN LEFT OPEN AND THIS SETTLES. They are
  * HARNESS UI AUDIO, not game assets, so they must not go through
- * kie_music_generate -> music_keep -> music_install: that pipeline installs
+ * music_generate -> music_keep -> music_install: that pipeline installs
  * under the ENGINE PROJECT, and a game would ship the dashboard's background
  * music in its own music library, where the next person to audit that folder
  * would find eight lofi tracks nobody wrote a cue for. They live beside the

--- a/frontend/src/shell/seats/Audio.tsx
+++ b/frontend/src/shell/seats/Audio.tsx
@@ -279,7 +279,7 @@ export function Audio({ seat, active, tab }: SeatBodyProps) {
         <Head label="Library" hint={`${sounds.length} files on disk`} />
         <ReadError error={lib.__error} what="the audio library" />
         {!sounds.length && !lib.__error && (
-          <Nothing what="no audio in the project" how="sfx_generate and kie_music_generate write into game/assets/audio" />
+          <Nothing what="no audio in the project" how="sfx_generate and music_generate write into game/assets/audio" />
         )}
         {!!sounds.length && (
           <div className="bgs-table" style={{ ["--cols" as string]: "24px 1fr 84px 116px 96px" }}>

--- a/scripts/gen_floor_music.py
+++ b/scripts/gen_floor_music.py
@@ -3,7 +3,7 @@ genres, downloaded next to the floor's other art and listed in a manifest.
 
 WHY THIS IS A SCRIPT AND NOT AN MCP TOOL, which is the open question the floor
 plan left and this settles. The music tools that already exist -
-kie_music_generate, music_keep, music_install - file every take as an ARTIFACT
+music_generate, music_keep, music_install - file every take as an ARTIFACT
 REVISION under the engine project and install the kept one into the GAME's music
 library. That is correct for a game's score and wrong for this: the floor's
 soundtrack is harness UI audio, the same kind of thing as the cast sprites and

--- a/tests/test_agentlog.py
+++ b/tests/test_agentlog.py
@@ -1,0 +1,154 @@
+"""The from-anywhere activity reader (bgate_core.agentlog).
+
+The dashboard's reader lives in bgate_ui and needs the dashboard's process
+state; this one is what the MCP server's agent_activity tool serves from any
+session. The properties worth pinning: it parses the claude stream-json
+shapes into the same step kinds the dashboard shows, a re-dispatch marker
+resets the feed, a missing log is an answer rather than an error, and
+liveness comes from the on-disk registry rather than a Popen handle.
+"""
+from __future__ import annotations
+
+import json
+
+from bgate_core import agentlog, agentreg
+
+
+def _write_log(root, item_id: int, events: list[dict]) -> None:
+    path = agentlog.log_path(root, item_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(json.dumps(e) for e in events) + "\n",
+                    encoding="utf-8")
+
+
+def _say(text):
+    return {"type": "assistant", "session_id": "sess-1",
+            "message": {"content": [{"type": "text", "text": text}]}}
+
+
+def _tool(name, **inp):
+    return {"type": "assistant",
+            "message": {"content": [{"type": "tool_use", "name": name,
+                                     "input": inp}]}}
+
+
+def _tool_result(text):
+    return {"type": "user",
+            "message": {"content": [{"type": "tool_result", "content": text}]}}
+
+
+class TestTail:
+    def test_no_log_is_an_answer_not_an_error(self, root, monkeypatch):
+        monkeypatch.setattr(agentreg, "live", list)
+        got = agentlog.tail(root, 99)
+        assert got["steps"] == [] and got["final"] is None
+        assert "never been dispatched" in got["note"]
+        assert got["running"] is False
+
+    def test_steps_and_final_parse_into_the_dashboard_shapes(self, root,
+                                                             monkeypatch):
+        monkeypatch.setattr(agentreg, "live", list)
+        _write_log(root, 7, [
+            _say("starting on the HUD"),
+            _tool("mcp__builders-gate__seat_brief", role="art"),
+            _tool("Bash", command="godot --headless"),
+            _tool_result("ok, 0 failures"),
+            {"type": "result", "subtype": "success",
+             "result": "shipped the HUD", "total_cost_usd": 0.42,
+             "num_turns": 9},
+        ])
+        got = agentlog.tail(root, 7)
+        kinds = [(s["kind"], s.get("name", "")) for s in got["steps"]]
+        assert kinds == [("say", ""), ("tool", "seat_brief"),
+                         ("tool", "Bash"), ("result", "")]
+        # The mcp prefix is stripped and the hint names the subject.
+        assert got["steps"][2]["hint"] == "godot --headless"
+        assert got["final"]["subtype"] == "success"
+        assert got["final"]["cost"] == 0.42
+        assert got["session_id"] == "sess-1"
+        assert got["step_count"] == 4 and got["truncated"] is False
+
+    def test_a_redispatch_marker_resets_the_feed(self, root, monkeypatch):
+        """The log appends across runs; run 1's steps must not read as run 2's
+        current state — same rule as the dashboard's reader."""
+        monkeypatch.setattr(agentreg, "live", list)
+        _write_log(root, 8, [
+            _say("old run"),
+            {"type": "result", "subtype": "success", "result": "old result"},
+            {"type": "bgate_run_start"},
+            _say("new run"),
+        ])
+        got = agentlog.tail(root, 8)
+        assert [s["text"] for s in got["steps"]] == ["new run"]
+        assert got["final"] is None
+
+    def test_limit_windows_from_the_newest(self, root, monkeypatch):
+        monkeypatch.setattr(agentreg, "live", list)
+        _write_log(root, 9, [_say(f"step {n}") for n in range(10)])
+        got = agentlog.tail(root, 9, limit=3)
+        assert [s["text"] for s in got["steps"]] == \
+            ["step 7", "step 8", "step 9"]
+        assert got["step_count"] == 10 and got["truncated"] is True
+
+    def test_liveness_reads_the_registry_for_this_item_and_root(
+            self, root, monkeypatch):
+        _write_log(root, 11, [_say("working")])
+        monkeypatch.setattr(agentreg, "live", lambda: [
+            {"pid": 4242, "item_id": 11, "root": str(root), "seat": "art",
+             "started_at": 1.0},
+            {"pid": 4343, "item_id": 11, "root": r"C:\somewhere\else",
+             "seat": "art", "started_at": 1.0},
+        ])
+        got = agentlog.tail(root, 11)
+        assert got["running"] is True and got["pid"] == 4242
+        # Same item number in a DIFFERENT project is not this item.
+        monkeypatch.setattr(agentreg, "live", lambda: [
+            {"pid": 4343, "item_id": 11, "root": r"C:\somewhere\else"}])
+        assert agentlog.tail(root, 11)["running"] is False
+
+    def test_an_unknown_codex_item_leaves_a_trace(self, root, monkeypatch):
+        """A codex capability this version has never seen must look
+        unreadable, not idle — same rule as the dashboard feed."""
+        monkeypatch.setattr(agentreg, "live", list)
+        _write_log(root, 12, [
+            {"type": "item.completed",
+             "item": {"type": "web_search", "text": "godot tilemap"}},
+        ])
+        got = agentlog.tail(root, 12)
+        assert got["steps"][0]["kind"] == "tool"
+        assert got["steps"][0]["name"] == "web_search"
+
+    def test_codex_thread_start_resets_like_a_redispatch(self, root,
+                                                         monkeypatch):
+        monkeypatch.setattr(agentreg, "live", list)
+        _write_log(root, 13, [
+            _say("old codex run"),
+            {"type": "thread.started"},
+            {"type": "item.completed",
+             "item": {"type": "agent_message", "text": "fresh run"}},
+        ])
+        got = agentlog.tail(root, 13)
+        assert [s["text"] for s in got["steps"]] == ["fresh run"]
+        # codex has no separate result event; the last say IS the final.
+        assert got["final"]["text"] == "fresh run"
+
+    def test_the_marker_and_prefix_agree_with_their_writers(self):
+        """The constants exist to be shared; drift here is the bug this
+        module was created to end."""
+        from bgate_ui import dispatch as _dispatch
+        from bgate_ui import runners as _runners
+        assert _dispatch.STEER_MARKER is agentlog.STEER_MARKER
+        assert agentlog.MCP_TOOL_PREFIX == \
+            f"mcp__{_runners.MCP_SERVER_NAME}__"
+
+    def test_a_steer_turn_is_a_steer_step(self, root, monkeypatch):
+        monkeypatch.setattr(agentreg, "live", list)
+        _write_log(root, 14, [
+            {"type": "user", "message": {"content": [
+                {"type": "text",
+                 "text": agentlog.STEER_MARKER + "use the pinned ref"}]}},
+        ])
+        got = agentlog.tail(root, 14)
+        assert got["steps"] == [got["steps"][0]]
+        assert got["steps"][0]["kind"] == "steer"
+        assert got["steps"][0]["text"] == "use the pinned ref"

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -114,6 +114,46 @@ class TestTheStateShowsWhatJustClosed:
         assert done and done[0]["title"] == "the thing that actually landed"
 
 
+class TestChainStateTellsTheWholeTruth:
+    """The card's readiness must match what dispatch would actually do.
+
+    Three lies the wire used to carry: an unmet EXTRA parent (work_item_dep)
+    rendered `ready` with a deploy button whose one outcome was a refusal; a
+    held row (escalation, chat) looked like any queued item; and a successor
+    behind a FAILED predecessor read as patiently "waiting" on a link that
+    was never going to close on its own.
+    """
+
+    def _items(self, client) -> dict:
+        rows = client.get("/api/console/state").json()["items"]
+        return {int(r["id"]): r for r in rows}
+
+    def test_an_extra_parent_blocks_the_card(self, client, root):
+        parent = _queue.add(root, "art", "the tileset")
+        child = _queue.add(root, "gameplay", "the level")
+        _queue.add_dependency(root, child["id"], parent["id"])
+        got = self._items(client)[int(child["id"])]
+        assert got["ready"] is False
+        assert got["waiting_on"]["id"] == parent["id"]
+
+    def test_a_dead_predecessor_is_stuck_not_waiting(self, client, root):
+        parent = _queue.add(root, "art", "doomed")
+        child = _queue.add(root, "gameplay", "downstream",
+                           depends_on=int(parent["id"]))
+        _queue.set_status(root, parent["id"], "failed")
+        got = self._items(client)[int(child["id"])]
+        assert got["ready"] is False
+        assert got["stuck"] is True
+
+    def test_a_held_row_says_so(self, client, root):
+        held = _queue.add(root, "director", "two agents disagreed",
+                          source="qa-gate-escalation", source_ref="1")
+        plain = _queue.add(root, "art", "ordinary work")
+        items = self._items(client)
+        assert items[int(held["id"])]["held"] is True
+        assert items[int(plain["id"])].get("held") is False
+
+
 class TestTheMessageSurvives:
     LONG = ("the hub screen feels dead — give it parallax, a day/night tint, and "
             "make the door hum when you can afford to open it, which is the bit "
@@ -272,8 +312,10 @@ class TestOnePayload:
 # Auto-deploy
 # ---------------------------------------------------------------------------
 class TestAutoDeploy:
-    def test_it_is_off_until_asked(self, client):
-        assert client.get("/api/console/autopilot").json()["on"] is False
+    def test_it_is_on_by_default(self, client):
+        # Flipped 2026-08-19: shipped off, a filed chain looked exactly like a
+        # running one and sat still until somebody found the toggle.
+        assert client.get("/api/console/autopilot").json()["on"] is True
 
     def test_the_switch_persists_to_the_project(self, client, root):
         client.post("/api/console/autopilot", json={"on": True})

--- a/tests/test_dispatch_adjust.py
+++ b/tests/test_dispatch_adjust.py
@@ -426,7 +426,9 @@ class TestSeatRulesAreProjectScoped:
         item = queue.add(root, "narrative", "write a bark")
         prompt = dispatch._prompt_for(str(root), item)
         assert "godot_check_project" not in prompt
-        assert "LOOK at what you produce" in prompt
+        # The eyes rule survives in the engine-less branch: no godot tools,
+        # but the agent is still told the render is the check.
+        assert "LOOK AT IT" in prompt
 
     def test_a_seat_rule_can_be_overridden_and_turned_off(self, root):
         (Path(root) / ".bgate").mkdir(parents=True, exist_ok=True)

--- a/tests/test_failure_escalation.py
+++ b/tests/test_failure_escalation.py
@@ -201,16 +201,22 @@ class TestApplying:
         assert "402" in filed["brief"] and "art" in filed["brief"]
         assert "STRUCTURAL" in filed["brief"]
 
-    def test_the_escalation_is_never_picked_up_by_an_auto_dispatcher(self, root):
-        """It is queued for a HUMAN to read. An auto-dispatcher grabbing it
-        would be the harness paying to rediscover the blocker the cap just
-        stopped paying for."""
+    def test_the_escalation_is_dispatchable_to_a_director_agent(self, root):
+        """Inverted on 2026-08-19. Held-for-a-human was the board's deepest
+        dead end: with no console session open, every escalation sat queued
+        forever and the failed item stayed failed until a person cleared and
+        re-dispatched by hand. It is now an ordinary director-seat row - an
+        auto-dispatcher may spawn an agent to diagnose and ACT on it - and
+        the spend bound lives where it always did: one escalation per item,
+        ever. Only qa-gate-escalation and chat stay human-held."""
         item = self._failed(root)
         followup.apply_action(root, {
             "kind": "fail_escalate", "item": int(item["id"]), "event": 1,
             "guard": "", "why": "", "reason": "capped", "auto_cap": 1})
-        assert queue.FAILURE_ESCALATION_SOURCE in queue.HELD_SOURCES
-        assert queue.claim_next(root, "director", actor="agent:test") is None
+        assert queue.FAILURE_ESCALATION_SOURCE not in queue.HELD_SOURCES
+        claimed = queue.claim_next(root, "director", actor="agent:test")
+        assert claimed is not None
+        assert claimed["source"] == queue.FAILURE_ESCALATION_SOURCE
 
     def test_filing_twice_files_one(self, root):
         """Delivery is at-least-once: the batch that decided this is replayed
@@ -304,13 +310,13 @@ class TestTheWholeLoopTerminates:
 
 
 class TestTheEscalationReachesTheSession:
-    """The held card becomes a decision that gets MADE.
+    """The filed card becomes a decision that gets MADE.
 
-    An escalation is still held from every auto-dispatcher — that promise is
-    untouched — but a project whose human uses the console's director session
-    hands it to THAT session, which can investigate and act. A project where
-    that session has never existed keeps the shipped behaviour: held for the
-    dashboard.
+    A project whose human uses the console's director session hands a fresh
+    escalation to THAT session first (it reserves the row, so no other
+    dispatcher can race it). A project without one no longer parks the card:
+    the row is an ordinary director-seat item and autodeploy may spawn an
+    agent for it.
     """
 
     def _fail_and_escalate(self, root):

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -1,0 +1,132 @@
+"""The provider gateway - a dead key must read as a routing event.
+
+The observed failure this pins: an agent's first call hit one provider,
+read "no credit", and hand-rolled the asset while a second provider sat
+keyed and funded. The gateway answers "who IS live" in one place, and the
+MCP server's _fail appends that answer to every billing-shaped failure so
+the redirect lands in the same tool result as the refusal.
+"""
+from __future__ import annotations
+
+import pytest
+
+from bgate_core import gateway
+
+
+@pytest.fixture(autouse=True)
+def _fresh_cache():
+    gateway._cache.clear()
+    yield
+    gateway._cache.clear()
+
+
+def _rows(monkeypatch, **rows):
+    """Stub the per-provider probe: rows maps provider id -> row overrides."""
+    def probe(provider, root):
+        base = {"id": provider, "keyed": False, "reason": "no key",
+                "balance": None, "balance_unit": ""}
+        base.update(rows.get(provider, {}))
+        return base
+    monkeypatch.setattr(gateway, "_probe", probe)
+
+
+class TestPick:
+    def test_doctrine_order_holds(self, monkeypatch):
+        """kie mints, RD animates - a funded openai must not outrank a funded
+        kie for images, and nothing but RD may serve `animate`."""
+        _rows(monkeypatch,
+              kie={"keyed": True, "balance": 400.0, "balance_unit": "credits"},
+              openai={"keyed": True, "reason": ""})
+        got = gateway.pick(None, "image")
+        assert got["provider"] == "kie"
+        assert got["alternatives"] == ["openai"]
+        assert gateway.pick(None, "animate")["provider"] is None
+
+    def test_unknown_balance_is_routable_but_drained_is_not(self, monkeypatch):
+        """None means UNKNOWN, never zero - krea never says; a provider whose
+        balance reads 0 is skipped and named as drained."""
+        _rows(monkeypatch,
+              kie={"keyed": True, "balance": 0.0, "balance_unit": "credits"},
+              krea={"keyed": True, "reason": ""})
+        got = gateway.pick(None, "image")
+        assert got["provider"] == "krea"
+        assert "balance unknown" in got["why"]
+
+    def test_nothing_routable_names_every_reason(self, monkeypatch):
+        _rows(monkeypatch,
+              kie={"keyed": True, "balance": 0.0})
+        got = gateway.pick(None, "image")
+        assert got["provider"] is None
+        assert "kie: drained" in got["why"]
+        assert "krea: no key" in got["why"]
+
+
+class TestBillingNote:
+    def test_a_live_provider_forbids_hand_rolling(self, monkeypatch):
+        _rows(monkeypatch,
+              kie={"keyed": True, "balance": 412.0, "balance_unit": "credits"})
+        note = gateway.billing_note(None)
+        assert "ROUTING EVENT" in note
+        assert "412 credits" in note
+        assert "Do NOT hand-roll" in note
+
+    def test_nothing_funded_routes_to_the_human(self, monkeypatch):
+        _rows(monkeypatch)
+        note = gateway.billing_note(None)
+        assert "Nothing is funded" in note
+        assert "file the top-up as the blocker" in note
+
+    def test_probes_are_cached_not_hammered(self, monkeypatch):
+        """A burst of billing failures is exactly when this runs - it must
+        not turn into a burst of network probes."""
+        calls = []
+        def probe(provider, root):
+            calls.append(provider)
+            return {"id": provider, "keyed": False, "reason": "no key",
+                    "balance": None, "balance_unit": ""}
+        monkeypatch.setattr(gateway, "_probe", probe)
+        gateway.billing_note(None)
+        gateway.billing_note(None)
+        assert len(calls) == len(gateway.PROVIDERS)
+        gateway.status(None, fresh=True)
+        assert len(calls) == len(gateway.PROVIDERS) * 2
+
+
+class TestBillingDetection:
+    def test_the_adapters_own_sentences_are_recognised(self):
+        # The exact phrasings kie.py / krea.py raise today.
+        for text in ("kie has no credit left — top the account up at kie.ai",
+                     "Krea has no API credit — the API balance is billed",
+                     "HTTP 402 Payment Required",
+                     "You exceeded your current quota"):
+            assert gateway.is_billing_error(text), text
+
+    def test_a_shape_error_is_not_a_money_problem(self):
+        """A 422 that reads as billing trains agents to provider-hop around
+        real bugs."""
+        for text in ("Krea refused the request shape for this model",
+                     "unknown seat 'artt'", "file not found", ""):
+            assert not gateway.is_billing_error(text), text
+
+
+class TestServerWiring:
+    def test_fail_appends_the_route_to_billing_errors(self, monkeypatch):
+        from bgate_mcp import server
+        _rows(monkeypatch,
+              kie={"keyed": True, "balance": 55.0, "balance_unit": "credits"})
+        out = server._fail(RuntimeError(
+            "kie has no credit left — top the account up at kie.ai"))
+        assert out["ok"] is False
+        assert "ROUTING EVENT" in out.get("route", "")
+
+    def test_fail_stays_silent_on_ordinary_errors(self):
+        from bgate_mcp import server
+        out = server._fail(ValueError("wrong direction set"))
+        assert "route" not in out
+
+    def test_fail_never_raises_over_a_broken_gateway(self, monkeypatch):
+        from bgate_mcp import server
+        monkeypatch.setattr(gateway, "billing_note",
+                            lambda root: 1 / 0)
+        out = server._fail(RuntimeError("no credit"))
+        assert out["ok"] is False   # the original error survives

--- a/tests/test_hook.py
+++ b/tests/test_hook.py
@@ -89,7 +89,10 @@ class TestProcessBoundary:
 
     def run_hook(self, data: dict, seat: str, cwd: str) -> subprocess.CompletedProcess:
         import os
-        env = {**os.environ, "BGATE_SEAT": seat}
+        # BGATE_LANES=block pins the lane dial: these tests are about the
+        # process contract (exit codes, stderr routing), not about the
+        # advisory default, which has its own tests in TestWorkerLaneMode.
+        env = {**os.environ, "BGATE_SEAT": seat, "BGATE_LANES": "block"}
         return subprocess.run([sys.executable, "-m", "bgate_cli.hook"],
                               input=json.dumps(data), capture_output=True,
                               text=True, timeout=60, cwd=cwd, env=env)
@@ -122,6 +125,71 @@ class TestProcessBoundary:
                              cwd=str(root),
                              env={**os.environ, "BGATE_SEAT": "gameplay"})
         assert got.returncode == 0  # fail-safe: never dam the session
+
+
+class TestWorkerLaneMode:
+    """The seated worker's lane went ADVISORY on 2026-08-19.
+
+    A seat is a toolset plus the aegis project boundary; the lane table inside
+    that boundary is a map, not a wall. The observed cost of the wall: on any
+    project whose layout missed the <root>/game scaffold, every seat was
+    refused on contact with the real source tree, and agents answered a
+    refusal by dying politely rather than routing. The refusal MESSAGE
+    survives as a warning to the human; the write lands.
+    """
+
+    def _judge(self, root, path, seat, owner, mode):
+        data = {"tool_name": "Write", "cwd": str(root),
+                "tool_input": {"file_path": str(path)}}
+        return hook.decide(data, seat, owner, mode)
+
+    def test_warn_is_the_default_and_garbage_falls_back(self, monkeypatch):
+        monkeypatch.delenv("BGATE_LANES", raising=False)
+        assert hook.worker_lane_mode() == "warn"
+        monkeypatch.setenv("BGATE_LANES", "BLOCK")
+        assert hook.worker_lane_mode() == "block"     # case-insensitive
+        monkeypatch.setenv("BGATE_LANES", "nonsense")
+        assert hook.worker_lane_mode() == "warn"
+
+    def test_the_dial_is_single_sourced_in_seats(self, monkeypatch):
+        from bgate_core import seats
+        monkeypatch.setenv("BGATE_LANES", "collide")
+        assert hook.worker_lane_mode() == seats.lane_mode() == "collide"
+
+    def test_warn_lets_an_out_of_lane_write_land_and_tells_the_human(self, root):
+        code, msg = self._judge(root, root / "game/assets/rock.png",
+                                "gameplay", "item-1", "warn")
+        # Exit 1: non-blocking, stderr goes to the HUMAN. The write lands.
+        assert code == hook.WARN
+        assert "gameplay" in msg
+
+    def test_collide_waives_the_lane_silently(self, root):
+        code, msg = self._judge(root, root / "game/assets/rock.png",
+                                "gameplay", "item-1", "collide")
+        assert (code, msg) == (hook.ALLOW, "")
+
+    def test_the_softened_write_still_takes_the_lease(self, root):
+        """warn is collide plus a sentence — the NEXT writer must collide with
+        something, or the softening silently turned leases off."""
+        target = root / "game" / "assets" / "rock.png"
+        self._judge(root, target, "gameplay", "item-1", "warn")
+        code, msg = self._judge(root, target, "tech", "item-2", "warn")
+        assert code == hook.BLOCK
+        assert "item-1" in msg
+
+    def test_a_lock_still_blocks_in_every_softened_mode(self, root):
+        """The lane is advisory; a second writer in the same binary is not."""
+        assets.lock(root, "game/assets/shard.blend", "art")
+        for mode in ("warn", "collide"):
+            code, msg = self._judge(root, root / "game/assets/shard.blend",
+                                    "tech", f"item-{mode}", mode)
+            assert code == hook.BLOCK
+            assert "locked by art" in msg
+
+    def test_block_is_still_available_for_a_curated_board(self, root):
+        code, _ = self._judge(root, root / "game/assets/rock.png",
+                              "gameplay", "item-1", "block")
+        assert code == hook.BLOCK
 
 
 class TestDirectorMode:
@@ -368,10 +436,12 @@ class TestContainment:
         loose = tmp_path_factory.mktemp("loose") / "notes.txt"
         assert self.write(root, loose)[0] == hook.ALLOW
 
-    def test_warn_is_the_default_and_garbage_falls_back_to_it(self, monkeypatch):
-        assert hook.aegis_mode() == "warn"
-        monkeypatch.setenv("BGATE_AEGIS", "BLOCK")
-        assert hook.aegis_mode() == "block"       # case-insensitive
+    def test_block_is_the_default_and_garbage_falls_back_to_it(self, monkeypatch):
+        # The default moved warn -> block on 2026-08-19: a seat is a toolset
+        # plus THIS boundary, and lanes inside it went advisory the same day.
+        assert hook.aegis_mode() == "block"
+        monkeypatch.setenv("BGATE_AEGIS", "WARN")
+        assert hook.aegis_mode() == "warn"        # case-insensitive
         monkeypatch.setenv("BGATE_AEGIS", "nonsense")
         assert hook.aegis_mode() == hook.DEFAULT_AEGIS_MODE
 

--- a/tests/test_kie.py
+++ b/tests/test_kie.py
@@ -559,7 +559,7 @@ class TestWiring:
     def test_the_mcp_server_exposes_the_two_new_capabilities(self):
         from bgate_mcp import server
 
-        for name in ("kie_status", "kie_music_generate", "kie_video_generate"):
+        for name in ("kie_status", "music_generate", "kie_video_generate"):
             assert hasattr(server, name), f"{name} is not an MCP tool"
 
 

--- a/tests/test_mcp_aegis.py
+++ b/tests/test_mcp_aegis.py
@@ -105,9 +105,11 @@ class TestLadder:
     """One dial for both enforcers. The hook and the server disagreeing about
     what BGATE_AEGIS=block means is not a policy, it is a coin flip."""
 
-    def test_default_is_warn(self, monkeypatch):
+    def test_default_is_block(self, monkeypatch):
+        # warn -> block on 2026-08-19: the project boundary IS what a seat
+        # enforces now that lanes are advisory.
         monkeypatch.delenv("BGATE_AEGIS", raising=False)
-        assert aegis.mode() == "warn" == aegis.DEFAULT_MODE
+        assert aegis.mode() == "block" == aegis.DEFAULT_MODE
 
     @pytest.mark.parametrize("mode", aegis.MODES)
     def test_hook_and_server_read_the_same_ladder(self, monkeypatch, mode):

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -13,14 +13,14 @@ from bgate_core import modules, settings
 class TestTheRegistry:
     def test_tool_gating_is_by_prefix(self):
         off = {"music", "cinematic"}
-        assert not modules.tool_enabled("kie_music_generate", off)
+        assert not modules.tool_enabled("music_generate", off)
         assert not modules.tool_enabled("cinematic_plan", off)
         assert not modules.tool_enabled("storyboard_auto", off)
         assert modules.tool_enabled("queue_add", off)
         assert modules.tool_enabled("image_generate", off)
 
     def test_everything_on_gates_nothing(self):
-        assert modules.tool_enabled("kie_music_generate", set())
+        assert modules.tool_enabled("music_generate", set())
 
     def test_a_shared_doctor_row_survives_one_module_leaving(self):
         # ffmpeg is named by cinematic AND playtest: off one, still required.
@@ -60,7 +60,7 @@ class TestTheServerRegistry:
         from bgate_mcp import server
 
         monkeypatch.setattr(server, "_MODULES_OFF", {"music", "three_d"})
-        assert not server._module_registers("kie_music_generate")
+        assert not server._module_registers("music_generate")
         assert not server._module_registers("blender_rig")
         assert server._module_registers("queue_add")
         assert server._module_registers("godot_run")
@@ -71,7 +71,7 @@ class TestTheServerRegistry:
         monkeypatch.setattr(server, "_MODULES_OFF", None)
         monkeypatch.delenv("BGATE_ROOT", raising=False)
         # No project resolvable in the test cwd -> empty disabled set.
-        assert server._module_registers("kie_music_generate")
+        assert server._module_registers("music_generate")
         monkeypatch.setattr(server, "_MODULES_OFF", None)  # drop the cache
 
 
@@ -97,7 +97,7 @@ class TestSeatScopedTools:
         assert modules.seat_tool_enabled("blender_rig", "art")
         assert modules.seat_tool_enabled("queue_add", "art")       # spine
         assert modules.seat_tool_enabled("seat_brief", "gameplay")  # spine
-        assert not modules.seat_tool_enabled("kie_music_generate", "art")
+        assert not modules.seat_tool_enabled("music_generate", "art")
         assert not modules.seat_tool_enabled("blender_rig", "gameplay")
         assert not modules.seat_tool_enabled("cinematic_plan", "audio")
 
@@ -106,9 +106,9 @@ class TestSeatScopedTools:
         assert not modules.seat_tool_enabled("image_generate", "narrative")
 
     def test_unknown_and_absent_seats_are_unscoped(self):
-        assert modules.seat_tool_enabled("kie_music_generate", "")
-        assert modules.seat_tool_enabled("kie_music_generate", "director")
-        assert modules.seat_tool_enabled("kie_music_generate", "mystery-seat")
+        assert modules.seat_tool_enabled("music_generate", "")
+        assert modules.seat_tool_enabled("music_generate", "director")
+        assert modules.seat_tool_enabled("music_generate", "mystery-seat")
 
     def test_the_server_gate_composes_seat_and_modules(self, monkeypatch):
         from bgate_mcp import server

--- a/tests/test_music.py
+++ b/tests/test_music.py
@@ -1015,7 +1015,7 @@ class TestBothDoorsExist:
     tool a seat actually calls is still a broken feature."""
 
     @pytest.mark.parametrize("name", [
-        "kie_music_options", "kie_music_generate", "kie_music_status",
+        "music_options", "music_generate", "music_status",
         "music_candidates", "music_keep", "music_discard",
     ])
     def test_the_tool_is_registered(self, name):
@@ -1033,6 +1033,6 @@ class TestBothDoorsExist:
 
         from bgate_mcp import server
 
-        source = inspect.getsource(server.kie_music_generate)
+        source = inspect.getsource(server.music_generate)
         assert "_music.generate" in source
         assert "kie.generate_music" not in source

--- a/tests/test_qa_gate.py
+++ b/tests/test_qa_gate.py
@@ -151,6 +151,53 @@ class TestRounds:
         assert [g["source_ref"] for g in gates] == [str(item["id"])] * 2
         assert dispatched == [gates[0]["id"], gates[1]["id"]]
 
+    def test_a_dead_reviewer_does_not_count_as_a_review(self, root, dispatched):
+        """THE SILENT PASS, closed 2026-08-19. A QA agent that crashed was
+        reaped 'failed' with no verdict — and because any closed gate row used
+        to count as the last review, the original item then passed the gate
+        without anyone ever looking at it. A verdict-less round now counts for
+        nothing: the sweep files a fresh reviewer."""
+        item = _done(root, "art", "the unseen HUD")
+        qa_gate._scan_once(root, EPOCH)
+        gate = _gates(root)[0]
+        # The reviewer dies: the reaper banks it failed, no VERDICT anywhere.
+        queue.set_status(root, gate["id"], "failed",
+                         result="session exited 1 without reporting")
+        _bump(root, item["id"], "2000-01-01 00:00:00")
+        qa_gate._scan_once(root, EPOCH)
+        assert len(_gates(root)) == 2          # a fresh round was filed
+
+    def test_a_verdictless_done_round_does_not_count_either(self, root,
+                                                            dispatched):
+        """Exit 0 with no verdict text is the reap path's 'done' — the same
+        silence wearing a green status."""
+        item = _done(root, "art", "the unjudged HUD")
+        qa_gate._scan_once(root, EPOCH)
+        gate = _gates(root)[0]
+        queue.set_status(root, gate["id"], "done",
+                         result="reported success without calling queue_complete")
+        _bump(root, item["id"], "2000-01-01 00:00:00")
+        qa_gate._scan_once(root, EPOCH)
+        assert len(_gates(root)) == 2
+
+    def test_a_reviewer_that_always_dies_escalates_instead_of_burning(
+            self, root, dispatched):
+        """The runaway guard: re-reviewing is bounded at twice the round cap
+        in total filings, then the director decides."""
+        item = _done(root, "art", "the cursed HUD")
+        cap = qa_gate.max_rounds(root)
+        for n in range(cap * 2):
+            qa_gate._scan_once(root, EPOCH)
+            open_gates = [g for g in _gates(root)
+                          if g["status"] not in ("done", "failed")]
+            assert len(open_gates) == 1, f"round {n}: expected one open gate"
+            queue.set_status(root, open_gates[0]["id"], "failed",
+                             result="died again")
+            _bump(root, item["id"], "2000-01-01 00:00:00")
+        qa_gate._scan_once(root, EPOCH)
+        assert len(_gates(root)) == cap * 2    # no fresh round past the bound
+        assert qa_gate.escalated(root, str(item["id"]))
+
     def test_several_originals_each_get_their_own_gate(self, root, dispatched):
         ids = [_done(root, "art", f"asset {n}")["id"] for n in range(3)]
         qa_gate._scan_once(root, EPOCH)

--- a/tests/test_seat_briefs.py
+++ b/tests/test_seat_briefs.py
@@ -127,7 +127,7 @@ NOT_TOOLS = {
     "first_frame", "last_frame", "max_cost_usd", "ref_image", "ref_images",
     "ref_strength", "source_ref", "style_note", "style_refs", "task_kind",
     "tileable", "transition_s", "unweighted_verts", "use_pinned",
-    "work_item_id",
+    "work_item_id", "item_id",
     # spritekit.row_report finding kinds, quoted by name in the art brief
     "size_ramp", "sheet_size_ramp",
     # not ours

--- a/tests/test_seat_traps.py
+++ b/tests/test_seat_traps.py
@@ -81,11 +81,12 @@ class TestItIsInTheBrief:
         assert any("ROW-major" in t for t in after)
 
     def test_the_existing_rules_survived(self, root):
-        """The tooling rule is prepended, not substituted — the lane rule and the
-        work manifest are what stop an agent writing outside its lanes and dying
-        without a checkpoint trail."""
+        """The tooling rule is prepended, not substituted — the boundary rule
+        and the work manifest are what stop an agent leaving its project and
+        dying without a checkpoint trail. (The lane rule went advisory on
+        2026-08-19; the project boundary is the enforced line now.)"""
         rules = " ".join(_brief(root)["rules"])
-        assert "can_write is the oracle" in rules
+        assert "boundary is enforced" in rules
         assert "WORK MANIFEST" in rules
 
 


### PR DESCRIPTION
## What and why

Dispatched agents were failing without acting, chains were not auto-deploying, the director argued instead of obeying, and seats over-enforced everything except the one thing they were meant to enforce. The causes were mechanical, and most of them were the same shape: a gate that blocks with no route out, or a rule with two drifting copies.

**The seat model inverted.** A seat is now its toolset plus the aegis project boundary (`BGATE_AEGIS` default `warn`→`block`); lanes inside it are advisory (`BGATE_LANES`, default `warn` — the write lands, the human gets the routed warning). The old hard lane gate refused whole source trees on adopted repos, and agents answered refusals by dying politely.

**Gates redirect instead of dead-ending.** `failure-escalation` left `HELD_SOURCES`: past the retry cap, a director-seat agent is dispatched to diagnose and act (console director session still gets first claim; still one escalation per item, ever). A QA reviewer that dies no longer silently passes the item — verdict-less rounds re-file, bounded at 2× the round cap. Blocked queue rows carry `waiting_on` naming the exact call that frees them. Escalations now appear on the ruling rail (previously they surfaced on no rail at all).

**Chains deploy.** `autopilot.on` defaults on (shipped off, a filed chain looked exactly like a running one), the candidate window is 120 (priority-0 links starved past 40), stall notice 2h→30min, and the director protocol opens with the human's instruction outranking doctrine.

**One home per rule** where there were drifting copies: seat house rules moved to `seats.DISPATCH_RULES` (the art rules and art workflow had contradicted each other on which animation tool is the default — both fixed and co-located); `queue.ready()` feeds both dispatchers; `bgate_core/agentlog.py` owns stream-json parsing for the dashboard feed, history browser, and the new `agent_activity` MCP tool (one fork had a misquoted steer marker and silently dropped steers). `kie_music_*` renamed `music_*` — one prefix per domain.

**Provider gateway** (`bgate_core/gateway.py`, `provider_status` tool, `GET /api/providers/balances`): keyed-and-funded per provider, doctrine-ordered routing, and every billing-shaped tool failure carries its own redirect — a 402 is a routing event, not permission to hand-roll assets. Unknown balances are never rendered as zero.

**The eyes rule** ships in every verify path (dispatch prompt, shared seat rules, QA workflow): render the deliverable and judge the picture; stats and green checks are one check, never the full check.

## Verification

- [ ] `python -m pytest -m "not slow" -q` passes locally — not run whole; every affected suite ran green (hook, aegis, queue, dispatch, seats/briefs/traps, mcp_server, followup, qa_gate, console, music, kie, modules, brainstorm, history, heartbeat, settings, gateway, agentlog: 1361+ tests)
- [x] New behaviour has a test (`test_gateway.py`, `test_agentlog.py`, worker-lane-mode, dead-reviewer, chain-state-truth, dispatchable-escalation classes)
- [ ] `npm run build` NOT run (no node_modules in this worktree) — React source changes (`Agents.tsx`, `api.ts`) need a build before `bgate_ui/static/dist` reflects them; the classic Generators panel was mirrored into `bgate_ui/static/` directly (gitignored here, updated locally)
- [ ] wheel-smoke: not run locally, CI will say
- [x] Docs updated (start-here, glossary, reference — lanes, autopilot, tool count 196→226)

Platform tested on: Windows 11, Python 3.x

🤖 Generated with [Claude Code](https://claude.com/claude-code)