### PR TITLE
test: the key-rotation test outlives a filesystem timer tick

### DIFF
--- a/tests/test_imagegen.py
+++ b/tests/test_imagegen.py
@@ -67,6 +67,11 @@ class TestEnvFile:
         env.write_text("BGATE_TEST_SECRET=v1", encoding="utf-8")
         envfile.load_project_env(tmp_path)
         env.write_text("BGATE_TEST_SECRET=v2", encoding="utf-8")
+        # Same length, so the (mtime_ns, size) stamp only moves if the clock
+        # does — and both writes can land inside one filesystem timer tick on
+        # a loaded CI runner. A real rotation never does; make the tick pass.
+        st = env.stat()
+        os.utime(env, ns=(st.st_atime_ns, st.st_mtime_ns + 1_000_000))
         envfile.load_project_env(tmp_path)
         assert os.environ["BGATE_TEST_SECRET"] == "v2"
         os.environ.pop("BGATE_TEST_SECRET", None)


### PR DESCRIPTION
v1 -> v2 keeps the .env's size identical, so the (mtime_ns, size) stamp only moves if the clock does - and on a loaded CI runner both writes can land inside one timer tick, making the cache honestly report 'unchanged' and the test fail as a flake (it did, windows py3.11 only). A real key rotation never happens inside one tick; the test now advances mtime explicitly after the rewrite.

<!-- Small and focused, please. See CONTRIBUTING.md. -->

## What and why

<!-- The reasoning, not the diff. What was wrong, and why this is the fix. -->

## Verification

- [ ] `python -m pytest -m "not slow" -q` passes locally
- [ ] New behaviour has a test
- [ ] If this touches `frontend/`, `npm run build` was run there and the
      regenerated `bgate_ui/static/` is in the same commit
- [ ] If this touches anything the wheel ships (`bgate_ui/static/`, `templates/`,
      `bgate_engine/schemas/`), the `wheel-smoke` CI job still passes
- [ ] Docs updated where they would otherwise become false

Platform tested on:
