### PR TITLE
fix: the MCP server boots under -m, the way every registration runs it

### DIFF
--- a/bgate_mcp/server.py
+++ b/bgate_mcp/server.py
@@ -39,6 +39,20 @@ bound INSIDE a copied context in that thread, so the isolation survives the hop.
 """
 from __future__ import annotations
 
+import sys as _sys
+
+# `python -m bgate_mcp.server` - the command every MCP registration runs -
+# executes this file as `__main__`, NOT as `bgate_mcp.server`. The domain
+# modules at the bottom then `from bgate_mcp.server import ...`, which starts
+# a SECOND execution of this file under its package name; that copy reaches
+# the star imports while tools_blender is still half-initialized and the whole
+# boot dies on a circular ImportError. Registering the running module under
+# its package name first means the domain modules find THIS instance, exactly
+# as they do under a plain `import bgate_mcp.server`. This must precede every
+# bgate import below.
+if __name__ == "__main__":  # pragma: no cover - the subprocess boot test
+    _sys.modules.setdefault("bgate_mcp.server", _sys.modules[__name__])
+
 import contextvars
 import functools
 import inspect

--- a/tests/test_mcp_boot.py
+++ b/tests/test_mcp_boot.py
@@ -1,0 +1,32 @@
+"""The server must BOOT the way registrations run it, not just import.
+
+`claude mcp add ... -- <python> -m bgate_mcp.server` is the documented
+registration, so `python -m bgate_mcp.server` is the one command every user's
+MCP client actually executes. Under `-m` the module runs as `__main__`, and
+when the domain modules import `bgate_mcp.server` back, Python starts a
+second execution of server.py under its package name — which reached the
+star imports while tools_blender was half-initialized and killed the boot
+with a circular ImportError. Every test imported the module normally, so CI
+stayed green while every registration on every machine got CONNECTION_CLOSED
+and agents concluded the toolset was "not attached".
+
+This test runs the real command: subprocess, closed stdin. A stdio MCP
+server that boots cleanly reads EOF and exits 0; the broken one died with a
+traceback before serving a byte.
+"""
+from __future__ import annotations
+
+import pathlib
+import subprocess
+import sys
+
+
+def test_the_registered_command_boots_and_exits_cleanly_on_eof():
+    repo = pathlib.Path(__file__).resolve().parents[1]
+    proc = subprocess.run(
+        [sys.executable, "-m", "bgate_mcp.server"],
+        cwd=repo, stdin=subprocess.DEVNULL, capture_output=True,
+        text=True, timeout=120)
+    assert proc.returncode == 0, (
+        "the MCP registration's own command crashed on boot:\n"
+        + proc.stderr[-2000:])


### PR DESCRIPTION
**The MCP toolset has been unattachable since the domain split landed** — this is the fix.

`claude mcp add ... -- <python> -m bgate_mcp.server` is the documented registration, and `python -m bgate_mcp.server` crashed on boot: under `-m` the module runs as `__main__`, so the domain modules' `from bgate_mcp.server import ...` re-executed server.py as a second copy under its package name, which hit the star imports while `tools_blender` was half-initialized and died on a circular ImportError. The client saw CONNECTION_CLOSED; agents concluded the toolset was "not attached" and fell back to reading `game.db` directly.

CI stayed green because every test imports the module — only the `-m` entry path breaks. The fix registers the running `__main__` module under `bgate_mcp.server` in `sys.modules` before any bgate import, so the domain modules find the one executing instance, identical to the plain-import case.

New regression test runs the real registered command as a subprocess with closed stdin and requires a clean exit — it fails on main today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)