### PR TITLE
test: the key-rotation test outlives a filesystem timer tick

### DIFF
--- a/tests/test_imagegen.py
+++ b/tests/test_imagegen.py
@@ -67,6 +67,11 @@ class TestEnvFile:
         env.write_text("BGATE_TEST_SECRET=v1", encoding="utf-8")
         envfile.load_project_env(tmp_path)
         env.write_text("BGATE_TEST_SECRET=v2", encoding="utf-8")
+        # Same length, so the (mtime_ns, size) stamp only moves if the clock
+        # does — and both writes can land inside one filesystem timer tick on
+        # a loaded CI runner. A real rotation never does; make the tick pass.
+        st = env.stat()
+        os.utime(env, ns=(st.st_atime_ns, st.st_mtime_ns + 1_000_000))
         envfile.load_project_env(tmp_path)
         assert os.environ["BGATE_TEST_SECRET"] == "v2"
         os.environ.pop("BGATE_TEST_SECRET", None)


### PR DESCRIPTION
PR #40's windows py3.11 leg failed on `test_a_rotated_key_takes_effect_without_a_restart` after the merge had already landed — a flake, not merge fallout, and it is on main now.

v1 → v2 keeps the .env's size identical, so envfile's `(mtime_ns, size)` stamp only moves if the clock does. On a loaded CI runner both writes can land inside one filesystem timer tick, the stamp holds still, and the cache honestly reports 'unchanged' — the test then pins v1. A real key rotation never happens inside one tick; the test now advances mtime explicitly after the rewrite.

One file, five lines, test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)